### PR TITLE
Convert id in fetch(id) to integer before passing to fetch_by_id

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -416,7 +416,7 @@ module IdentityCache
     # ActiveRecord::Base.find, will raise ActiveRecord::RecordNotFound exception
     # if id is not in the cache or the db.
     def fetch(id)
-      fetch_by_id(id) or raise(ActiveRecord::RecordNotFound, "Couldn't find #{self.class.name} with ID=#{id}")
+      fetch_by_id(id.to_i) or raise(ActiveRecord::RecordNotFound, "Couldn't find #{self.class.name} with ID=#{id}")
     end
 
 
@@ -740,3 +740,4 @@ module IdentityCache
     end
   end
 end
+


### PR DESCRIPTION
@hornairs @camilo 

This'll turn some attempted sql injection cases from 500s into 404s, so we don't get errorspam :)

Any issues with this?
