### PR TITLE
fetch_multi now logs hits/misses correctly

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -93,7 +93,8 @@ module IdentityCache
       result = {}
       result = cache.read_multi(*keys) if should_cache?
 
-      missed_keys = keys - result.select {|key, value| value.present? }.keys
+      hit_keys = result.select {|key, value| value.present? }.keys
+      missed_keys = keys - hit_keys
 
       if missed_keys.size > 0
         if block_given?
@@ -110,10 +111,10 @@ module IdentityCache
             result[key] = replacement_result
           end
         end
-      else
-        result.keys.each do |key|
-          logger.debug "[IdentityCache] cache hit for #{key} (multi)"
-        end
+      end
+
+      hit_keys.each do |key|
+        logger.debug "[IdentityCache] cache hit for #{key} (multi)"
       end
 
       result.keys.each do |key|

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -151,6 +151,19 @@ class FetchMultiTest < IdentityCache::TestCase
     Record.find_batch([@bob, @joe, @fred].map(&:id).map(&:to_s))
   end
 
+  def test_fetch_multi_accurately_logs_hits_and_misses
+    cache_response = {}
+    cache_response[@bob_blob_key] = @bob
+    cache_response[@joe_blob_key] = nil
+    cache_response[@fred_blob_key] = @fred
+    IdentityCache.cache.stubs(:read_multi).returns(cache_response)
+
+    IdentityCache.logger.expects(:debug).with {|str| str[/hit/] }.times(2)
+    IdentityCache.logger.expects(:debug).with {|str| str[/miss/] }.once
+
+    Record.fetch_multi(@bob.id, @joe.id, @fred.id)
+  end
+
   private
 
   def populate_only_fred

--- a/test/helpers/cache.rb
+++ b/test/helpers/cache.rb
@@ -19,6 +19,6 @@ module Rails
   end
 
   def self.logger
-    @logger = Logger.new
+    @logger ||= Logger.new
   end
 end


### PR DESCRIPTION
A miss in fetch_multi caused no hits to be logged at all. Hits and misses are now logged correctly. Added a regression test, as well.
