### PR TITLE
Identity cache

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -110,7 +110,7 @@ module IdentityCache
       result = {}
       result = cache.read_multi(*keys) if should_cache?
 
-      hit_keys = result.select {|key, value| value.present? }.keys
+      hit_keys = result.reject {|key, value| value == nil }.keys
       missed_keys = keys - hit_keys
 
       if missed_keys.size > 0

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -100,6 +100,18 @@ class FetchMultiTest < IdentityCache::TestCase
     assert_equal fetch_result, results
   end
 
+  def test_fetch_multi_works_with_blanks
+    cache_result = {1 => false, 2 => '   '}
+
+    IdentityCache.cache.expects(:read_multi).with(1,2).returns(cache_result)
+
+    results = IdentityCache.fetch_multi(1,2) do |keys|
+      flunk "Contents should have been fetched from cache successfully"
+    end
+
+    assert_equal cache_result, results
+  end
+
   def test_fetch_multi_duplicate_ids
     assert_equal [@joe, @bob, @joe], Item.fetch_multi(@joe.id, @bob.id, @joe.id)
   end


### PR DESCRIPTION
Fixes a small issue with blank values, similarly to #38.
Also a couple of optimizations.
There no official dependency for Ruby 1.9+ and it looks like 1.8 compatibility is obtained easily, although some tests would need tweaking because hashes in 1.8 are not ordered.
