### PR TITLE
Include association schema in primary cache key's schema hash.

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -128,6 +128,17 @@ module IdentityCache
       columns.sort_by(&:name).map {|c| "#{c.name}:#{c.type}"} * ","
     end
 
+    def embedded_schema_to_string(klass)
+      schema_string = schema_to_string(klass.columns)
+      unless (embeded_associations = klass.all_cached_associations_needing_population).empty?
+        embedded_schema = embeded_associations.map do |name, options|
+          "#{name}:(#{embedded_schema_to_string(options[:association_class])})"
+        end.sort.join(',')
+        schema_string << "," << embedded_schema
+      end
+      schema_string
+    end
+
     def included(base) #:nodoc:
       raise AlreadyIncludedError if base.respond_to? :cache_indexes
 

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -9,7 +9,7 @@ module IdentityCache
 
       def rails_cache_key_prefix
         @rails_cache_key_prefix ||= begin
-          "IDC:blob:#{base_class.name}:#{IdentityCache.memcache_hash(IdentityCache.schema_to_string(columns))}:"
+          "IDC:blob:#{base_class.name}:#{IdentityCache.memcache_hash(IdentityCache.embedded_schema_to_string(self))}:"
         end
       end
 

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -7,11 +7,9 @@ module IdentityCache
       base.class_attribute :cache_attributes
       base.class_attribute :cached_has_manys
       base.class_attribute :cached_has_ones
-      base.class_attribute :embedded_schema_hashes
 
       base.cached_has_manys = {}
       base.cached_has_ones = {}
-      base.embedded_schema_hashes = {}
       base.cache_attributes = []
       base.cache_indexes = []
 

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -250,27 +250,13 @@ module IdentityCache
 
     def populate_denormalized_cached_association(ivar_name, association_name) # :nodoc:
       ivar_full_name = :"@#{ivar_name}"
-      schema_hash_ivar = :"@#{ivar_name}_schema_hash"
       reflection = association(association_name)
 
-      current_schema_hash = self.class.embedded_schema_hashes[association_name] ||= begin
-        IdentityCache.memcache_hash(IdentityCache.schema_to_string(reflection.klass.columns))
-      end
-
-      saved_schema_hash = instance_variable_get(schema_hash_ivar)
-
-      if saved_schema_hash == current_schema_hash
-        value = instance_variable_get(ivar_full_name)
-        return value unless value.nil?
-      elsif saved_schema_hash
-        reflection.reset
-      end
-
-      reflection.load_target unless reflection.loaded?
+      value = instance_variable_get(ivar_full_name)
+      return value unless value.nil?
 
       loaded_association = send(association_name)
 
-      instance_variable_set(schema_hash_ivar, current_schema_hash)
       instance_variable_set(ivar_full_name, IdentityCache.map_cached_nil_for(loaded_association))
     end
 

--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -39,29 +39,22 @@ class SchemaChangeTest < IdentityCache::TestCase
     AssociatedRecord.reset_column_information
     DeeplyAssociatedRecord.reset_column_information
 
-    AssociatedRecord.embedded_schema_hashes = {}
-    Record.embedded_schema_hashes = {}
+    AssociatedRecord.send(:instance_variable_set, :@rails_cache_key_prefix, nil)
+    Record.send(:instance_variable_set, :@rails_cache_key_prefix, nil)
   end
 
-  def test_schema_changes_on_embedded_association_when_the_cached_object_is_already_in_the_cache_should_request_from_the_db
+  def test_schema_changes_on_embedded_association_should_cause_cache_miss_for_old_cached_objects
     record = Record.fetch(@record.id)
     record.fetch_associated
 
     AddColumnToChild.new.up
     read_new_schema
 
-    # Reloading the association queries
-    # SHOW FULL FIELDS FROM `associated_records`
-    # SHOW TABLES LIKE 'associated_records'
-    # SELECT  `associated_records`.* FROM `associated_records`  WHERE `associated_records`.`record_id` = 1 ORDER BY id ASC LIMIT 1.
-    assert_queries(3) do
-      assert_nothing_raised { record.fetch_associated.shiny }
-    end
-
-    assert_no_queries { record.fetch_associated.shiny }
+    Record.expects(:resolve_cache_miss).returns(@record)
+    record = Record.fetch(@record.id)
   end
 
-  def test_schema_changes_on_deeply_embedded_association_when_the_cached_object_is_already_in_the_cache_should_request_from_the_db
+  def test_schema_changes_on_deeply_embedded_association_should_cause_cache_miss_for_old_cached_objects
     record = Record.fetch(@record.id)
     associated_record_from_cache = record.fetch_associated
     associated_record_from_cache.fetch_deeply_associated_records
@@ -69,20 +62,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     AddColumnToDeepChild.new.up
     read_new_schema
 
-    # Loading association queries
-    # SHOW FULL FIELDS FROM `deeply_associated_records`
-    # SHOW FULL FIELDS FROM `associated_records`
-    # SHOW TABLES LIKE 'deeply_associated_records'
-    # SELECT `deeply_associated_records`.* FROM `deeply_associated_records` WHERE `deeply_associated_records`.`associated_record_id` = 1 ORDER BY name DESC.
-    assert_queries(4) do
-      assert_nothing_raised do
-        associated_record_from_cache.fetch_deeply_associated_records.map(&:new_column)
-      end
-    end
-
-    assert_no_queries do
-      associated_record_from_cache.fetch_deeply_associated_records.each{ |obj| assert_nil obj.new_column }
-      record.fetch_associated.fetch_deeply_associated_records.each{ |obj| assert_nil obj.new_column }
-    end
+    Record.expects(:resolve_cache_miss).returns(@record)
+    record = Record.fetch(@record.id)
   end
 end


### PR DESCRIPTION
@boourns & @camilo for review
## Problem

When a model has a 2 level deep denormalized has many associations, and the schema changes for the deeply associated records, then multiple associations would be reloaded after a record embedding them is fetched from the cache.  This re-introduces the problem pull request #32 tries to solve, but only occurs after a schema change without a cache flush.
## Solution

Simply include the associated schema's in the calculation of the schema hash that is used in the primary cache key prefix.
