### PR TITLE
Fix for lack of read_multi memoization.

### DIFF
--- a/test/memoized_cache_proxy_test.rb
+++ b/test/memoized_cache_proxy_test.rb
@@ -6,7 +6,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
     IdentityCache.cache_backend = Rails.cache
   end
 
-  def test_chaging_default_cache
+  def test_changing_default_cache
     IdentityCache.cache_backend = ActiveSupport::Cache::MemoryStore.new
     IdentityCache.cache.write('foo', 'bar')
     assert_equal 'bar', IdentityCache.cache.read('foo')
@@ -51,6 +51,29 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
     end
   end
 
+  def test_read_should_memoize_values
+    IdentityCache.cache_backend = backend = ActiveSupport::Cache::MemoryStore.new
+    backend.write('foo', 'bar')
+
+    IdentityCache.cache.with_memoization do
+      assert_equal 'bar', IdentityCache.cache.read('foo')
+      backend.delete('foo')
+      assert_equal 'bar', IdentityCache.cache.read('foo')
+    end
+  end
+
+  def test_read_multi_should_memoize_values
+    IdentityCache.cache_backend = backend = ActiveSupport::Cache::MemoryStore.new
+    backend.write('foo', 'bar')
+
+    IdentityCache.cache.with_memoization do
+      assert_equal({'foo' => 'bar'}, IdentityCache.cache.read_multi('foo', 'fooz'))
+      backend.delete('foo')
+      backend.write('fooz', 'baz')
+      assert_equal({'foo' => 'bar'}, IdentityCache.cache.read_multi('foo', 'fooz'))
+    end
+  end
+
   def test_read_multi_with_partially_memoized_should_read_missing_keys_from_memcache
     IdentityCache.cache.write('foo', 'bar')
     Rails.cache.write('fooz', 'baz')
@@ -65,9 +88,9 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
 
     IdentityCache.cache.with_memoization do
       IdentityCache.cache.write('foo', [])
-      IdentityCache.cache.write('bar', nil)
+      IdentityCache.cache.write('bar', false)
       IdentityCache.cache.write('baz', {})
-      assert_equal({'foo' => [], 'bar' => nil, 'baz' => {}}, IdentityCache.cache.read_multi('foo', 'bar', 'baz'))
+      assert_equal({'foo' => [], 'bar' => false, 'baz' => {}}, IdentityCache.cache.read_multi('foo', 'bar', 'baz'))
     end
   end
 


### PR DESCRIPTION
@hornairs & @camilo for review
## Problem

Previously read_multi wasn't memoizing for results found in the cache.
## Solution

Store the results from `@memcache.read_multi` in the memoized hash, including `nil` for cache misses.
