### PR TITLE
Avoid extraneous call to the cache engine when all the keys are memozied

### DIFF
--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -74,7 +74,9 @@ module IdentityCache
             true
           end
         end
-        hits = @memcache.read_multi(*missing_keys)
+
+        hits =   missing_keys.empty? ? {} : @memcache.read_multi(*missing_keys)
+
         missing_keys.each do |key|
           hit = hits[key]
           mkv[key] = hit

--- a/test/memoized_cache_proxy_test.rb
+++ b/test/memoized_cache_proxy_test.rb
@@ -83,8 +83,8 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
     end
   end
 
-  def test_read_multi_with_blank_values
-    Rails.cache.expects(:read_multi).with().returns({})
+  def test_read_multi_with_blank_values_should_not_hit_the_cache_engine
+    Rails.cache.expects(:read_multi).never
 
     IdentityCache.cache.with_memoization do
       IdentityCache.cache.write('foo', [])


### PR DESCRIPTION
@hornairs @dylanahsmith 

As we hypothesized correctly this (on top of being wasteful) causes Memcached::NotFound errors on some adaptors (memcached gem?).
