### PR TITLE
adding namespace method to idc keys

### DIFF
--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -1,6 +1,7 @@
 module IdentityCache
   module CacheKeyGeneration
     extend ActiveSupport::Concern
+    DEFAULT_NAMESPACE = "IDC:".freeze
 
     def self.schema_to_string(columns)
       columns.sort_by(&:name).map{|c| "#{c.name}:#{c.type}"}.join(',')
@@ -32,18 +33,23 @@ module IdentityCache
 
       def rails_cache_key_prefix
         @rails_cache_key_prefix ||= begin
-          "IDC:blob:#{base_class.name}:#{IdentityCache::CacheKeyGeneration.denormalized_schema_hash(self)}:"
+          "#{rails_cache_key_namespace}blob:#{base_class.name}:#{IdentityCache::CacheKeyGeneration.denormalized_schema_hash(self)}:"
         end
       end
 
       def rails_cache_index_key_for_fields_and_values(fields, values)
-        "IDC:index:#{base_class.name}:#{rails_cache_string_for_fields_and_values(fields, values)}"
+        "#{rails_cache_key_namespace}index:#{base_class.name}:#{rails_cache_string_for_fields_and_values(fields, values)}"
       end
 
       def rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, values)
-        "IDC:attribute:#{base_class.name}:#{attribute}:#{rails_cache_string_for_fields_and_values(fields, values)}"
+        "#{rails_cache_key_namespace}attribute:#{base_class.name}:#{attribute}:#{rails_cache_string_for_fields_and_values(fields, values)}"
       end
 
+      def rails_cache_key_namespace
+        DEFAULT_NAMESPACE
+      end
+
+      private
       def rails_cache_string_for_fields_and_values(fields, values)
         "#{fields.join('/')}:#{IdentityCache.memcache_hash(values.join('/'))}"
       end

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -16,6 +16,17 @@ class FetchMultiTest < IdentityCache::TestCase
     assert_equal [], Record.fetch_multi
   end
 
+  def test_fetch_multi_namespace
+    Record.send(:include, SwitchNamespace)
+    bob_blob_key, joe_blob_key, fred_blob_key = [@bob_blob_key, @joe_blob_key, @fred_blob_key].map { |k| "ns:#{k}" }
+    cache_response = {}
+    cache_response[bob_blob_key] = @bob
+    cache_response[joe_blob_key] = @joe
+    cache_response[fred_blob_key] = @fred
+    IdentityCache.cache.expects(:read_multi).with(bob_blob_key, joe_blob_key, fred_blob_key).returns(cache_response)
+    assert_equal [@bob, @joe, @fred], Record.fetch_multi(@bob.id, @joe.id, @fred.id)
+  end
+
   def test_fetch_multi_with_all_hits
     cache_response = {}
     cache_response[@bob_blob_key] = @bob

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -13,9 +13,18 @@ class FetchTest < IdentityCache::TestCase
     @index_key = "IDC:index:Record:title:#{cache_hash('bob')}"
   end
 
-
   def test_fetch_cache_hit
     IdentityCache.cache.expects(:read).with(@blob_key).returns(@record)
+
+    assert_equal @record, Record.fetch(1)
+  end
+
+  def test_fetch_hit_cache_namespace
+    Record.send(:include, SwitchNamespace)
+    Record.namespace = 'test_namespace'
+
+    new_blob_key = "test_namespace:#{@blob_key}"
+    IdentityCache.cache.expects(:read).with(new_blob_key).returns(@record)
 
     assert_equal @record, Record.fetch(1)
   end
@@ -85,6 +94,14 @@ class FetchTest < IdentityCache::TestCase
 
     # got id, do memcache lookup on that, hit -> done
     IdentityCache.cache.expects(:read).with(@blob_key).returns(@record)
+
+    assert_equal @record, Record.fetch_by_title('bob')
+  end
+
+  def test_fetch_by_title_cache_namespace
+    Record.send(:include, SwitchNamespace)
+    IdentityCache.cache.expects(:read).with("ns:#{@index_key}").returns(1)
+    IdentityCache.cache.expects(:read).with("ns:#{@blob_key}").returns(@record)
 
     assert_equal @record, Record.fetch_by_title('bob')
   end

--- a/test/helpers/active_record_objects.rb
+++ b/test/helpers/active_record_objects.rb
@@ -1,4 +1,23 @@
+module SwitchNamespace
+
+  module ClassMethods
+    def rails_cache_key_namespace
+      "#{self.namespace}:#{super}"
+    end
+  end
+
+  def self.included(base)
+    base.instance_variable_set :@rails_cache_key_prefix, nil
+    base.extend ClassMethods
+    base.class_eval do
+      class_attribute :namespace
+      self.namespace = 'ns'
+    end
+  end
+end
+
 module ActiveRecordObjects
+
   def setup_models(base = ActiveRecord::Base)
     Object.send :const_set, 'DeeplyAssociatedRecord', Class.new(base).tap {|klass|
       klass.send :include, IdentityCache
@@ -40,4 +59,3 @@ module ActiveRecordObjects
     Object.send :remove_const, 'Record'
   end
 end
-


### PR DESCRIPTION
@hornairs @dylanahsmith @camilo can you guys review this?

it basically adds a method `rails_cache_key_namespace` to the class level, so extending to switch the namespace would be easier.
