### PR TITLE
dont memoaize the namespace on the class level

### DIFF
--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -28,13 +28,12 @@ module IdentityCache
 
     module ClassMethods
       def rails_cache_key(id)
-        rails_cache_key_prefix + id.to_s
+        "#{rails_cache_key_prefix}#{id}"
       end
 
       def rails_cache_key_prefix
-        @rails_cache_key_prefix ||= begin
-          "#{rails_cache_key_namespace}blob:#{base_class.name}:#{IdentityCache::CacheKeyGeneration.denormalized_schema_hash(self)}:"
-        end
+        @rails_cache_key_prefix ||= IdentityCache::CacheKeyGeneration.denormalized_schema_hash(self)
+        "#{rails_cache_key_namespace}blob:#{base_class.name}:#{@rails_cache_key_prefix}:"
       end
 
       def rails_cache_index_key_for_fields_and_values(fields, values)

--- a/test/helpers/active_record_objects.rb
+++ b/test/helpers/active_record_objects.rb
@@ -7,7 +7,6 @@ module SwitchNamespace
   end
 
   def self.included(base)
-    base.instance_variable_set :@rails_cache_key_prefix, nil
     base.extend ClassMethods
     base.class_eval do
       class_attribute :namespace


### PR DESCRIPTION
This does not affect much the performance. follow benchmarks

before PR

``` ruby
/opt/boxen/rbenv/versions/1.9.3-p385-perf/bin/ruby ./performance/cpu.rb
Rehearsal ----------------------------------------------------
FindRunner:        0.860000   0.090000   0.950000 (  1.224831)
FetchMissRunner:  12.160000   0.760000  12.920000 ( 83.156324)
FetchHitRunner:   13.250000   0.850000  14.100000 ( 84.238404)
------------------------------------------ total: 27.970000sec

                       user     system      total        real
FindRunner:        0.840000   0.080000   0.920000 (  1.190167)
FetchMissRunner:  12.010000   0.730000  12.740000 ( 82.843079)
FetchHitRunner:   13.250000   0.840000  14.090000 ( 84.364599)
```

after PR

``` ruby
/opt/boxen/rbenv/versions/1.9.3-p385-perf/bin/ruby ./performance/cpu.rb
Rehearsal ----------------------------------------------------
FindRunner:        0.890000   0.090000   0.980000 (  1.258933)
FetchMissRunner:  12.580000   0.780000  13.360000 ( 84.006055)
FetchHitRunner:   13.760000   0.890000  14.650000 ( 85.127375)
------------------------------------------ total: 28.990000sec

                       user     system      total        real
FindRunner:        0.860000   0.080000   0.940000 (  1.214727)
FetchMissRunner:  12.270000   0.750000  13.020000 ( 82.983523)
FetchHitRunner:   13.810000   0.880000  14.690000 ( 85.356588)
```

cc @camilo @hornairs @dylanahsmith 
