### PR TITLE
small rearrange of public attributes

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -38,8 +38,8 @@ module IdentityCache
 
   class << self
 
-    attr_accessor :logger, :readonly
-    attr_reader :cache
+    attr_accessor :readonly
+    attr_writer :logger
 
     # Sets the cache adaptor IdentityCache will be using
     #


### PR DESCRIPTION
- we already have a `cache` method, so no need for the reader.
- we have the reader for `logger` so only need for the writer.

review @hornairs 
