### PR TITLE
Make IdentityCache return only readonly records

### DIFF
--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -102,4 +102,23 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
       Record.cache_has_one :polymorphic_record, :inverse_name => :owner, :embed => true
     end
   end
+
+  def test_returned_record_should_be_readonly_on_cache_hit
+    Record.fetch_by_title('foo')
+
+    record_from_cache_hit = Record.fetch(1)
+    assert record_from_cache_hit.fetch_associated.readonly?
+  end
+
+
+  def test_returned_record_should_be_readonly_on_cache_miss
+    record_from_cache_miss = Record.fetch(1)
+    assert record_from_cache_miss.fetch_associated.readonly?
+  end
+
+  def test_returned_record_with_open_transactions_should_be_readonly
+    Record.transaction do
+      assert Record.fetch(1).fetch_associated.readonly?
+    end
+  end
 end

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -126,4 +126,25 @@ class FetchTest < IdentityCache::TestCase
       Record.fetch_by_title!('bob')
     end
   end
+
+  def test_returned_records_are_readonly_on_cache_hit
+    IdentityCache.cache.expects(:read).with(@blob_key).returns(@cached_value)
+
+    assert Record.fetch(1).readonly?
+  end
+
+  def test_returned_records_are_readonly_on_cache_miss
+    Record.expects(:find_by_id).with(1, :include => []).returns(@record)
+    IdentityCache.cache.expects(:read).with(@blob_key).returns(nil)
+
+    assert Record.fetch(1).readonly?
+  end
+
+  def test_returned_records_are_readonly_with_open_transactions
+    Record.expects(:find_by_id).with(1).returns(@record)
+
+    @record.transaction do
+      assert Record.fetch(1).readonly?
+    end
+  end
 end

--- a/test/normalized_belongs_to_test.rb
+++ b/test/normalized_belongs_to_test.rb
@@ -43,4 +43,19 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
     Record.expects(:fetch_by_id).with(@parent_record.id).returns(nil)
     assert_equal nil, @record.fetch_record
   end
+
+  def test_returned_record_should_be_readonly_on_cache_hit
+    Record.fetch(@parent_record.id) # warm cache
+    assert @record.fetch_record.readonly?
+  end
+
+  def test_returned_record_should_be_readonly_on_cache_miss
+    assert @record.fetch_record.readonly?
+  end
+
+  def test_returned_record_with_open_transactions_should_be_readonly
+    Record.transaction do
+      assert @record.fetch_record.readonly?
+    end
+  end
 end

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -135,4 +135,20 @@ class NormalizedHasManyTest < IdentityCache::TestCase
     @not_cached.save
   end
 
+  def test_returned_records_should_be_readonly_on_cache_hit
+    Record.fetch(@record.id) # warm cache
+
+    record_from_cache_hit = Record.fetch(@record.id)
+    record_from_cache_hit.fetch_associated_records.each do |record|
+      assert record.readonly?
+    end
+  end
+
+  def test_returned_records_should_be_readonly_on_cache_miss
+    record_from_cache_miss = Record.fetch(@record.id)
+
+    record_from_cache_miss.fetch_associated_records.each do |record|
+      assert record.readonly?
+    end
+  end
 end


### PR DESCRIPTION
@fbogsany @camilo @arthurnn for review please.

IdentityCache is a forever inconsistent datastore. It is a duplication of state across two different storage backends, and unless we somehow confirmed commit in both places before acknowledging, we can't guarantee that the two are in sync. The ruby process could die before it has a chance to issue the memcache DEL, the request could get lost if the connection is interrupted or any number of other things could prevent IDC from reflecting whats truly in the database.

This being the case, it is sketchy to write something you find in IDC back to the database, because you might be writing out of date data to the database. This is already the case with a MySQL insert in Rails cause you had to have read that data a finite amount of time ago, but that window is usually much smaller, and we have locking primitives and transactions to manage this. With IDC, we don't have that, and we don't have any way of knowing if the data is out of date without asking the database, which entirely defeats the purpose of IDC.

So, I suggest we return only readonly records from IDC. If you are gonna write a record, first fetch its values from the DB.