### PR TITLE
Workaround serialized attributes bug

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -83,6 +83,10 @@ module IdentityCache
       def record_from_coder(coder) #:nodoc:
         if coder.present? && coder.has_key?(:class)
           record = coder[:class].allocate
+          unless coder[:class].serialized_attributes.empty?
+            coder = coder.dup
+            coder['attributes'] = coder['attributes'].dup
+          end
           if record.class._initialize_callbacks.empty?
             record.instance_eval do
               @attributes = self.class.initialize_attributes(coder['attributes'])


### PR DESCRIPTION
If a record has serialized attributes, record.init_with(coder) will modify coder to wrap the serialized attributes. When MemoizedCacheProxy is used, the coder persists for the duration of the request, so later calls to fetch will return the same coder instance and record.init_with(coder) will again modify the cached coder by re-wrapping the already wrapped serialized attributes.

This works around the modification of the cached coder by duplicating both the coder hash and its "attributes" hash before calling init_with if the record type has serialized attributes.

@camilo @hornairs for review
