### PR TITLE
Add IdentityCache.cache_namespace which can be a string or proc.

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -26,6 +26,9 @@ module IdentityCache
     attr_accessor :readonly
     attr_writer :logger
 
+    mattr_accessor :cache_namespace
+    self.cache_namespace = "IDC:#{CACHE_VERSION}:".freeze
+
     def included(base) #:nodoc:
       raise AlreadyIncludedError if base.respond_to? :cache_indexes
 

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -45,7 +45,8 @@ module IdentityCache
       end
 
       def rails_cache_key_namespace
-        DEFAULT_NAMESPACE
+        ns = IdentityCache.cache_namespace
+        ns.is_a?(Proc) ? ns.call(self) : ns
       end
 
       private

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class FetchMultiTest < IdentityCache::TestCase
-  NAMESPACE = IdentityCache::CacheKeyGeneration::DEFAULT_NAMESPACE
+  NAMESPACE = IdentityCache.cache_namespace
 
   def setup
     super

--- a/test/fetch_multi_with_batched_associations_test.rb
+++ b/test/fetch_multi_with_batched_associations_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class FetchMultiWithBatchedAssociationsTest < IdentityCache::TestCase
-  NAMESPACE = IdentityCache::CacheKeyGeneration::DEFAULT_NAMESPACE
+  NAMESPACE = IdentityCache.cache_namespace
 
   def setup
     super

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -24,13 +24,15 @@ class FetchTest < IdentityCache::TestCase
   end
 
   def test_fetch_hit_cache_namespace
-    Record.send(:include, SwitchNamespace)
-    Record.namespace = 'test_namespace'
+    old_ns = IdentityCache.cache_namespace
+    IdentityCache.cache_namespace = proc { |model| "#{model.table_name}:#{old_ns}" }
 
-    new_blob_key = "test_namespace:#{@blob_key}"
+    new_blob_key = "records:#{@blob_key}"
     IdentityCache.cache.expects(:read).with(new_blob_key).returns(@cached_value)
 
     assert_equal @record, Record.fetch(1)
+  ensure
+    IdentityCache.cache_namespace = old_ns
   end
 
   def test_exists_with_identity_cache_when_cache_hit


### PR DESCRIPTION
@camilo & @arthurnn for review
## Problem

If someone wants to provide a cache namespace, then they could override the rails_cache_key_namespace on the model.  Doing this across all models could be done using a mixin, however, if that mixin is included before IdentityCache, then it wouldn't be used.

A simple use case would be vertical sharding, where some models are moved to a different database.  In this case there should be an easy way to generically provide this namespace, but have it be model dependant.
## Solution

Add an IdentityCache.cache_namespace attribute which can take a string or a Proc, initialized to the same default namespace we previously used.  rails_cache_key_namespace will return the string or the result of calling the Proc with the model as an argument.

Example:

```
old_ns = IdentityCache.cache_namespace
IdentityCache.cache_namespace = proc { |model| "#{old_ns}#{model.connection_config[:database]}:" }
```
