### PR TITLE
fetch_multi association preloading mark associations as loaded to prevent N+1 queries

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -240,6 +240,7 @@ module IdentityCache
 
             if details[:embed]
               child_records = records.map(&details[:cached_accessor_name].to_sym).flatten
+              records.map { |r| r.association(association).loaded! }
             else
               ids_to_parent_record = records.each_with_object({}) do |record, hash|
                 child_ids = record.send(details[:cached_ids_name])
@@ -282,6 +283,7 @@ module IdentityCache
           when details = cached_has_ones[association]
             if details[:embed]
               parent_records = records.map(&details[:cached_accessor_name].to_sym)
+              records.map { |r| r.association(association).loaded! }
             else
               raise ArgumentError.new("Non-embedded has_one associations do not support prefetching yet.")
             end

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -138,6 +138,42 @@ class FetchMultiTest < IdentityCache::TestCase
     Record.fetch_multi(@bob.id, @joe.id)
   end
 
+  def test_fetch_multi_with_includes_mark_embeded_has_one_associations_as_loaded
+    Record.cache_has_one :associated, embed: true
+    record = Record.fetch_multi(@bob.id, includes: :associated).first
+
+    assert record
+    assert record.association(:associated).loaded?, 'association should be marked as loaded'
+    assert_nil record.associated
+  end
+
+  def test_fetch_multi_with_includes_mark_embeded_has_many_associations_as_loaded
+    Record.cache_has_many :associated_records, embed: true
+    record = Record.fetch_multi(@bob.id, includes: :associated_records).first
+
+    assert record
+    assert record.association(:associated_records).loaded?, 'association should be marked as loaded'
+    assert_equal [], record.associated_records
+  end
+
+  def test_fetch_multi_with_includes_do_not_mark_non_embeded_has_many_associations_as_loaded
+    Record.cache_has_many :associated_records, embed: false
+    record = Record.fetch_multi(@bob.id, includes: :associated_records).first
+
+    assert record
+    refute record.association(:associated_records).loaded?, 'association should not be marked as loaded'
+    assert_equal [], record.associated_records
+  end
+
+  def test_fetch_multi_with_includes_do_not_mark_the_belongs_to_associations_as_loaded
+    Record.cache_belongs_to :record, embed: false
+    record = Record.fetch_multi(@bob.id, includes: :record).first
+
+    assert record
+    refute record.association(:record).loaded?, 'association should not be marked as loaded'
+    assert_equal nil, record.record
+  end
+
   private
 
   def populate_only_fred


### PR DESCRIPTION
Previously associations were not marked as prefetched.

So any has_one association correctly prefetched but null, was triggering a N+1 query.

I tested this branch locally on orders controllers, it got rid of all remaining N+1 queries (~25 queries for 5 orders).

/cc @camilo @hornairs for review

My only concern is that non-embeded associations should not be marked as loaded on cache miss. But I don't have the full picture here.
