### PR TITLE
Add require to AS attribute_accessors

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -1,4 +1,5 @@
 require 'active_record'
+require 'active_support/core_ext/module/attribute_accessors'
 require 'ar_transaction_changes'
 
 require "identity_cache/version"


### PR DESCRIPTION
### Problem

ActiveSupport 4+ doesnt require attribute_accessors by default, so we need to include it. So `mattr_accessor` wont work.
### Solution

We just need to require it.

This is a pretty small change, it wont hurt backwards compatibility with rails 3.

review @dylanahsmith or @jduff 
