### PR TITLE
Remove find_by_id

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -26,7 +26,7 @@ module IdentityCache
       end
 
       # Default fetcher added to the model on inclusion, it behaves like
-      # ActiveRecord::Base.find_by_id
+      # ActiveRecord::Base.where(id: id).first
       def fetch_by_id(id)
         raise NotImplementedError, "fetching needs the primary index enabled" unless primary_cache_index_enabled
         if IdentityCache.should_cache?
@@ -40,7 +40,7 @@ module IdentityCache
           end
 
         else
-          self.find_by_id(id)
+          self.where(id: id).first
         end
       end
 
@@ -175,9 +175,9 @@ module IdentityCache
       end
 
       def resolve_cache_miss(id)
-        self.find_by_id(id, :include => cache_fetch_includes).tap do |object|
-          object.try(:populate_association_caches)
-        end
+        object = self.includes(cache_fetch_includes).where(id: id).try(:first)
+        object.try(:populate_association_caches)
+        object
       end
 
       def all_embedded_associations

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -28,7 +28,9 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     @record.associated = nil
     @record.save!
     @record.reload
-    Item.expects(:find_by_id).with(@record.id, :include => Item.cache_fetch_includes).returns(@record)
+    @record.populate_association_caches
+    Item.expects(:resolve_cache_miss).with(@record.id).once.returns(@record)
+
     IdentityCache.cache.expects(:read).with(@record.secondary_cache_index_key_for_current_values([:title]))
     IdentityCache.cache.expects(:read).with(@record.primary_cache_index_key)
 
@@ -49,7 +51,8 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
   end
 
   def test_on_cache_hit_record_should_come_back_with_cached_association
-    Item.expects(:find_by_id).with(1, :include => Item.cache_fetch_includes).once.returns(@record)
+    @record.populate_association_caches
+    Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
     Item.fetch_by_title('foo')
 
     record_from_cache_hit = Item.fetch_by_title('foo')
@@ -64,7 +67,8 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     @record.save!
     @record.reload
 
-    Item.expects(:find_by_id).with(1, :include => Item.cache_fetch_includes).once.returns(@record)
+    @record.populate_association_caches
+    Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
     Item.fetch_by_title('foo')
 
     record_from_cache_hit = Item.fetch_by_title('foo')

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -43,20 +43,20 @@ class FetchTest < IdentityCache::TestCase
 
   def test_exists_with_identity_cache_when_cache_miss_and_in_db
     IdentityCache.cache.expects(:read).with(@blob_key).returns(nil)
-    Item.expects(:find_by_id).with(1, :include => []).returns(@record)
+    Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
 
     assert Item.exists_with_identity_cache?(1)
   end
 
   def test_exists_with_identity_cache_when_cache_miss_and_not_in_db
     IdentityCache.cache.expects(:read).with(@blob_key).returns(nil)
-    Item.expects(:find_by_id).with(1, :include => []).returns(nil)
+    Item.expects(:resolve_cache_miss).with(1).once.returns(nil)
 
     assert !Item.exists_with_identity_cache?(1)
   end
 
   def test_fetch_miss
-    Item.expects(:find_by_id).with(1, :include => []).returns(@record)
+    Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
 
     IdentityCache.cache.expects(:read).with(@blob_key).returns(nil)
     IdentityCache.cache.expects(:write).with(@blob_key, @cached_value)


### PR DESCRIPTION
find_by_id is deprecated on rails 4. We could replace with where().first and make work on 3 and 4

review @camilo @jduff @hornairs 
