### PR TITLE
Add column_types init for AR 4

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -97,6 +97,7 @@ module IdentityCache
               @aggregation_cache = {}
               @readonly = @destroyed = @marked_for_destruction = false
               @new_record = false
+              @column_types = self.class.column_types if self.class.respond_to?(:column_types)
             end
           else
             record.init_with(coder)


### PR DESCRIPTION
see:
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/core.rb#L172

AR 4.0 init a `@column_types` to be used when reading an attribute. When not calling `init_with` we need to pre-setup that.

review @camilo @dylanahsmith @jduff 
