### PR TITLE
Replace .all with .to_a

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -223,7 +223,7 @@ module IdentityCache
       def find_batch(ids, options = {})
         @id_column ||= columns.detect {|c| c.name == "id"}
         ids = ids.map{ |id| @id_column.type_cast(id) }
-        records = where('id IN (?)', ids).includes(cache_fetch_includes(options[:includes])).all
+        records = where('id IN (?)', ids).includes(cache_fetch_includes(options[:includes])).to_a
         records_by_id = records.index_by(&:id)
         records = ids.map{ |id| records_by_id[id] }
         mismatching_ids = records.compact.map(&:id) - ids

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -123,7 +123,7 @@ class FetchMultiTest < IdentityCache::TestCase
   def test_find_batch_coerces_ids_to_primary_key_type
     mock_relation = mock("ActiveRecord::Relation")
     Item.expects(:where).returns(mock_relation)
-    mock_relation.expects(:includes).returns(stub(:all => [@bob, @joe, @fred]))
+    mock_relation.expects(:includes).returns(stub(:to_a => [@bob, @joe, @fred]))
 
     Item.find_batch([@bob, @joe, @fred].map(&:id).map(&:to_s))
   end

--- a/test/fetch_multi_with_batched_associations_test.rb
+++ b/test/fetch_multi_with_batched_associations_test.rb
@@ -28,7 +28,7 @@ class FetchMultiWithBatchedAssociationsTest < IdentityCache::TestCase
 
     mock_relation = mock("ActiveRecord::Relation")
     Item.expects(:where).returns(mock_relation)
-    mock_relation.expects(:includes).with([:associated_records, :associated]).returns(stub(:all => [@bob, @joe, @fred]))
+    mock_relation.expects(:includes).with([:associated_records, :associated]).returns(stub(:to_a => [@bob, @joe, @fred]))
     assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id)
   end
 
@@ -46,7 +46,7 @@ class FetchMultiWithBatchedAssociationsTest < IdentityCache::TestCase
 
     mock_relation = mock("ActiveRecord::Relation")
     Item.expects(:where).returns(mock_relation)
-    mock_relation.expects(:includes).with([:associated_records, :associated, {:item => []}]).returns(stub(:all => [@bob, @joe, @fred]))
+    mock_relation.expects(:includes).with([:associated_records, :associated, {:item => []}]).returns(stub(:to_a => [@bob, @joe, @fred]))
     assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id, {:includes => :item})
   end
 
@@ -201,7 +201,7 @@ class FetchMultiWithBatchedAssociationsTest < IdentityCache::TestCase
   def test_find_batch_coerces_ids_to_primary_key_type
     mock_relation = mock("ActiveRecord::Relation")
     Item.expects(:where).returns(mock_relation)
-    mock_relation.expects(:includes).returns(stub(:all => [@bob, @joe, @fred]))
+    mock_relation.expects(:includes).returns(stub(:to_a => [@bob, @joe, @fred]))
 
     Item.find_batch([@bob, @joe, @fred].map(&:id).map(&:to_s))
   end


### PR DESCRIPTION
AR 4 has deprecated .all, we need to replace it with .to_a to avoid warnings.

review [ @jduff @byroot @fbogsany @camilo ].any?
