### PR TITLE
test: Use Time rather than DateTime to avoid an improper time conversion.

### DIFF
--- a/test/helpers/serialization_format.rb
+++ b/test/helpers/serialization_format.rb
@@ -12,7 +12,7 @@ module SerializationFormat
     record.not_cached_records << NotCachedRecord.new(:name => 'NoCache')
     record.associated.deeply_associated_records << DeeplyAssociatedRecord.new(:name => "corge")
     record.associated.deeply_associated_records << DeeplyAssociatedRecord.new(:name => "qux")
-    record.created_at = DateTime.parse('1970-01-01T00:00:00 +0000')
+    record.created_at = Time.parse('1970-01-01T00:00:00 UTC')
     record.save
     Item.where(id: record.id).update_all(updated_at: record.created_at)
     record.reload


### PR DESCRIPTION
@arthurnn & @fbogsany 
## Problem

The tests are failing locally for me.

```
  1) Failure:
test_serialization_format_has_not_changed(SerializationFormatChangeTest) [test/serialization_format_change_test.rb:12]:
serialization format changed => increment IdentityCache.CACHE_VERSION and run rake update_serialization_format.
--- expected
+++ actual
@@ -1 +1 @@
-{:version=>3, :record=>{:class=>Item(id: integer, item_id: integer, title: string, created_at: datetime, updated_at: datetime), "attributes"=>{"id"=>1, "item_id"=>nil, "title"=>"foo", "created_at"=>1970-01-01 00:00:00 UTC, "updated_at"=>1970-01-01 00:00:00 UTC}, :associations=>{:associated_records=>[{:class=>AssociatedRecord(id: integer, name: string, item_id: integer), "attributes"=>{"id"=>3, "name"=>"bork", "item_id"=>1}, :associations=>{:deeply_associated_records=>[{:class=>DeeplyAssociatedRecord(id: integer, name: string, associated_record_id: integer), "attributes"=>{"id"=>2, "name"=>"qux", "associated_record_id"=>3}}, {:class=>DeeplyAssociatedRecord(id: integer, name: string, associated_record_id: integer), "attributes"=>{"id"=>1, "name"=>"corge", "associated_record_id"=>3}}]}, :normalized_has_many=>{}}, {:class=>AssociatedRecord(id: integer, name: string, item_id: integer), "attributes"=>{"id"=>2, "name"=>"baz", "item_id"=>1}, :associations=>{:deeply_associated_records=>[]}, :normalized_has_many=>{}}, {:class=>AssociatedRecord(id: integer, name: string, item_id: integer), "attributes"=>{"id"=>1, "name"=>"bar", "item_id"=>1}, :associations=>{:deeply_associated_records=>[]}, :normalized_has_many=>{}}], :associated=>{:class=>AssociatedRecord(id: integer, name: string, item_id: integer), "attributes"=>{"id"=>3, "name"=>"bork", "item_id"=>1}, :associations=>{:deeply_associated_records=>[{:class=>DeeplyAssociatedRecord(id: integer, name: string, associated_record_id: integer), "attributes"=>{"id"=>2, "name"=>"qux", "associated_record_id"=>3}}, {:class=>DeeplyAssociatedRecord(id: integer, name: string, associated_record_id: integer), "attributes"=>{"id"=>1, "name"=>"corge", "associated_record_id"=>3}}]}, :normalized_has_many=>{}}}, :normalized_has_many=>{}}}
+{:version=>3, :record=>{:class=>Item(id: integer, item_id: integer, title: string, created_at: datetime, updated_at: datetime), "attributes"=>{"id"=>1, "item_id"=>nil, "title"=>"foo", "created_at"=>1970-01-01 00:00:00 -0500, "updated_at"=>1970-01-01 00:00:00 -0500}, :associations=>{:associated_records=>[{:class=>AssociatedRecord(id: integer, name: string, item_id: integer), "attributes"=>{"id"=>3, "name"=>"bork", "item_id"=>1}, :associations=>{:deeply_associated_records=>[{:class=>DeeplyAssociatedRecord(id: integer, name: string, associated_record_id: integer), "attributes"=>{"id"=>2, "name"=>"qux", "associated_record_id"=>3}}, {:class=>DeeplyAssociatedRecord(id: integer, name: string, associated_record_id: integer), "attributes"=>{"id"=>1, "name"=>"corge", "associated_record_id"=>3}}]}, :normalized_has_many=>{}}, {:class=>AssociatedRecord(id: integer, name: string, item_id: integer), "attributes"=>{"id"=>2, "name"=>"baz", "item_id"=>1}, :associations=>{:deeply_associated_records=>[]}, :normalized_has_many=>{}}, {:class=>AssociatedRecord(id: integer, name: string, item_id: integer), "attributes"=>{"id"=>1, "name"=>"bar", "item_id"=>1}, :associations=>{:deeply_associated_records=>[]}, :normalized_has_many=>{}}], :associated=>{:class=>AssociatedRecord(id: integer, name: string, item_id: integer), "attributes"=>{"id"=>3, "name"=>"bork", "item_id"=>1}, :associations=>{:deeply_associated_records=>[{:class=>DeeplyAssociatedRecord(id: integer, name: string, associated_record_id: integer), "attributes"=>{"id"=>2, "name"=>"qux", "associated_record_id"=>3}}, {:class=>DeeplyAssociatedRecord(id: integer, name: string, associated_record_id: integer), "attributes"=>{"id"=>1, "name"=>"corge", "associated_record_id"=>3}}]}, :normalized_has_many=>{}}}, :normalized_has_many=>{}}}
```

This seems to happen because `Time.zone == nil`, and local time on my machine is Eastern Standard Time.

```
    irb> record.created_at = DateTime.parse('1970-01-01T00:00:00 +0000')
    => Thu, 01 Jan 1970 00:00:00 +0000
    irb> record.save!
    irb> record.created_at
    => Thu, 01 Jan 1970 00:00:00 +0000
    irb> record.reload
    irb> record.created_at
    => 1970-01-01 00:00:00 -0500
```

A regression test shows commit e5c266cb559b66025a3c71fb577ba7a34080f740 as the first failing commit.

I'm not sure why DateTime has this problem.
## Solution

Using Time for some reason avoids this problem.
