### PR TITLE
Fix nil @_start_transaction_state variable.

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -95,6 +95,7 @@ module IdentityCache
               @attributes_cache, @previously_changed, @changed_attributes = {}, {}, {}
               @association_cache = {}
               @aggregation_cache = {}
+              @_start_transaction_state = {}
               @readonly = @destroyed = @marked_for_destruction = false
               @new_record = false
               @column_types = self.class.column_types if self.class.respond_to?(:column_types)


### PR DESCRIPTION
Which was throwing an `undefined method '[]' for nil:NilClass` error in Rails 4.0.2.

I noticed that these instance variables from `ActiveRecord::Core#init_internals` aren't being set either. But they haven't given me trouble so I didn't include them.

```
@txn = nil
@_start_transaction_state = {}
@reflects_state = [false]
@destroyed_by_association = nil
```
