### PR TITLE
add default column vlaue for quote_value with rails4.1.0beta1

### DIFF
--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -292,7 +292,7 @@ module IdentityCache
       end
 
       def identity_cache_sql_conditions(fields, values)
-        fields.each_with_index.collect { |f, i| "#{connection.quote_column_name(f)} = #{quote_value(values[i])}" }.join(" AND ")
+        fields.each_with_index.collect { |f, i| "#{connection.quote_column_name(f)} = #{quote_value(values[i],nil)}" }.join(" AND ")
       end
     end
   end


### PR DESCRIPTION
rails 4.1.0beta1 changed the method

from

```
def quote_value(value, column = nil) #:nodoc:
  connection.quote(value, column)
end
```

to

```
def quote_value(value, column) #:nodoc:
  connection.quote(value, column)
end
```

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/sanitization.rb
