### PR TITLE
belongs_to embed: true

### DIFF
--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -16,15 +16,26 @@ module IdentityCache
         options[:foreign_key]             ||= reflect_on_association(association).foreign_key
         options[:association_class]       ||= reflect_on_association(association).klass
         options[:prepopulate_method_name] ||= "prepopulate_fetched_#{association}"
-        if options[:embed]
-          raise NotImplementedError
-        else
-          build_normalized_belongs_to_cache(association, options)
-        end
+
+        build_embedded_belongs_to_cache(association, options) if options[:embed]
+
+        build_normalized_belongs_to_cache(association, options)
+      end
+
+      def build_embedded_belongs_to_cache(association, options)
+        self.class_eval <<-CODE, __FILE__, __LINE__ + 1
+          def #{association}
+            if IdentityCache.should_cache? && #{options[:foreign_key]}.present? && !association(:#{association}).loaded?
+              self.#{association} = #{options[:association_class]}.fetch_by_id(#{options[:foreign_key]})
+            else
+              super
+            end
+          end
+        CODE
       end
 
       def build_normalized_belongs_to_cache(association, options)
-        self.class_eval(ruby = <<-CODE, __FILE__, __LINE__ + 1)
+        self.class_eval <<-CODE, __FILE__, __LINE__ + 1
           def #{options[:cached_accessor_name]}
             if IdentityCache.should_cache? && #{options[:foreign_key]}.present? && !association(:#{association}).loaded?
               self.#{association} = #{options[:association_class]}.fetch_by_id(#{options[:foreign_key]})


### PR DESCRIPTION
This adds support for `embed: true` option. Seems to work in Rails 4. 

Once in a while I get `AssociationTypeMismatch` error in development. I guess this has to clear when Rails reloads the class somehow.

This also needs tests.
