### PR TITLE
Fix cache key to not change when adding a non-embedded association.

### DIFF
--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -19,8 +19,8 @@ module IdentityCache
     end
 
     def self.embedded_associations(klass)
-      if klass.respond_to?(:all_cached_associations_needing_population)
-        klass.all_cached_associations_needing_population
+      if klass.respond_to?(:all_embedded_associations)
+        klass.all_embedded_associations
       else
         {}
       end

--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -81,4 +81,17 @@ class SchemaChangeTest < IdentityCache::TestCase
     Item.expects(:resolve_cache_miss).returns(@record)
     record = Item.fetch(@record.id)
   end
+
+  def test_embed_existing_cache_has_many
+    Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => false
+    read_new_schema
+
+    record = Item.fetch(@record.id)
+
+    Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => true
+    read_new_schema
+
+    Item.expects(:resolve_cache_miss).returns(@record)
+    record = Item.fetch(@record.id)
+  end
 end


### PR DESCRIPTION
@fbogsany & @arthurnn for review
cc @jahfer, @byroot 
## Problem

The IdentityCache::ClassMethods.rails_cache_key_prefix is meant to change when columns for a cached model or its embedded associations change.  This should allow us to add embedded associations and not use cache keys without those embedded associations.  However, we were treating non-embedded has_many associations as if they were embedded when generating the cache key prefix, so we would use the same cache key after changing a non-embedded cached association to an embedded cached association.  This would result in the following error from using the old cached data:

```
NameError: `@' is not allowed as an instance variable name
    /Users/dylansmith/src/identity_cache/lib/identity_cache/query_api.rb:109:in `instance_variable_set'
    /Users/dylansmith/src/identity_cache/lib/identity_cache/query_api.rb:109:in `block in record_from_coder'
    /Users/dylansmith/src/identity_cache/lib/identity_cache/query_api.rb:109:in `each'
    /Users/dylansmith/src/identity_cache/lib/identity_cache/query_api.rb:109:in `record_from_coder'
    /Users/dylansmith/src/identity_cache/lib/identity_cache/query_api.rb:38:in `block in fetch_by_id'
    /Users/dylansmith/src/identity_cache/lib/identity_cache/query_api.rb:164:in `require_if_necessary'
    /Users/dylansmith/src/identity_cache/lib/identity_cache/query_api.rb:35:in `fetch_by_id'
    /Users/dylansmith/src/identity_cache/lib/identity_cache/query_api.rb:52:in `fetch'
```
## Solution

Fix the cache prefix so that it uses the right list of associations as embedded associations.

A regression test was added which was used to generate the above exception without the fix.
