### PR TITLE
cache_backend= should not touch Rails

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -47,7 +47,11 @@ module IdentityCache
     # +cache_adaptor+ - A ActiveSupport::Cache::Store
     #
     def cache_backend=(cache_adaptor)
-      cache.cache_backend = cache_adaptor
+      if @cache
+        cache.cache_backend = cache_adaptor
+      else
+        @cache = MemoizedCacheProxy.new(cache_adaptor)
+      end
     end
 
     def cache

--- a/test/memoized_cache_proxy_test.rb
+++ b/test/memoized_cache_proxy_test.rb
@@ -102,4 +102,9 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
     assert_equal 'bar', Rails.cache.read('foo')
   end
 
+  def test_set_backend_should_not_touch_rails
+    Rails.expects(:cache).never
+    IdentityCache.instance_variable_set(:@cache, nil)
+    IdentityCache.cache_backend = Rails::Cache.new
+  end
 end


### PR DESCRIPTION
When using IDC without Rails, we should set a `IDC.cache_backend=` to
replace the Rails.cache, So we need to create the CacheProxy passing
that backend.

review @dylanahsmith 
