### PR TITLE
Only create CollectionProxy when need it.

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -118,7 +118,7 @@ module IdentityCache
           association = reflection.association_class.new(record, reflection)
           association.target = coder_or_array.map {|e| record_from_coder(e) }
           association.target.each {|e| association.set_inverse_instance(e) }
-          association.reader
+          association
         else
           record_from_coder(coder_or_array)
         end
@@ -337,7 +337,8 @@ module IdentityCache
       ivar_full_name = :"@#{ivar_name}"
       if IdentityCache.should_cache?
         populate_denormalized_cached_association(ivar_name, association_name)
-        IdentityCache.unmap_cached_nil_for(instance_variable_get(ivar_full_name))
+        assoc = IdentityCache.unmap_cached_nil_for(instance_variable_get(ivar_full_name))
+        assoc.is_a?(ActiveRecord::Associations::CollectionAssociation) ? assoc.reader : assoc
       else
         send(association_name.to_sym)
       end


### PR DESCRIPTION
### Problem

Rails 4, has a big performance hit on the `reader` method. `reader` instantiate a `CollectionProxy` and return it. On rails 4 they preload the scopes when creating the `CollectionProxy`.
### Solution

When we un-marshal the object, we dont need to create the `CollectionProxy` right away, as it might not even be used. This is deferring the `.reader` call to when we call `fetch_#{association_name}`.

This is the example file I used to benchmark the change https://gist.github.com/arthurnn/9096869.

Rails 3:

```
       user     system      total        real
  20.220000   2.040000  22.260000 ( 23.073374)
```

Rails4:
before:

```
       user     system      total        real
  36.310000   2.480000  38.790000 ( 39.942972)
```

after:

```
       user     system      total        real
  21.880000   2.200000  24.080000 ( 24.851130)
```

The benchmark only has one has_many cached association, if we increase the number of cached associations, we can see a even bigger difference on the marks.
