### PR TITLE
Added support for non-integer primary keys

### DIFF
--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -187,7 +187,7 @@ module IdentityCache
         cache_key = rails_cache_index_key_for_fields_and_values(fields, values)
         id = IdentityCache.fetch(cache_key) { connection.select_value(sql_on_miss) }
         unless id.nil?
-          record = fetch_by_id(id.to_i)
+          record = fetch_by_id(id)
           IdentityCache.cache.delete(cache_key) unless record
         end
 


### PR DESCRIPTION
Fixes #123.

identity_cache currently crashes when fetching by attribute with models that have primary keys that are not integers (e.g. UUID).

This removes id being converted to an integer when passing to `find_by_id` on cache miss.

Travis agrees with my changes.

https://travis-ci.org/anthonator/identity_cache
