### PR TITLE
Change cache key for non-embedded cache_has_many since they embed ids.

### DIFF
--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -94,4 +94,14 @@ class SchemaChangeTest < IdentityCache::TestCase
     Item.expects(:resolve_cache_miss).returns(@record)
     record = Item.fetch(@record.id)
   end
+
+  def test_add_non_embedded_cache_has_many
+    record = Item.fetch(@record.id)
+
+    Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => false
+    read_new_schema
+
+    Item.expects(:resolve_cache_miss).returns(@record)
+    record = Item.fetch(@record.id)
+  end
 end


### PR DESCRIPTION
@fbogsany & @camilo for review
## Problem

Pull #120 made the assumption that cache_has_many with `:embed => false` will not embed anything for the association, when cache_has_many actually embeds the association's ids.  This led to a regression where old cache values will be used after adding a non-embedded cache_has_many association.

A clearer API would require `:embed => :ids` to be used for this type of association, but that is a problem for another pull request.
## Solution

The cache key has a hashed schema string that includes the column names, their types, and the names and hashed schema string for all embedded associations in the format `#{name}:(#{denormalized_schema_hash(options[:association_class])})`.

For cache_has_many associations with `:embed => false` we will now add `#{name}:ids` to the schema string.  Since we only embed the ids, we don't need to have it dependant on the columns or associations of this associated model.
