### PR TITLE
Fix not implemented error for cache_has_one with embed: false.

### DIFF
--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -134,7 +134,7 @@ module IdentityCache
       #   necessary if the name is not the lowercase pluralization of the
       #   parent object's class)
       def cache_has_one(association, options = {})
-        options[:embed] ||= true
+        options[:embed] = true unless options.has_key?(:embed)
         options[:inverse_name] ||= self.name.underscore.to_sym
         raise InverseAssociationError unless self.reflect_on_association(association)
         self.cached_has_ones[association] = options

--- a/test/normalized_has_one_test.rb
+++ b/test/normalized_has_one_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class NormalizedHasOneTest < IdentityCache::TestCase
+  def test_not_implemented_error
+    assert_raises(NotImplementedError) do
+      Item.cache_has_one :associated, :embed => false
+    end
+  end
+end


### PR DESCRIPTION
@fbogsany for review
## Problem

``` ruby
cache_has_one :friends, :embed => false
```

should cause NotImplementedError to be raised.  Instead, it just silently embedded the association.

This was because we had `options[:embed]` before a `if options[:embed]` condition, so the `else` branch was never taken.
## Solution

Use `options[:embed] = true unless options.has_key?(:embed)` to set the default option value.
