### PR TITLE
Make some undocumented methods private.

### DIFF
--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -10,7 +10,7 @@ module IdentityCache
     def self.denormalized_schema_hash(klass)
       schema_string = schema_to_string(klass.columns)
       if klass.include?(IdentityCache)
-        klass.all_cached_associations.sort.each do |name, options|
+        klass.send(:all_cached_associations).sort.each do |name, options|
           if options[:embed]
             schema_string << ",#{name}:(#{denormalized_schema_hash(options[:association_class])})"
           elsif options[:cached_ids_name]

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -14,10 +14,6 @@ module IdentityCache
       base.cache_attributes = []
       base.cache_indexes = []
       base.primary_cache_index_enabled = true
-
-      base.private_class_method :build_normalized_has_many_cache, :build_denormalized_association_cache,
-                                :add_parent_expiry_hook, :identity_cache_multiple_value_dynamic_fetcher,
-                                :identity_cache_single_value_dynamic_fetcher, :identity_cache_sql_conditions
     end
 
     module ClassMethods
@@ -181,6 +177,8 @@ module IdentityCache
         raise NotImplementedError, "Secondary indexes rely on the primary index to function. You must either remove the secondary indexes or don't disable the primary" if self.cache_indexes.size > 0
         self.primary_cache_index_enabled = false
       end
+
+      private
 
       def identity_cache_single_value_dynamic_fetcher(fields, values) # :nodoc:
         sql_on_miss = "SELECT #{quoted_primary_key} FROM #{quoted_table_name} WHERE #{identity_cache_sql_conditions(fields, values)} LIMIT 1"

--- a/lib/identity_cache/parent_model_expiration.rb
+++ b/lib/identity_cache/parent_model_expiration.rb
@@ -5,16 +5,16 @@ module IdentityCache
 
       if new_parent && new_parent.respond_to?(:expire_primary_index, true)
         if should_expire_identity_cache_parent?(foreign_key, only_on_foreign_key_change)
-          new_parent.expire_primary_index
-          new_parent.expire_parent_cache if new_parent.respond_to?(:expire_parent_cache)
+          new_parent.send(:expire_primary_index)
+          new_parent.send(:expire_parent_cache) if new_parent.respond_to?(:expire_parent_cache, true)
         end
       end
 
       if transaction_changed_attributes[foreign_key].present?
         begin
           old_parent = parent_class.find(transaction_changed_attributes[foreign_key])
-          old_parent.expire_primary_index if old_parent.respond_to?(:expire_primary_index)
-          old_parent.expire_parent_cache  if old_parent.respond_to?(:expire_parent_cache)
+          old_parent.send(:expire_primary_index) if old_parent.respond_to?(:expire_primary_index, true)
+          old_parent.send(:expire_parent_cache)  if old_parent.respond_to?(:expire_parent_cache, true)
         rescue ActiveRecord::RecordNotFound => e
           # suppress errors finding the old parent if its been destroyed since it will have expired itself in that case
         end

--- a/performance/cache_runner.rb
+++ b/performance/cache_runner.rb
@@ -147,7 +147,7 @@ class NormalizedRunner < CacheRunner
       rec.fetch_associated
       associated_records = rec.fetch_associated_records
       # FIXME: Only fetch_multi has :includes support, so use what it uses internally
-      AssociatedRecord.prefetch_associations(:deeply_associated_records, associated_records)
+      AssociatedRecord.send(:prefetch_associations, :deeply_associated_records, associated_records)
     end
   end
 end

--- a/test/cache_fetch_includes_test.rb
+++ b/test/cache_fetch_includes_test.rb
@@ -7,28 +7,28 @@ class CacheFetchIncludesTest < IdentityCache::TestCase
 
   def test_cached_embedded_has_manys_are_included_in_includes
     Item.send(:cache_has_many, :associated_records, :embed => true)
-    assert_equal [:associated_records], Item.cache_fetch_includes
+    assert_equal [:associated_records], Item.send(:cache_fetch_includes)
   end
 
   def test_cached_nonembedded_has_manys_are_included_in_includes
     Item.send(:cache_has_many, :associated_records, :embed => false)
-    assert_equal [], Item.cache_fetch_includes
+    assert_equal [], Item.send(:cache_fetch_includes)
   end
 
   def test_cached_has_ones_are_included_in_includes
     Item.send(:cache_has_one, :associated)
-    assert_equal [:associated], Item.cache_fetch_includes
+    assert_equal [:associated], Item.send(:cache_fetch_includes)
   end
 
   def test_cached_nonembedded_belongs_tos_are_not_included_in_includes
     Item.send(:cache_belongs_to, :item)
-    assert_equal [], Item.cache_fetch_includes
+    assert_equal [], Item.send(:cache_fetch_includes)
   end
 
   def test_cached_child_associations_are_included_in_includes
     Item.send(:cache_has_many, :associated_records, :embed => true)
     AssociatedRecord.send(:cache_has_many, :deeply_associated_records, :embed => true)
-    assert_equal [{:associated_records => [:deeply_associated_records]}], Item.cache_fetch_includes
+    assert_equal [{:associated_records => [:deeply_associated_records]}], Item.send(:cache_fetch_includes)
   end
 
   def test_multiple_cached_associations_and_child_associations_are_included_in_includes
@@ -40,16 +40,16 @@ class CacheFetchIncludesTest < IdentityCache::TestCase
       {:associated_records => [:deeply_associated_records]},
       :polymorphic_records,
       {:associated => [:deeply_associated_records]}
-    ],  Item.cache_fetch_includes
+    ],  Item.send(:cache_fetch_includes)
   end
 
   def test_empty_additions_for_top_level_associations_makes_no_difference
     Item.send(:cache_has_many, :associated_records, :embed => true)
-    assert_equal [:associated_records], Item.cache_fetch_includes({})
+    assert_equal [:associated_records], Item.send(:cache_fetch_includes, {})
   end
 
   def test_top_level_additions_are_included_in_includes
-    assert_equal [{:associated_records => []}], Item.cache_fetch_includes({:associated_records => []})
+    assert_equal [{:associated_records => []}], Item.send(:cache_fetch_includes, {:associated_records => []})
   end
 
   def test_top_level_additions_alongside_top_level_cached_associations_are_included_in_includes
@@ -57,21 +57,21 @@ class CacheFetchIncludesTest < IdentityCache::TestCase
     assert_equal [
       :associated_records,
       {:polymorphic_records => []}
-    ], Item.cache_fetch_includes({:polymorphic_records => []})
+    ], Item.send(:cache_fetch_includes, {:polymorphic_records => []})
   end
 
   def test_child_level_additions_for_top_level_cached_associations_are_included_in_includes
     Item.send(:cache_has_many, :associated_records, :embed => true)
     assert_equal [
       {:associated_records => [{:deeply_associated_records => []}]}
-    ], Item.cache_fetch_includes({:associated_records => :deeply_associated_records})
+    ], Item.send(:cache_fetch_includes, {:associated_records => :deeply_associated_records})
   end
 
   def test_array_child_level_additions_for_top_level_cached_associations_are_included_in_includes
     Item.send(:cache_has_many, :associated_records, :embed => true)
     assert_equal [
       {:associated_records => [{:deeply_associated_records => []}]}
-    ], Item.cache_fetch_includes({:associated_records => [:deeply_associated_records]})
+    ], Item.send(:cache_fetch_includes, {:associated_records => [:deeply_associated_records]})
   end
 
   def test_array_child_level_additions_for_child_level_cached_associations_are_included_in_includes
@@ -82,7 +82,7 @@ class CacheFetchIncludesTest < IdentityCache::TestCase
         :deeply_associated_records,
         {:record => []}
       ]}
-    ], Item.cache_fetch_includes({:associated_records => [:record]})
+    ], Item.send(:cache_fetch_includes, {:associated_records => [:record]})
   end
 
 end

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -28,7 +28,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     @record.associated = nil
     @record.save!
     @record.reload
-    @record.populate_association_caches
+    @record.send(:populate_association_caches)
     Item.expects(:resolve_cache_miss).with(@record.id).once.returns(@record)
 
     IdentityCache.cache.expects(:read).with(@record.secondary_cache_index_key_for_current_values([:title]))
@@ -51,7 +51,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
   end
 
   def test_on_cache_hit_record_should_come_back_with_cached_association
-    @record.populate_association_caches
+    @record.send(:populate_association_caches)
     Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
     Item.fetch_by_title('foo')
 
@@ -67,7 +67,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     @record.save!
     @record.reload
 
-    @record.populate_association_caches
+    @record.send(:populate_association_caches)
     Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
     Item.fetch_by_title('foo')
 

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -125,7 +125,7 @@ class FetchMultiTest < IdentityCache::TestCase
     Item.expects(:where).returns(mock_relation)
     mock_relation.expects(:includes).returns(stub(:to_a => [@bob, @joe, @fred]))
 
-    Item.find_batch([@bob, @joe, @fred].map(&:id).map(&:to_s))
+    Item.send(:find_batch, [@bob, @joe, @fred].map(&:id).map(&:to_s))
   end
 
   def test_fetch_multi_doesnt_freeze_keys

--- a/test/fetch_multi_with_batched_associations_test.rb
+++ b/test/fetch_multi_with_batched_associations_test.rb
@@ -203,7 +203,7 @@ class FetchMultiWithBatchedAssociationsTest < IdentityCache::TestCase
     Item.expects(:where).returns(mock_relation)
     mock_relation.expects(:includes).returns(stub(:to_a => [@bob, @joe, @fred]))
 
-    Item.find_batch([@bob, @joe, @fred].map(&:id).map(&:to_s))
+    Item.send(:find_batch, [@bob, @joe, @fred].map(&:id).map(&:to_s))
   end
 
   private

--- a/test/recursive_denormalized_has_many_test.rb
+++ b/test/recursive_denormalized_has_many_test.rb
@@ -23,7 +23,7 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
   end
 
   def test_cache_fetch_includes
-    assert_equal [{:associated_records => [:deeply_associated_records]}, :associated => [:deeply_associated_records]], Item.cache_fetch_includes
+    assert_equal [{:associated_records => [:deeply_associated_records]}, :associated => [:deeply_associated_records]], Item.send(:cache_fetch_includes)
   end
 
   def test_uncached_record_from_the_db_will_use_normal_association_for_deeply_associated_records


### PR DESCRIPTION
@arthurnn & @fbogsany for review
## Problem

Currently, we are calling `private_class_method` and `private` with a list of methods to make private, which makes it easy to miss marking methods private that should be.  E.g. IdentityCache::ConfigurationDSL::ClassMethods#attribute_dynamic_fetcher should probably have been marked private and was commented with `#:nodoc:`, but was missed from the private_class_method list. 

I also found there were methods that might have been left public to make them easy to call within tests or external to the object in identity_cache.
## Solution

This uses `private` without arguments to make everything after it private.  We were already structuring the code such that the private methods were always last in the classes.

In cases where we need to call an internal methods from another object, I just used `.send(:` instead.  I also had to change some `respond_to?` calls to pass a second argument of `true` to have it also check for private methods.

I think this makes it easier to see what methods are private when reading the code.
