### PR TITLE
Avoid preloading non-embedded associations when resolving cache misses.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Unreleased
+* Fix: Avoid unused preload on fetch_multi with :includes option for cache miss
 * Change :embed option value from false to :ids for cache_has_many for clarity
 
 0.0.7

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('memcached_store', '~> 0.11.2')
   gem.add_development_dependency('rake')
   gem.add_development_dependency('mocha', '0.14.0')
+  gem.add_development_dependency('spy')
 
   if RUBY_PLATFORM == 'java'
     gem.add_development_dependency 'jruby-openssl'

--- a/test/cache_fetch_includes_test.rb
+++ b/test/cache_fetch_includes_test.rb
@@ -42,47 +42,4 @@ class CacheFetchIncludesTest < IdentityCache::TestCase
       {:associated => [:deeply_associated_records]}
     ],  Item.send(:cache_fetch_includes)
   end
-
-  def test_empty_additions_for_top_level_associations_makes_no_difference
-    Item.send(:cache_has_many, :associated_records, :embed => true)
-    assert_equal [:associated_records], Item.send(:cache_fetch_includes, {})
-  end
-
-  def test_top_level_additions_are_included_in_includes
-    assert_equal [{:associated_records => []}], Item.send(:cache_fetch_includes, {:associated_records => []})
-  end
-
-  def test_top_level_additions_alongside_top_level_cached_associations_are_included_in_includes
-    Item.send(:cache_has_many, :associated_records, :embed => true)
-    assert_equal [
-      :associated_records,
-      {:polymorphic_records => []}
-    ], Item.send(:cache_fetch_includes, {:polymorphic_records => []})
-  end
-
-  def test_child_level_additions_for_top_level_cached_associations_are_included_in_includes
-    Item.send(:cache_has_many, :associated_records, :embed => true)
-    assert_equal [
-      {:associated_records => [{:deeply_associated_records => []}]}
-    ], Item.send(:cache_fetch_includes, {:associated_records => :deeply_associated_records})
-  end
-
-  def test_array_child_level_additions_for_top_level_cached_associations_are_included_in_includes
-    Item.send(:cache_has_many, :associated_records, :embed => true)
-    assert_equal [
-      {:associated_records => [{:deeply_associated_records => []}]}
-    ], Item.send(:cache_fetch_includes, {:associated_records => [:deeply_associated_records]})
-  end
-
-  def test_array_child_level_additions_for_child_level_cached_associations_are_included_in_includes
-    Item.send(:cache_has_many, :associated_records, :embed => true)
-    AssociatedRecord.send(:cache_has_many, :deeply_associated_records, :embed => true)
-    assert_equal [
-      {:associated_records => [
-        :deeply_associated_records,
-        {:record => []}
-      ]}
-    ], Item.send(:cache_fetch_includes, {:associated_records => [:record]})
-  end
-
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require 'active_support/cache/memcached_store'
 require 'helpers/cache'
 require 'helpers/database_connection'
 require 'helpers/active_record_objects'
+require 'spy'
 
 require File.dirname(__FILE__) + '/../lib/identity_cache'
 


### PR DESCRIPTION
@fbogsany & @arthurnn for review
## Problem

`fetch_multi` supports an `:includes` option to preloading associations with identity cache which aren't fully embedded.  For example:

``` ruby
User.fetch_multi(*user_ids, :includes => :friends)
```

would fetch the friends associations for all fetched user's using a single `fetch_multi` call to avoid an N+1.

This is similar to how active record allows associations to be preloaded, so previously we were using active record's preloading when IDC is disabled (i.e. `IdentityCache.should_cache?` is false) by passing the `:includes` option into `find_batch`.

Unfortunately, we were also passing the `:includes` option into `find_batch` when resolving cache misses, even though these associations get ignored when serializing the records to store into memcached, and lost after deserializing these records.  This was likely unintentional since we were calling prefetch_associations on the deserialized records to fetch these additional associations.
## Solution

Avoiding passing in options to find_batch when resolving the cache miss solves this problem.

We can also use `prefetch_associations` even when caching is disabled, since it just uses `fetch_multi` to load the additional associations.  By using this, we can completely remove the `options` argument from `find_batch`, and remove a lot of extra logic.

We actually had a test which was asserting the buggy behaviour, since it was heavily using mocha to test internals, which missed the high level problem.  I added the spy gem to easily assert that fetch_multi was called for the cache_belongs_to association, since the associated class was the same class we are making the fetch_multi on in the test, so I couldn't stub out the Item.fetch_multi method.
