### PR TITLE
Fix fetch_multi to always compact results even when not using cache.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Unreleased
+* Fix: Bug in fetch_multi in a transaction where results weren't compacted.
 * Fix: Avoid unused preload on fetch_multi with :includes option for cache miss
 * Change :embed option value from false to :ids for cache_has_many for clarity
 

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -62,11 +62,12 @@ module IdentityCache
               records.map {|record| coder_from_record(record) }
             end
 
-            cache_keys.map{ |key| key_to_record_map[key] || record_from_coder(coders_by_key[key]) }.compact
+            cache_keys.map{ |key| key_to_record_map[key] || record_from_coder(coders_by_key[key]) }
           end
         else
           find_batch(ids)
         end
+        records.compact!
         prefetch_associations(options[:includes], records) if options[:includes]
         records
       end

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -115,6 +115,11 @@ class FetchMultiTest < IdentityCache::TestCase
     assert_equal [@joe, @bob, @fred], Item.fetch_multi(@joe.id, @bob.id, @fred.id)
   end
 
+  def test_fetch_multi_with_open_transactions_should_compacts_returned_array
+    Item.connection.expects(:open_transactions).at_least_once.returns(1)
+    assert_equal [@joe, @fred], Item.fetch_multi(@joe.id, 0, @fred.id)
+  end
+
   def test_fetch_multi_with_duplicate_ids_in_transaction_returns_results_in_the_order_of_the_passed_ids
     Item.connection.expects(:open_transactions).at_least_once.returns(1)
     assert_equal [@joe, @bob, @joe], Item.fetch_multi(@joe.id, @bob.id, @joe.id)


### PR DESCRIPTION
@arthurnn & @fbogsany for review
## Problem

Previously doing something like

``` ruby
  User.transaction do
    users = User.fetch_multi(*user_ids)
  end
```

could result in `nil` entries in the users array.

This bug became more apparent after doing `prefetch_associations` directly on the results of `find_batch`, however, the regression has been around for a while.
## Solution

compact the records array outside of the `IdentityCache.should_cache?` block.
