### PR TITLE
Invalidate instance variable cache on reload

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -10,6 +10,7 @@ require 'identity_cache/configuration_dsl'
 require 'identity_cache/parent_model_expiration'
 require 'identity_cache/query_api'
 require "identity_cache/cache_hash"
+require "identity_cache/cache_invalidation"
 
 module IdentityCache
   CACHED_NIL = :idc_cached_nil
@@ -38,6 +39,7 @@ module IdentityCache
       base.send(:include, IdentityCache::CacheKeyGeneration)
       base.send(:include, IdentityCache::ConfigurationDSL)
       base.send(:include, IdentityCache::QueryAPI)
+      base.send(:include, IdentityCache::CacheInvalidation)
     end
 
     # Sets the cache adaptor IdentityCache will be using

--- a/lib/identity_cache/cache_invalidation.rb
+++ b/lib/identity_cache/cache_invalidation.rb
@@ -1,0 +1,26 @@
+module IdentityCache
+  module CacheInvalidation
+
+    CACHE_KEY_NAMES = [:ids_variable_name, :records_variable_name]
+
+    def reload(*)
+      clear_cached_associations
+      super
+    end
+
+    private
+
+    def clear_cached_associations
+      self.class.send(:all_cached_associations).each do |_, data|
+        CACHE_KEY_NAMES.each do |key|
+          if data[key]
+            instance_variable_name = "@#{data[key]}"
+            if instance_variable_defined?(instance_variable_name)
+              remove_instance_variable(instance_variable_name)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class CacheInvalidationTest < IdentityCache::TestCase
+  def setup
+    super
+    Item.cache_has_many :associated_records, :embed => :ids
+
+    @record = Item.new(:title => 'foo')
+    @record.associated_records << AssociatedRecord.new(:name => 'bar')
+    @record.associated_records << AssociatedRecord.new(:name => 'baz')
+    @record.save
+    @record.reload
+    @baz, @bar = @record.associated_records[0], @record.associated_records[1]
+  end
+
+  def test_reload_invalidate_cached_ids
+    variable_name = "@#{@record.class.send(:embedded_associations)[:associated_records][:ids_variable_name]}"
+
+    @record.fetch_associated_record_ids
+    assert_equal [@baz.id, @bar.id], @record.instance_variable_get(variable_name)
+
+    @record.reload
+    assert_equal nil, @record.instance_variable_get(variable_name)
+
+    @record.fetch_associated_record_ids
+    assert_equal [@baz.id, @bar.id], @record.instance_variable_get(variable_name)
+  end
+
+  def test_reload_invalidate_cached_objects
+    variable_name = "@#{@record.class.send(:embedded_associations)[:associated_records][:records_variable_name]}"
+
+    @record.fetch_associated_records
+    assert_equal [@baz, @bar], @record.instance_variable_get(variable_name)
+
+    @record.reload
+    assert_equal nil, @record.instance_variable_get(variable_name)
+
+    @record.fetch_associated_records
+    assert_equal [@baz, @bar], @record.instance_variable_get(variable_name)
+  end
+
+  def test_after_a_reload_the_cache_perform_as_expected
+    assert_equal [@baz, @bar], @record.associated_records
+    assert_equal [@baz, @bar], @record.fetch_associated_records
+
+    @baz.destroy
+    @record.reload
+
+    assert_equal [@bar], @record.associated_records
+    assert_equal [@bar], @record.fetch_associated_records
+  end
+end


### PR DESCRIPTION
Assuming `ARecord.cache_has_many :b_records, :embed => true`
And `ARecord` has 2 `BRecord`
The nested cache invalidation mechanism work well when the modification is made through the relation

```
a = ARecord.first
a.fetch_b_records.count
  => 2 
a.fetch_b_records.destroy_all
a.fetch_b_records.count
  => 0
```

But if the record is deleted outside the relation of the original object there is currently no way to bust the cache

```
a = ARecord.first
a.fetch_b_records.count
  => 2 
ARecord.first.fetch_b_records.destroy_all
a.fetch_b_records.count
  => 2
a.reload
a.fetch_b_records.count
  => 2
```

This PR makes `reload` clear object instance internal cache. Object would have to retrieve a new copy of the cached object.
