### PR TITLE
Fix query api for custom primary key name.

### DIFF
--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -177,6 +177,11 @@ class FetchMultiTest < IdentityCache::TestCase
     assert_nothing_raised { Item.fetch_multi([@fred.id] * 200_000) }
   end
 
+  def test_fetch_multi_with_non_id_primary_key
+    fixture = KeyedRecord.create!(:value => "a") { |r| r.hashed_key = 123 }
+    assert_equal [fixture], KeyedRecord.fetch_multi(123, 456)
+  end
+
   private
 
   def populate_only_fred

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -64,6 +64,12 @@ class FetchTest < IdentityCache::TestCase
     assert_equal @record, Item.fetch(1)
   end
 
+  def test_fetch_miss_with_non_id_primary_key
+    hashed_key = Zlib::crc32("foo") % (2 ** 30 - 1)
+    fixture = KeyedRecord.create!(:value => "foo") { |r| r.hashed_key = hashed_key }
+    assert_equal fixture, KeyedRecord.fetch(hashed_key)
+  end
+
   def test_fetch_by_id_not_found_should_return_nil
     nonexistent_record_id = 10
     IdentityCache.cache.expects(:write).with(@blob_key + '0', IdentityCache::CACHED_NIL)

--- a/test/helpers/active_record_objects.rb
+++ b/test/helpers/active_record_objects.rb
@@ -56,6 +56,11 @@ module ActiveRecordObjects
       has_one :polymorphic_record, :as => 'owner'
       has_one :associated, :class_name => 'AssociatedRecord'
     }
+
+    Object.send :const_set, 'KeyedRecord', Class.new(base) {
+      include IdentityCache
+      self.primary_key = "hashed_key"
+    }
   end
 
   def teardown_models
@@ -67,5 +72,6 @@ module ActiveRecordObjects
     Object.send :remove_const, 'AssociatedRecord'
     Object.send :remove_const, 'NotCachedRecord'
     Object.send :remove_const, 'Item'
+    Object.send :remove_const, 'KeyedRecord'
   end
 end

--- a/test/helpers/database_connection.rb
+++ b/test/helpers/database_connection.rb
@@ -17,7 +17,9 @@ module DatabaseConnection
 
   def self.create_tables
     TABLES.each do |table, fields|
-      ActiveRecord::Base.connection.create_table(table) do |t|
+      fields = fields.dup
+      options = fields.last.is_a?(Hash) ? fields.pop : {}
+      ActiveRecord::Base.connection.create_table(table, options) do |t|
         fields.each do |column_type, *args|
           t.send(column_type, *args)
         end
@@ -32,7 +34,8 @@ module DatabaseConnection
     :normalized_associated_records => [[:string, :name], [:integer, :item_id], [:timestamps]],
     :not_cached_records            => [[:string, :name], [:integer, :item_id], [:timestamps]],
     :items                         => [[:integer, :item_id], [:string, :title], [:timestamps]],
-    :items2                        => [[:integer, :item_id], [:string, :title], [:timestamps]]
+    :items2                        => [[:integer, :item_id], [:string, :title], [:timestamps]],
+    :keyed_records                 => [[:string, :value], :primary_key => "hashed_key"],
   }
 
   DATABASE_CONFIG = {


### PR DESCRIPTION
@arthurnn & @camilo for review

Fixes #142
## Problem

Identity cache wasn't working when a primary key other than "id" is used.
## Solution

Use the primary_key method on the model's class to get the column name rather than hard coding `id`.
