### PR TITLE
Bump ar_transaction changes to 1.0 and loosen version constraint.

### DIFF
--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = IdentityCache::VERSION
 
-  gem.add_dependency('ar_transaction_changes', '= 0.0.3')
+  gem.add_dependency('ar_transaction_changes', '~> 1.0')
   gem.add_dependency('activerecord', '>= 3.2')
 
   gem.add_development_dependency('memcached_store', '~> 0.11.2')


### PR DESCRIPTION
@arthurnn and @fbogsany for review

Bump ar_transaction_changes due the private methods create_record and update_record being prefixed with an underscore in active record 4 stable branches.  Instead, the public run_callbacks method is now overridden to avoid these problems (https://github.com/dylanahsmith/ar_transaction_changes/commit/69c295832fce6fd234fea218770c733805bc0d4f).

I also loosened the constrain to allow minor and bug fix releases.  I released ar_transaction_changes v1.0.0 so will follow semantic versioning to avoid breaking the API.

Full upstream changeset: https://github.com/dylanahsmith/ar_transaction_changes/compare/v0.0.3...v1.0.0
