### PR TITLE
Remove the brittle fast path that avoids calling record.init_with.

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -84,22 +84,7 @@ module IdentityCache
             coder = coder.dup
             coder['attributes'] = coder['attributes'].dup
           end
-          if record.class._initialize_callbacks.empty?
-            record.instance_eval do
-              @attributes = self.class.initialize_attributes(coder['attributes'])
-              @relation = nil
-
-              @attributes_cache, @previously_changed, @changed_attributes = {}, {}, {}
-              @association_cache = {}
-              @aggregation_cache = {}
-              @_start_transaction_state = {}
-              @readonly = @destroyed = @marked_for_destruction = false
-              @new_record = false
-              @column_types = self.class.column_types if self.class.respond_to?(:column_types)
-            end
-          else
-            record.init_with(coder)
-          end
+          record.init_with(coder)
 
           coder[:associations].each {|name, value| set_embedded_association(record, name, value) } if coder.has_key?(:associations)
           coder[:normalized_has_many].each {|name, ids| record.instance_variable_set(:"@#{record.class.cached_has_manys[name][:ids_variable_name]}", ids) } if coder.has_key?(:normalized_has_many)


### PR DESCRIPTION
@fbogsany & @arthurnn for review

Fixes #156
## Problem

We have a fast path in record_from_coder that tries to avoid calling `record.init_with`, but heavily depends on active record's implementation of init_with.  Issue #156, pull #86, pull #115 and pull #108 show how brittle this code path has been.
## Solution

Remove the code path and always call `record.init_with(coder)`.
## Benchmark

Before:

```
/Users/dylansmith/.rbenv/versions/2.1.1/bin/ruby ./performance/cpu.rb
Rehearsal: -------------------------------------------------------------
FindRunner:                  1.290000   0.090000   1.380000 (  2.684553)
FetchEmbedMissRunner:        2.490000   0.100000   2.590000 (  4.202616)
FetchEmbedHitRunner:         0.310000   0.010000   0.320000 (  0.373246)
FetchNormalizedMissRunner:   3.170000   0.210000   3.380000 (  5.552480)
FetchNormalizedHitRunner:    0.310000   0.020000   0.330000 (  0.418562)
------------------------------------------------------------------------
FindRunner:                  1.280000   0.060000   1.340000 (  2.685253)
FetchEmbedMissRunner:        2.470000   0.090000   2.560000 (  4.224196)
FetchEmbedHitRunner:         0.320000   0.010000   0.330000 (  0.382576)
FetchNormalizedMissRunner:   3.180000   0.210000   3.390000 (  5.565715)
FetchNormalizedHitRunner:    0.300000   0.010000   0.310000 (  0.391651)
```

after

```
/Users/dylansmith/.rbenv/versions/2.1.1/bin/ruby ./performance/cpu.rb
Rehearsal: -------------------------------------------------------------
FindRunner:                  1.310000   0.100000   1.410000 (  2.748865)
FetchEmbedMissRunner:        2.470000   0.100000   2.570000 (  4.257986)
FetchEmbedHitRunner:         0.300000   0.010000   0.310000 (  0.366290)
FetchNormalizedMissRunner:   3.160000   0.220000   3.380000 (  5.571780)
FetchNormalizedHitRunner:    0.280000   0.010000   0.290000 (  0.365467)
------------------------------------------------------------------------
FindRunner:                  1.250000   0.070000   1.320000 (  2.639191)
FetchEmbedMissRunner:        2.450000   0.100000   2.550000 (  4.250216)
FetchEmbedHitRunner:         0.300000   0.010000   0.310000 (  0.351906)
FetchNormalizedMissRunner:   3.180000   0.210000   3.390000 (  5.604480)
FetchNormalizedHitRunner:    0.300000   0.020000   0.320000 (  0.366612)
```

The Fetch_HitRunner benchmarks are probably the most relevant, since this is for deserializing cached records and the other benchmarks are dominated by database time.  Surprisingly, there is actually an improvement in the Fetch_HitRunner benchmarks.  I have re-run the benchmarks and continue to see an improvement for those benchmarks.

Perhaps the fast path is no longer needed due to optimizations done in active record itself.  Perhaps we should have investigated adding the fast path to active record itself originally, since that would be a better place to maintain the code.
