### PR TITLE
Don't require memcached dependency

### DIFF
--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('ar_transaction_changes', '~> 1.0')
   gem.add_dependency('activerecord', '>= 3.2')
-  gem.add_dependency('memcached', '~> 1.8.0')
+  gem.add_development_dependency('memcached', '~> 1.8.0')
 
   gem.add_development_dependency('memcached_store', '~> 0.12.6')
   gem.add_development_dependency('rake')


### PR DESCRIPTION
Change the memcached dependency to be a dev dependency, since https://github.com/Shopify/identity_cache/pull/161 allows other adapters to be used. 
