### PR TITLE
Add debug benchmarking time spent in fetch and fetch_multi

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/module/attribute_accessors'
 require 'ar_transaction_changes'
 
 require "identity_cache/version"
+require 'identity_cache/benchmarking'
 require 'identity_cache/memoized_cache_proxy'
 require 'identity_cache/belongs_to_caching'
 require 'identity_cache/cache_key_generation'

--- a/lib/identity_cache/benchmarking.rb
+++ b/lib/identity_cache/benchmarking.rb
@@ -1,0 +1,35 @@
+module IdentityCache
+  module Benchmarking
+    def self.included(base)
+      base.send :extend, ClassMethods
+    end
+
+    module ClassMethods
+      def add_benchmark_to_method(method)
+        method_name_without_benchmark = :"#{method}_on_#{self.name}_without_benchmark"
+
+        raise ArgumentError, "already instrumented #{method} for #{self.name}" if method_defined? method_name_without_benchmark
+        raise ArgumentError, "could not find method #{method} for #{self.name}" unless method_defined?(method) || private_method_defined?(method)
+
+        alias_method method_name_without_benchmark, method
+
+        define_method(method) do |*args, &block|
+
+          if IdentityCache.logger.debug?
+            result = nil
+
+            time_ms = Benchmark.realtime do
+              result = send(method_name_without_benchmark, *args, &block)
+            end
+
+            IdentityCache.logger.debug("[IdentityCache] call_time=#{(time_ms * 1000).round(2)} ms")
+
+            result
+          else
+            send(method_name_without_benchmark, *args, &block)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -2,6 +2,8 @@ require 'monitor'
 
 module IdentityCache
   class MemoizedCacheProxy
+    include Benchmarking
+
     attr_reader :cache_fetcher
 
     def initialize(cache_adaptor = nil)
@@ -68,6 +70,7 @@ module IdentityCache
 
       value
     end
+    add_benchmark_to_method :fetch
 
     def fetch_multi(*keys)
       memoized_keys, missed_keys = [], [] if IdentityCache.logger.debug?
@@ -105,6 +108,7 @@ module IdentityCache
 
       result
     end
+    add_benchmark_to_method :fetch_multi
 
     def clear
       clear_memoization

--- a/test/benchmarking_test.rb
+++ b/test/benchmarking_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+class BenchmarkingTest < IdentityCache::TestCase
+
+  class BenchmarkingSample
+    include IdentityCache::Benchmarking
+
+    def test_a(param, &block)
+      test_b(param, &block)
+    end
+
+    def test_b(param, &block)
+      # noop
+    end
+
+    add_benchmark_to_method :test_a
+  end
+
+  def setup
+    super
+
+    IdentityCache.logger = Logger.new(nil)
+    IdentityCache.logger.level = 0
+
+    @instance = BenchmarkingSample.new
+  end
+
+  def test_add_benchmark_report_execution_time_in_logs
+    IdentityCache.logger.expects(:debug).with do |text|
+      text[/\[IdentityCache\] call_time=\d+\.\d{1,2} ms/]
+    end
+
+    @instance.test_a(nil)
+  end
+
+  def test_add_benchmark_forward_method_call
+    block = begin
+      # noop
+    end
+
+    @instance.expects(:test_b).with(1, &block)
+
+    @instance.test_a(1, &block)
+  end
+
+  def test_add_benchmark_skip_when_log_level_is_greater_than_debug
+    IdentityCache.logger.level = 1
+
+    block = begin
+      # noop
+    end
+
+    IdentityCache.logger.expects(:debug).never
+    Benchmark.expects(:realtime).never
+
+    @instance.expects(:test_b).with(1, &block)
+
+    @instance.test_a(1, &block)
+  end
+
+  def test_add_benchmark_raises_when_benchmarking_a_non_existing_method
+    e = assert_raises ArgumentError do
+      BenchmarkingSample.send(:add_benchmark_to_method, :unknown)
+    end
+    assert_equal 'could not find method unknown for BenchmarkingTest::BenchmarkingSample', e.message
+  end
+
+  def test_add_benchmark_raises_when_benchmarking_the_same_method_twice
+    e = assert_raises ArgumentError do
+      BenchmarkingSample.send(:add_benchmark_to_method, :test_a)
+    end
+    assert_equal 'already instrumented test_a for BenchmarkingTest::BenchmarkingSample', e.message
+  end
+end


### PR DESCRIPTION
Add an extra log around cache `fetch` and `fetch_multi` in order to better diagnose time spent performing the actions.

This is done via the help of a module helper

```
add_benchmark_to_method :fetch
```

Here is the log sample:

```
[IdentityCache] call_time=0.24 ms
```

This is performed in the log level `DEBUG`

@airhorns @camilo @fbogsany thoughts?
