### PR TITLE
Add #read and #exists_in_identity_cache?

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -77,6 +77,14 @@ module IdentityCache
       ActiveRecord::Base.connection.open_transactions == 0
     end
 
+    def exists?(key)
+      should_use_cache? && cache.exists?(key)
+    end
+
+    def read(key)
+      unmap_cached_nil_for(cache.read(key)) if should_use_cache?
+    end
+
     # Cache retrieval and miss resolver primitive; given a key it will try to
     # retrieve the associated value from the cache otherwise it will return the
     # value of the execution of the block.

--- a/lib/identity_cache/cache_fetcher.rb
+++ b/lib/identity_cache/cache_fetcher.rb
@@ -18,6 +18,15 @@ module IdentityCache
       @cache_backend.clear if IdentityCache.should_update_cache?
     end
 
+    def exists?(key)
+      !!IdentityCache.unmap_cached_nil_for(read(key))
+    end
+
+    def read(key)
+      value = @cache_backend.read(key)
+      value unless IdentityCache::DELETED == value
+    end
+
     def fetch_multi(keys, &block)
       results = cas_multi(keys, &block)
       results = add_multi(keys, &block) if results.nil?

--- a/lib/identity_cache/fallback_fetcher.rb
+++ b/lib/identity_cache/fallback_fetcher.rb
@@ -18,6 +18,14 @@ module IdentityCache
       @cache_backend.clear if IdentityCache.should_update_cache?
     end
 
+    def exists?(key)
+      @cache_backend.exist?(key)
+    end
+
+    def read(key)
+      @cache_backend.read(key)
+    end
+
     def fetch_multi(keys, &block)
       results = @cache_backend.read_multi(*keys)
       missed_keys = keys - results.keys

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -17,6 +17,27 @@ module IdentityCache
         !!fetch_by_id(id)
       end
 
+      def exists_in_identity_cache?(id)
+        return false unless id
+        raise NotImplementedError, "exists_in_identity_cache? needs the primary index enabled" unless primary_cache_index_enabled
+        IdentityCache.exists?(rails_cache_key(id))
+      end
+
+      def read_by_id(id)
+        return unless id
+        raise NotImplementedError, "reading needs the primary index enabled" unless primary_cache_index_enabled
+        return nil unless IdentityCache.should_use_cache?
+        require_if_necessary do
+          object = record_from_coder(IdentityCache.read(rails_cache_key(id)))
+          IdentityCache.logger.error "[IDC id mismatch] read_by_id_requested=#{id} read_by_id_got=#{object.id} for #{object.inspect[(0..100)]} " if object && object.id != id.to_i
+          object
+        end
+      end
+
+      def read(id)
+        read_by_id(id) or raise(ActiveRecord::RecordNotFound, "Couldn't find #{self.name} with ID=#{id}")
+      end
+
       # Default fetcher added to the model on inclusion, it behaves like
       # ActiveRecord::Base.where(id: id).first
       def fetch_by_id(id)

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -65,6 +65,96 @@ class FetchTest < IdentityCache::TestCase
     assert fetch.has_been_called_with?(@blob_key)
   end
 
+  def test_exists_in_identity_cache_when_cache_hit
+    Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
+    Item.fetch(1)
+
+    assert_memcache_operations(1) do
+      assert_memcache_operations(1, :read) do
+        assert_no_queries do
+          assert Item.exists_in_identity_cache?(1)
+        end
+      end
+    end
+  end
+
+  def test_exists_in_identity_cache_when_cache_miss
+    assert_memcache_operations(1) do
+      assert_memcache_operations(1, :read) do
+        assert_no_queries do
+          refute Item.exists_in_identity_cache?(1)
+        end
+      end
+    end
+  end
+
+  def test_exists_in_identity_cache_when_cached_nil
+    Item.fetch_by_id(1)
+
+    assert_memcache_operations(1) do
+      assert_memcache_operations(1, :read) do
+        assert_no_queries do
+          refute Item.exists_in_identity_cache?(1)
+        end
+      end
+    end
+  end
+
+  def test_read_hit
+    Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
+    Item.fetch(1)
+
+    Item.expects(:resolve_cache_miss).never
+    assert_memcache_operations(1) do
+      assert_memcache_operations(1, :read) do
+        assert_no_queries do
+          assert_equal @record, Item.read(1)
+        end
+      end
+    end
+  end
+
+  def test_read_miss
+    Item.expects(:resolve_cache_miss).never
+    assert_memcache_operations(2) do
+      assert_memcache_operations(2, :read) do
+        assert_no_queries do
+          assert_raises(ActiveRecord::RecordNotFound) { Item.read(1) }
+          assert_nil Item.read_by_id(1)
+        end
+      end
+    end
+  end
+
+  def test_read_when_cached_nil
+    Item.fetch_by_id(1)
+
+    Item.expects(:resolve_cache_miss).never
+    assert_memcache_operations(2) do
+      assert_memcache_operations(2, :read) do
+        assert_no_queries do
+          assert_raises(ActiveRecord::RecordNotFound) { Item.read(1) }
+          assert_nil Item.read_by_id(1)
+        end
+      end
+    end
+  end
+
+  def test_read_when_cached_deleted
+    @record.send(:expire_cache)
+    assert_equal IdentityCache::DELETED, backend.read(@record.primary_cache_index_key)
+
+    Item.expects(:resolve_cache_miss).never
+    assert_memcache_operations(2) do
+      assert_memcache_operations(2, :read) do
+        assert_no_queries do
+          assert_raises(ActiveRecord::RecordNotFound) { Item.read(1) }
+          assert_nil Item.read_by_id(1)
+        end
+      end
+    end
+  end
+
   def test_fetch_miss
     Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,9 +68,13 @@ class IdentityCache::TestCase < MiniTest::Unit::TestCase
     assert_equal num, counter.log.size, "#{counter.log.size} instead of #{num} queries were executed.#{counter.log.size == 0 ? '' : "\nQueries:\n#{counter.log.join("\n")}"}" unless exception
   end
 
-  def assert_memcache_operations(num)
+  def assert_memcache_operations(num, operation=nil)
     counter = CacheCounter.new
-    subscriber = ActiveSupport::Notifications.subscribe(/cache_.*\.active_support/, counter)
+    subscriber = if operation
+                   ActiveSupport::Notifications.subscribe("cache_#{operation}.active_support", counter)
+                 else
+                   ActiveSupport::Notifications.subscribe(/cache_.*\.active_support/, counter)
+                 end
     exception = false
     yield
   rescue => e


### PR DESCRIPTION
https://github.com/Shopify/shopify/pull/29456 shows a use-case for reading or checking existence of an entry in IDC without resolving a cache miss. `exists_with_identity_cache` is implemented as `!!fetch_by_id(id)`, so it will resolve a cache miss: https://github.com/Shopify/identity_cache/blob/master/lib/identity_cache/query_api.rb#L15

This adds `read(id)` and `exists_in_identity_cache?(id)` operations. `read` both deserializes & inflates ActiveRecord objects on a cache hit, while `exists_in_identity_cache?` only deserializes to check for cached-nil & cached-deleted.

@camilo, @Thibaut 
/cc @Shopify/webscale 
