### PR TITLE
Stop connecting to database in IdentityCache.should_use_cache?

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -74,7 +74,8 @@ module IdentityCache
     end
 
     def should_use_cache? # :nodoc:
-      ActiveRecord::Base.connection.open_transactions == 0
+      pool = ActiveRecord::Base.connection_pool
+      !pool.active_connection? || pool.connection.open_transactions == 0
     end
 
     # Cache retrieval and miss resolver primitive; given a key it will try to

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -188,4 +188,15 @@ class FetchTest < IdentityCache::TestCase
     fetcher.expects(:add).never
     assert_raises(ActiveRecord::RecordNotFound) { Item.fetch(nil) }
   end
+
+  def test_fetch_cache_hit_does_not_checkout_database_connection
+    @record.save!
+    record = Item.fetch(@record.id)
+
+    ActiveRecord::Base.clear_active_connections!
+
+    assert_equal record, Item.fetch(@record.id)
+
+    assert_equal false, ActiveRecord::Base.connection_handler.active_connections?
+  end
 end

--- a/test/identity_cache_test.rb
+++ b/test/identity_cache_test.rb
@@ -14,4 +14,13 @@ class IdentityCacheTest < IdentityCache::TestCase
     end
   end
 
+  def test_should_use_cache_outside_transaction
+    assert_equal true, IdentityCache.should_use_cache?
+  end
+
+  def test_should_use_cache_in_transaction
+    ActiveRecord::Base.transaction do
+      assert_equal false, IdentityCache.should_use_cache?
+    end
+  end
 end


### PR DESCRIPTION
@fbogsany & @Sirupsen for review
## Problem

Identity cache was connecting to the database when calling `IdentityCache.should_use_cache?` because it would checkout the connection to find out if there was any open transactions on it.
## Solution

Check if a connection is checked out on the pool before checking for open transactions on the connection itself.
