### PR TITLE
Use type_cast method on connection adapter for rails 4.2 compatibility.

### DIFF
--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in identity_cache.gemspec
+gemspec
+
+gem 'activerecord', '~> 4.2.0.rc1'
+gem 'activesupport', '~> 4.2.0.rc1'

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -204,7 +204,7 @@ module IdentityCache
 
       def find_batch(ids)
         @id_column ||= columns.detect {|c| c.name == primary_key}
-        ids = ids.map{ |id| @id_column.type_cast(id) }
+        ids = ids.map{ |id| connection.type_cast(id, @id_column) }
         records = where(primary_key => ids).includes(cache_fetch_includes).to_a
         records_by_id = records.index_by(&:id)
         ids.map{ |id| records_by_id[id] }


### PR DESCRIPTION
@arthurnn & @fbogsany for review
## Problem

Yesterday I found out that ar_transaction_changes doesn't work with the rails 4.2 release candidate, so fixed that and made a release.  I tested the changes with IDC, since it uses ar_transaction_changes and found out we are calling a removed/renamed method (Column#type_cast).  There are now variants of that, including type_cast_for_database and type_cast_for_user, type_cast_from_database and type_cast_for_schema.
## Solution

Use the type_cast method on the connection, since that has been around long enough to work with the versions we already support.  Internally it uses type_cast_for_database in rails 4.2, which is what we want.

There are other test failures with rails 4.2, so I didn't add it to travis CI yet.
