### PR TITLE
Allow cache invalidation in transactions again.

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -69,8 +69,8 @@ module IdentityCache
       @logger || Rails.logger
     end
 
-    def should_update_cache? # :nodoc:
-      !readonly && should_use_cache?
+    def should_fill_cache? # :nodoc:
+      !readonly
     end
 
     def should_use_cache? # :nodoc:

--- a/lib/identity_cache/cache_fetcher.rb
+++ b/lib/identity_cache/cache_fetcher.rb
@@ -7,15 +7,15 @@ module IdentityCache
     end
 
     def write(key, value)
-      @cache_backend.write(key, value) if IdentityCache.should_update_cache?
+      @cache_backend.write(key, value) if IdentityCache.should_fill_cache?
     end
 
     def delete(key)
-      @cache_backend.write(key, IdentityCache::DELETED, :expires_in => IdentityCache::DELETED_TTL.seconds) if IdentityCache.should_update_cache?
+      @cache_backend.write(key, IdentityCache::DELETED, :expires_in => IdentityCache::DELETED_TTL.seconds)
     end
 
     def clear
-      @cache_backend.clear if IdentityCache.should_update_cache?
+      @cache_backend.clear
     end
 
     def fetch_multi(keys, &block)
@@ -34,7 +34,7 @@ module IdentityCache
           break
         end
         result = yield
-        break unless IdentityCache.should_update_cache?
+        break unless IdentityCache.should_fill_cache?
         result
       end
       unless yielded
@@ -68,7 +68,7 @@ module IdentityCache
         end
 
         break if updates.empty?
-        break unless IdentityCache.should_update_cache?
+        break unless IdentityCache.should_fill_cache?
         updates
       end
       result
@@ -81,7 +81,7 @@ module IdentityCache
     end
 
     def add(key, value)
-      @cache_backend.write(key, value, :unless_exist => true) if IdentityCache.should_update_cache?
+      @cache_backend.write(key, value, :unless_exist => true) if IdentityCache.should_fill_cache?
     end
   end
 end

--- a/lib/identity_cache/fallback_fetcher.rb
+++ b/lib/identity_cache/fallback_fetcher.rb
@@ -7,15 +7,15 @@ module IdentityCache
     end
 
     def write(key, value)
-      @cache_backend.write(key, value) if IdentityCache.should_update_cache?
+      @cache_backend.write(key, value) if IdentityCache.should_fill_cache?
     end
 
     def delete(key)
-      @cache_backend.delete(key) if IdentityCache.should_update_cache?
+      @cache_backend.delete(key)
     end
 
     def clear
-      @cache_backend.clear if IdentityCache.should_update_cache?
+      @cache_backend.clear
     end
 
     def fetch_multi(keys, &block)
@@ -24,7 +24,7 @@ module IdentityCache
       unless missed_keys.empty?
         replacement_results = yield missed_keys
         missed_keys.zip(replacement_results) do |key, replacement_result|
-          @cache_backend.write(key, replacement_result) if IdentityCache.should_update_cache?
+          @cache_backend.write(key, replacement_result) if IdentityCache.should_fill_cache?
           results[key] = replacement_result
         end
       end
@@ -35,7 +35,7 @@ module IdentityCache
       result = @cache_backend.read(key)
       if result.nil?
         result = yield
-        @cache_backend.write(key, result) if IdentityCache.should_update_cache?
+        @cache_backend.write(key, result) if IdentityCache.should_fill_cache?
       end
       result
     end

--- a/test/save_test.rb
+++ b/test/save_test.rb
@@ -16,21 +16,21 @@ class SaveTest < IdentityCache::TestCase
     @record = Item.new
     @record.title = 'bob'
 
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}index:Item:id/title:#{cache_hash('2/bob')}")
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:2").once
+    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('2/bob')}")
+    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:2").once
     @record.save
   end
 
   def test_update
     # Regular flow, write index id, write index id/tile, delete data blob since Record has changed
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/fred')}")
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}index:Item:title:#{cache_hash('fred')}")
-    IdentityCache.cache.expects(:delete).with(@blob_key)
+    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/fred')}")
+    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('fred')}")
+    expect_cache_delete(@blob_key)
 
     # Delete index id, delete index id/title
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
 
     @record.title = 'fred'
     @record.save
@@ -38,18 +38,18 @@ class SaveTest < IdentityCache::TestCase
 
   def test_destroy
     # Regular flow: delete data blob, delete index id, delete index id/tile
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
-    IdentityCache.cache.expects(:delete).with(@blob_key)
+    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
+    expect_cache_delete(@blob_key)
 
     @record.destroy
   end
 
   def test_destroy_with_changed_attributes
     # Make sure to delete the old cache index key, since the new title never ended up in an index
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
-    IdentityCache.cache.expects(:delete).with(@blob_key)
+    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
+    expect_cache_delete(@blob_key)
 
     @record.title = 'fred'
     @record.destroy
@@ -57,10 +57,26 @@ class SaveTest < IdentityCache::TestCase
 
   def test_touch_will_expire_the_caches
     # Regular flow: delete data blob, delete index id, delete index id/tile
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
-    IdentityCache.cache.expects(:delete).with(@blob_key)
+    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
+    expect_cache_delete(@blob_key)
 
     @record.touch
+  end
+
+  def test_expire_cache_works_in_a_transaction
+    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
+    expect_cache_delete(@blob_key)
+
+    ActiveRecord::Base.transaction do
+      @record.send(:expire_cache)
+    end
+  end
+
+  private
+
+  def expect_cache_delete(key)
+    @backend.expects(:write).with(key, IdentityCache::DELETED, anything)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,7 +26,7 @@ end
 
 class IdentityCache::TestCase < MiniTest::Unit::TestCase
   include ActiveRecordObjects
-  attr_reader :backend, :fetcher
+  attr_reader :backend
 
   def setup
     DatabaseConnection.drop_tables
@@ -34,7 +34,6 @@ class IdentityCache::TestCase < MiniTest::Unit::TestCase
 
     IdentityCache.logger = Logger.new(nil)
     IdentityCache.cache_backend = @backend = ActiveSupport::Cache::MemcachedStore.new("localhost:11211", :support_cas => true)
-    @fetcher = IdentityCache.cache.cache_fetcher
 
     setup_models
   end
@@ -42,6 +41,12 @@ class IdentityCache::TestCase < MiniTest::Unit::TestCase
   def teardown
     IdentityCache.cache.clear
     teardown_models
+  end
+
+  private
+
+  def fetcher
+    IdentityCache.cache.cache_fetcher
   end
 
   def assert_nothing_raised


### PR DESCRIPTION
@fbogsany & @arthurnn for review
cc @jstorimer 

## Problem

IDC v0.2.2 has a regression where touching a record no longer invalidates the cache for that record.  This was because the record was being invalidated in an after_touch callback, where `IdentityCache.should_update_cache?` returned falsey, since `IdentityCache.should_update_cache?` returns falsey.

## Solution

Ideally we would always invalidate the cache in an after_commit callback, but invalidating the cache should always be a safe thing to do, even inside a transaction.

The actual concern in updating the cache with `IdentityCache.readonly = true` in our use case was database slave lag, where is it safe to fetch from the cache, but unsafe to fill the cache, since it could fill the cache with stale data.  Therefore, I renamed `should_update_cache?` to `should_fill_cache?` and had it stop requiring `should_use_cache?` to return truthy.