### PR TITLE
Fix a test that expected expiry without changes to saved record.

### DIFF
--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'activerecord', '~> 4.2.0.rc1'
-gem 'activesupport', '~> 4.2.0.rc1'
+gem 'activerecord', '~> 4.2.0'
+gem 'activesupport', '~> 4.2.0'

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -147,7 +147,8 @@ class NormalizedHasManyTest < IdentityCache::TestCase
 
   def test_saving_child_with_touch_true_on_parent_expires_parent
     IdentityCache.cache.expects(:delete).with(@record.primary_cache_index_key).once
-    @not_cached.save
+    @not_cached.name = 'Changed'
+    @not_cached.save!
   end
 
 end


### PR DESCRIPTION
@arthurnn for review

In rails 4.2 the parent record isn't touched through the `touch: true` option on the belongs_to association if there were no changes to the record being saved, since no update statement is sent to the database.