### PR TITLE
Make the rails_cache_key_prefix method indepedent

### DIFF
--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -24,12 +24,15 @@ module IdentityCache
 
     module ClassMethods
       def rails_cache_key(id)
-        "#{rails_cache_key_prefix}#{id}"
+        "#{prefixed_rails_cache_key}#{id}"
       end
 
       def rails_cache_key_prefix
         @rails_cache_key_prefix ||= IdentityCache::CacheKeyGeneration.denormalized_schema_hash(self)
-        "#{rails_cache_key_namespace}blob:#{base_class.name}:#{@rails_cache_key_prefix}:"
+      end
+
+      def prefixed_rails_cache_key
+        "#{rails_cache_key_namespace}blob:#{base_class.name}:#{rails_cache_key_prefix}:"
       end
 
       def rails_cache_index_key_for_fields_and_values(fields, values)


### PR DESCRIPTION
This narrows the scope of the `IdentityCache::CacheKeyGeneration.rails_cache_key_prefix` method so it can be overridden properly in testing environments. Functionally the same as before, but allows you to stub the prefix in mocha for consistent tests (rather than say, stubbing CityHash.hash64 and polluting a classes cache keys).

```ruby
class Foo < ActiveRecord::Base
  include IdentityCache
end

class FooTest < ActiveSupport::TestCase
  setup do
    Foo.stubs(:rails_cache_key_prefix).returns("stableprefix")
  end

  test "cache key prefix" do
    assert_match "Foo:stableprefix:12345", Foo.rails_cache_key(12345)
  end
end
```

##### Review

@arthurnn @dylanahsmith