### PR TITLE
Remove undocumented overrides.

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -21,6 +21,7 @@ module IdentityCache
   DELETED_TTL = 1000
 
   class AlreadyIncludedError < StandardError; end
+  class AssociationError < StandardError; end
   class InverseAssociationError < StandardError
     def initialize
       super "Inverse name for association could not be determined. Please use the :inverse_name option to specify the inverse association name for this cache."

--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -11,13 +11,17 @@ module IdentityCache
       def cache_belongs_to(association, options = {})
         raise NotImplementedError if options[:embed]
 
+        unless association_reflection = reflect_on_association(association)
+          raise AssociationError, "Association named '#{association}' was not found on #{self.class}"
+        end
+
         options = {}
         self.cached_belongs_tos[association] = options
 
         options[:embed]                   = false
         options[:cached_accessor_name]    = "fetch_#{association}"
-        options[:foreign_key]             = reflect_on_association(association).foreign_key
-        options[:association_class]       = reflect_on_association(association).klass
+        options[:foreign_key]             = association_reflection.foreign_key
+        options[:association_class]       = association_reflection.klass
         options[:prepopulate_method_name] = "prepopulate_fetched_#{association}"
 
         build_normalized_belongs_to_cache(association, options)

--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -9,18 +9,18 @@ module IdentityCache
 
     module ClassMethods
       def cache_belongs_to(association, options = {})
+        raise NotImplementedError if options[:embed]
+
+        options = {}
         self.cached_belongs_tos[association] = options
 
-        options[:embed] ||= false
-        options[:cached_accessor_name]    ||= "fetch_#{association}"
-        options[:foreign_key]             ||= reflect_on_association(association).foreign_key
-        options[:association_class]       ||= reflect_on_association(association).klass
-        options[:prepopulate_method_name] ||= "prepopulate_fetched_#{association}"
-        if options[:embed]
-          raise NotImplementedError
-        else
-          build_normalized_belongs_to_cache(association, options)
-        end
+        options[:embed]                   = false
+        options[:cached_accessor_name]    = "fetch_#{association}"
+        options[:foreign_key]             = reflect_on_association(association).foreign_key
+        options[:association_class]       = reflect_on_association(association).klass
+        options[:prepopulate_method_name] = "prepopulate_fetched_#{association}"
+
+        build_normalized_belongs_to_cache(association, options)
       end
 
       def build_normalized_belongs_to_cache(association, options)

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -98,7 +98,9 @@ module IdentityCache
         options[:embed] = :ids unless options.has_key?(:embed)
         deprecate_embed_option(options, false, :ids)
         options[:inverse_name] ||= self.name.underscore.to_sym
-        raise InverseAssociationError unless self.reflect_on_association(association)
+        unless self.reflect_on_association(association)
+          raise AssociationError, "Association named '#{association}' was not found on #{self.class}"
+        end
         self.cached_has_manys[association] = options
 
         case options[:embed]
@@ -136,7 +138,9 @@ module IdentityCache
         options = options.slice(:embed, :inverse_name)
         options[:embed] = true unless options.has_key?(:embed)
         options[:inverse_name] ||= self.name.underscore.to_sym
-        raise InverseAssociationError unless self.reflect_on_association(association)
+        unless self.reflect_on_association(association)
+          raise AssociationError, "Association named '#{association}' was not found on #{self.class}"
+        end
         self.cached_has_ones[association] = options
 
         if options[:embed] == true


### PR DESCRIPTION
@fbogsany & @arthurnn for review
cc @camilo 

## Problem

I hadn't noticed until seeing pull #171 that we allow all these internal configuration options to be overridden by the caller to `cache_belongs_to`, `cache_has_many` and `cache_has_one`.  I don't think these should be overridable, and I don't think we should even add them directly to the input options hash so that they aren't exposed at all.

I `grep`ed Shopify and couldn't find anywhere that we use these options.  It seems unlikely that others would use them.

## Solution

Duplicate the hash before any assignments using `.slice` to avoid making these options accessible on the input hash, and replace all those `||=` assignments with unconditional `=` assignments.

## Compatibility

These were undocumented, so I think it should be alright to remove these options without a major release, but it would break any code that used these options.