### PR TITLE
Stop testing on rails 3.2 and ruby 1.9.3 and 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1
   - 2.2
 
 gemfile:
-  - Gemfile.rails32
   - Gemfile.rails40
   - Gemfile.rails41
   - Gemfile.rails42


### PR DESCRIPTION
@camilo @dylanahsmith WDYT?

It works right now, but those rails/ruby versions are super old, so I dont think we should keep supporting them.
If you are both OK, I will cut a new version before merging this, and we merge this moving forward.
(will also add a changelog)