### PR TITLE
Raise if a class method is called with a scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # IdentityCache changelog
 
+#### 0.2.6 (unreleased)
+
+- Raise if a class method is called on a scope.  Previously the scope was ignored.
+
+#### 0.2.5
+
+- Fixed support for namespaced model classes
+- Added some deduplication for parent cache expiry
+- Fixed some deprecation warnings in rails 4.2
+
+#### 0.2.4
+
+- Refactoring, documentation and test changes
+
 #### 0.2.3
 
 - PostgreSQL support

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -27,6 +27,7 @@ module IdentityCache
       super "Inverse name for association could not be determined. Please use the :inverse_name option to specify the inverse association name for this cache."
     end
   end
+  class UnsupportedScopeError < StandardError; end
 
   class << self
     include IdentityCache::CacheHash

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -189,6 +189,7 @@ module IdentityCache
       private
 
       def identity_cache_single_value_dynamic_fetcher(fields, values) # :nodoc:
+        raise_if_scoped
         cache_key = rails_cache_index_key_for_fields_and_values(fields, values)
         id = IdentityCache.fetch(cache_key) { identity_cache_conditions(fields, values).limit(1).pluck(primary_key).first }
         unless id.nil?
@@ -200,6 +201,7 @@ module IdentityCache
       end
 
       def identity_cache_multiple_value_dynamic_fetcher(fields, values) # :nodoc
+        raise_if_scoped
         cache_key = rails_cache_index_key_for_fields_and_values(fields, values)
         ids = IdentityCache.fetch(cache_key) { identity_cache_conditions(fields, values).pluck(primary_key) }
 

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -20,6 +20,7 @@ module IdentityCache
       # Default fetcher added to the model on inclusion, it behaves like
       # ActiveRecord::Base.where(id: id).first
       def fetch_by_id(id)
+        raise_if_scoped
         return unless id
         raise NotImplementedError, "fetching needs the primary index enabled" unless primary_cache_index_enabled
         if IdentityCache.should_use_cache?
@@ -47,6 +48,7 @@ module IdentityCache
       # Default fetcher added to the model on inclusion, if behaves like
       # ActiveRecord::Base.find_all_by_id
       def fetch_multi(*ids)
+        raise_if_scoped
         raise NotImplementedError, "fetching needs the primary index enabled" unless primary_cache_index_enabled
         options = ids.extract_options!
         ids.flatten!(1)
@@ -76,6 +78,12 @@ module IdentityCache
       end
 
       private
+
+      def raise_if_scoped
+        if current_scope
+          raise UnsupportedScopeError, "IdentityCache doesn't support rails scopes"
+        end
+      end
 
       def record_from_coder(coder) #:nodoc:
         if coder.present? && coder.has_key?(:class)

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -199,6 +199,12 @@ class FetchMultiTest < IdentityCache::TestCase
     assert_equal cache_response_for(Item.find(@bob.id)), backend.read(@bob.primary_cache_index_key)
   end
 
+  def test_fetch_multi_raises_when_called_on_a_scope
+    assert_raises(IdentityCache::UnsupportedScopeError) do
+      Item.where(updated_at: nil).fetch_multi(@bob.id, @joe.id, @fred.id)
+    end
+  end
+
   private
 
   def populate_only_fred

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -199,4 +199,16 @@ class FetchTest < IdentityCache::TestCase
 
     assert_equal false, ActiveRecord::Base.connection_handler.active_connections?
   end
+
+  def test_fetch_raises_when_called_on_a_scope
+    assert_raises(IdentityCache::UnsupportedScopeError) do
+      Item.where(updated_at: nil).fetch(1)
+    end
+  end
+
+  def test_fetch_by_raises_when_called_on_a_scope
+    assert_raises(IdentityCache::UnsupportedScopeError) do
+      Item.where(updated_at: nil).fetch_by_id(1)
+    end
+  end
 end

--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -121,4 +121,18 @@ class IndexCacheTest < IdentityCache::TestCase
     assert_equal [@record], Item.fetch_by_title('bob')
     assert_equal [@record.id], backend.read(@cache_key)
   end
+
+  def test_fetch_by_index_raises_when_called_on_a_scope
+    Item.cache_index :title
+    assert_raises(IdentityCache::UnsupportedScopeError) do
+      Item.where(updated_at: nil).fetch_by_title('bob')
+    end
+  end
+
+  def test_fetch_by_unique_index_raises_when_called_on_a_scope
+    Item.cache_index :title, :id, :unique => true
+    assert_raises(IdentityCache::UnsupportedScopeError) do
+      Item.where(updated_at: nil).fetch_by_title_and_id('bob', 2)
+    end
+  end
 end


### PR DESCRIPTION
@camilo & @arthurnn for review
cc @EmilS 

## Problem

Identity cache doesn't support rails scopes, but rails will automatically call class methods on relations, which IDC will ignore.  E.g. `user.associated_records.find_by_id(params[:record_id])` is a common pattern to prevent a user from records that it doesn't own, but `user.associated_records.find_by_id(params[:record_id])` will appear to work without proper testing for the case where record_id is for another user.

## Solution

When one of these class methods is called on an identity cache class method with a scope, then raise an exception.