### PR TITLE
postpone klass calls

### DIFF
--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -21,7 +21,7 @@ module IdentityCache
         options[:embed]                   = false
         options[:cached_accessor_name]    = "fetch_#{association}"
         options[:foreign_key]             = association_reflection.foreign_key
-        options[:association_class]       = association_reflection.klass
+        options[:association_class]       = association_reflection
         options[:prepopulate_method_name] = "prepopulate_fetched_#{association}"
 
         build_normalized_belongs_to_cache(association, options)
@@ -31,7 +31,7 @@ module IdentityCache
         self.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
           def #{options[:cached_accessor_name]}
             if IdentityCache.should_use_cache? && #{options[:foreign_key]}.present? && !association(:#{association}).loaded?
-              self.#{association} = #{options[:association_class]}.fetch_by_id(#{options[:foreign_key]})
+              self.#{association} = #{options[:association_class].klass}.fetch_by_id(#{options[:foreign_key]})
             else
               #{association}
             end

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -13,7 +13,7 @@ module IdentityCache
         klass.send(:all_cached_associations).sort.each do |name, options|
           case options[:embed]
           when true
-            schema_string << ",#{name}:(#{denormalized_schema_hash(options[:association_class])})"
+            schema_string << ",#{name}:(#{denormalized_schema_hash(options[:association_class].klass)})"
           when :ids
             schema_string << ",#{name}:ids"
           end

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -209,7 +209,7 @@ module IdentityCache
       end
 
       def build_recursive_association_cache(association, options) #:nodoc:
-        options[:association_class]      = reflect_on_association(association).klass
+        options[:association_class]      = reflect_on_association(association)
         options[:cached_accessor_name]   = "fetch_#{association}"
         options[:records_variable_name]  = "cached_#{association}"
         options[:population_method_name] = "populate_#{association}_cache"
@@ -233,7 +233,7 @@ module IdentityCache
 
       def build_id_embedded_has_many_cache(association, options) #:nodoc:
         singular_association = association.to_s.singularize
-        options[:association_class]       = reflect_on_association(association).klass
+        options[:association_class]       = reflect_on_association(association)
         options[:cached_accessor_name]    = "fetch_#{association}"
         options[:ids_name]                = "#{singular_association}_ids"
         options[:cached_ids_name]         = "fetch_#{options[:ids_name]}"
@@ -258,7 +258,7 @@ module IdentityCache
           def #{options[:cached_accessor_name]}
             if IdentityCache.should_use_cache? || #{association}.loaded?
               #{options[:population_method_name]} unless @#{options[:ids_variable_name]} || @#{options[:records_variable_name]}
-              @#{options[:records_variable_name]} ||= #{options[:association_class]}.fetch_multi(@#{options[:ids_variable_name]})
+              @#{options[:records_variable_name]} ||= #{options[:association_class].klass}.fetch_multi(@#{options[:ids_variable_name]})
             else
               #{association}
             end
@@ -279,7 +279,7 @@ module IdentityCache
       end
 
       def add_parent_expiry_hook(options)
-        child_class = options[:association_class]
+        child_class = options[:association_class].klass
         raise InverseAssociationError unless child_class.reflect_on_association(options[:inverse_name])
 
         child_class.send(:include, ArTransactionChanges) unless child_class.include?(ArTransactionChanges)

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -242,7 +242,7 @@ module IdentityCache
               end
 
               parent_record_to_child_records = Hash.new { |h, k| h[k] = [] }
-              child_records = details[:association_class].fetch_multi(*ids_to_parent_record.keys)
+              child_records = details[:association_class].klass.fetch_multi(*ids_to_parent_record.keys)
               child_records.each do |child_record|
                 parent_record = ids_to_parent_record[child_record.id]
                 parent_record_to_child_records[parent_record] << child_record
@@ -263,7 +263,7 @@ module IdentityCache
                 parent_id = child_record.send(details[:foreign_key])
                 hash[parent_id] = child_record if parent_id.present?
               end
-              parent_records = details[:association_class].fetch_multi(ids_to_child_record.keys)
+              parent_records = details[:association_class].klass.fetch_multi(ids_to_child_record.keys)
               parent_records.each do |parent_record|
                 child_record = ids_to_child_record[parent_record.id]
                 child_record.send(details[:prepopulate_method_name], parent_record)
@@ -285,8 +285,8 @@ module IdentityCache
             raise ArgumentError.new("Unknown cached association #{association} listed for prefetching")
           end
 
-          if details && details[:association_class].respond_to?(:prefetch_associations, true)
-            details[:association_class].send(:prefetch_associations, sub_associations, next_level_records)
+          if details && details[:association_class].klass.respond_to?(:prefetch_associations, true)
+            details[:association_class].klass.send(:prefetch_associations, sub_associations, next_level_records)
           end
         end
       end


### PR DESCRIPTION
This is a fix for issue #215 
identity_cache tries to call klass on associated models which are not yet loaded, raisng a missing constant exception.
