### PR TITLE
Use the association's inverse_of if available.

### DIFF
--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -82,6 +82,11 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     end
   end
 
+  def test_cache_uses_inverse_of_on_association
+    Item.has_many :invertable_association, :inverse_of => :owner, :class_name => 'PolymorphicRecord', :as => "owner", :inverse_of => :owner
+    Item.cache_has_many :invertable_association, :embed => true
+  end
+
   def test_saving_associated_records_should_expire_itself_and_the_parents_cache
     child = @record.associated_records.first
     IdentityCache.cache.expects(:delete).with(child.primary_cache_index_key).once


### PR DESCRIPTION
@arthurnn & @fbogsany for review

## Problem

If the inverse association name can't be determined using the class name, then the `:inverse_name` option must be specified on the cache_has_many or cache_has_one, even when the actual association has specified the inverse name using the `:inverse_of` option.

## Solution

Use `inverse_of.name` on the association reflection if it is available.