### PR TITLE
Return an array from fetch association methods to prevent chaining.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 0.2.6 (unreleased)
 
 - Raise if a class method is called on a scope.  Previously the scope was ignored.
+- fetched has many associations returns an Array rather than a relation.
 
 #### 0.2.5
 

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -265,7 +265,7 @@ module IdentityCache
               #{options[:population_method_name]} unless @#{options[:ids_variable_name]} || @#{options[:records_variable_name]}
               @#{options[:records_variable_name]} ||= #{options[:association_class]}.fetch_multi(@#{options[:ids_variable_name]})
             else
-              #{association}
+              association(:#{association}).load_target
             end
           end
 

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -113,7 +113,7 @@ module IdentityCache
           association = reflection.association_class.new(record, reflection)
           association.target = coder_or_array.map {|e| record_from_coder(e) }
           association.target.each {|e| association.set_inverse_instance(e) }
-          association
+          association.target
         else
           record_from_coder(coder_or_array)
         end
@@ -125,7 +125,7 @@ module IdentityCache
         embedded_variable = record.instance_variable_get(:"@#{options[:records_variable_name]}")
         if IdentityCache.unmap_cached_nil_for(embedded_variable).nil?
           nil
-        elsif record.class.reflect_on_association(association).collection?
+        elsif embedded_variable.is_a?(Array)
           embedded_variable.map {|e| coder_from_record(e) }
         else
           coder_from_record(embedded_variable)
@@ -329,10 +329,9 @@ module IdentityCache
       ivar_full_name = :"@#{ivar_name}"
       if IdentityCache.should_use_cache?
         populate_recursively_cached_association(ivar_name, association_name)
-        assoc = IdentityCache.unmap_cached_nil_for(instance_variable_get(ivar_full_name))
-        assoc.is_a?(ActiveRecord::Associations::CollectionAssociation) ? assoc.reader : assoc
+        IdentityCache.unmap_cached_nil_for(instance_variable_get(ivar_full_name))
       else
-        send(association_name.to_sym)
+        association(association_name).load_target
       end
     end
 
@@ -342,7 +341,7 @@ module IdentityCache
       value = instance_variable_get(ivar_full_name)
       return value unless value.nil?
 
-      loaded_association = send(association_name)
+      loaded_association = association(association_name).load_target
 
       instance_variable_set(ivar_full_name, IdentityCache.map_cached_nil_for(loaded_association))
     end

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -13,13 +13,14 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
   end
 
   def test_uncached_record_from_the_db_will_use_normal_association
-    expected = @record.associated_records
+    expected = @record.associated_records.to_a
     record_from_db = Item.find(@record.id)
 
-    Item.any_instance.expects(:associated_records).returns(expected)
-
-    assert_equal @record, record_from_db
-    assert_equal expected, record_from_db.fetch_associated_records
+    assert_queries(1) do
+      assert_memcache_operations(0) do
+        assert_equal expected, record_from_db.fetch_associated_records
+      end
+    end
   end
 
   def test_on_cache_hit_record_should_come_back_with_cached_association
@@ -28,9 +29,12 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     record_from_cache_hit = Item.fetch(@record.id)
     assert_equal @record, record_from_cache_hit
 
-    expected = @record.associated_records
-    Item.any_instance.expects(:associated_records).never
-    assert_equal expected, record_from_cache_hit.fetch_associated_records
+    expected = @record.associated_records.to_a
+    assert_queries(0) do
+      assert_memcache_operations(0) do
+        assert_equal expected, record_from_cache_hit.fetch_associated_records
+      end
+    end
   end
 
   def test_on_cache_miss_record_should_embed_associated_objects_and_return
@@ -87,5 +91,11 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     IdentityCache.cache.expects(:delete).with(child.primary_cache_index_key).once
     IdentityCache.cache.expects(:delete).with(@record.primary_cache_index_key)
     child.save!
+  end
+
+  def test_fetch_association_does_not_allow_chaining
+    check = proc { assert_equal false, Item.fetch(@record.id).fetch_associated_records.respond_to?(:where) }
+    2.times { check.call } # for miss and hit
+    Item.transaction { check.call }
   end
 end

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -151,4 +151,9 @@ class NormalizedHasManyTest < IdentityCache::TestCase
     @not_cached.save!
   end
 
+  def test_fetch_association_does_not_allow_chaining
+    check = proc { assert_equal false, Item.fetch(@record.id).fetch_associated_records.respond_to?(:where) }
+    2.times { check.call } # for miss and hit
+    Item.transaction { check.call }
+  end
 end


### PR DESCRIPTION
@fbogsany & @tjoyal for review

## Problem

It was possible to chain the result of a fetched association (e.g. `record.fetch_association.where(important: true)` which could result in the association being loaded twice, once for fetching the association (e.g. `record.fetch_association`) and again to load the further scoped relation (e.g. the result of `.where(important: true)` in this case).

## Solution

Return an Array from the fetch association method rather than a relation to prevent chaining.  Any time they want a relation, they should use the association directly.