### PR TITLE
Allow cache_belongs_to on polymorphic associations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Raise when trying to cache a through association. Previously it wouldn't be invalidated properly.
 - Raise if a class method is called on a scope.  Previously the scope was ignored.
 - Raise if a class method is called on a subclass of one that included IdentityCache. This never worked properly.
+- Fix cache_belongs_to on polymorphic assocations.
 
 #### 0.2.5
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ IdentityCache tries to figure out both sides of an association whenever it can s
 
 ``` ruby
 class Metafield < ActiveRecord::Base
+  include IdentityCache
   belongs_to :owner, :polymorphic => true
+  cache_belongs_to :owner
 end
 
 class Product < ActiveRecord::Base

--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -21,8 +21,7 @@ module IdentityCache
 
         options[:embed]                   = false
         options[:cached_accessor_name]    = "fetch_#{association}"
-        options[:foreign_key]             = association_reflection.foreign_key
-        options[:association_class]       = association_reflection.klass
+        options[:association_reflection]  = association_reflection
         options[:prepopulate_method_name] = "prepopulate_fetched_#{association}"
 
         build_normalized_belongs_to_cache(association, options)
@@ -31,10 +30,11 @@ module IdentityCache
       private
 
       def build_normalized_belongs_to_cache(association, options)
+        foreign_key = options[:association_reflection].foreign_key
         self.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
           def #{options[:cached_accessor_name]}
-            if IdentityCache.should_use_cache? && #{options[:foreign_key]}.present? && !association(:#{association}).loaded?
-              self.#{association} = #{options[:association_class]}.fetch_by_id(#{options[:foreign_key]})
+            if IdentityCache.should_use_cache? && #{foreign_key}.present? && !association(:#{association}).loaded?
+              self.#{association} = association(:#{association}).klass.fetch_by_id(#{foreign_key})
             else
               #{association}
             end

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -13,7 +13,7 @@ module IdentityCache
         klass.send(:all_cached_associations).sort.each do |name, options|
           case options[:embed]
           when true
-            schema_string << ",#{name}:(#{denormalized_schema_hash(options[:association_class])})"
+            schema_string << ",#{name}:(#{denormalized_schema_hash(options[:association_reflection].klass)})"
           when :ids
             schema_string << ",#{name}:ids"
           end

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -215,7 +215,7 @@ module IdentityCache
       end
 
       def build_recursive_association_cache(association, options) #:nodoc:
-        options[:association_class]      = reflect_on_association(association).klass
+        options[:association_reflection] = reflect_on_association(association)
         options[:cached_accessor_name]   = "fetch_#{association}"
         options[:records_variable_name]  = "cached_#{association}"
         options[:population_method_name] = "populate_#{association}_cache"
@@ -239,7 +239,7 @@ module IdentityCache
 
       def build_id_embedded_has_many_cache(association, options) #:nodoc:
         singular_association = association.to_s.singularize
-        options[:association_class]       = reflect_on_association(association).klass
+        options[:association_reflection]  = reflect_on_association(association)
         options[:cached_accessor_name]    = "fetch_#{association}"
         options[:ids_name]                = "#{singular_association}_ids"
         options[:cached_ids_name]         = "fetch_#{options[:ids_name]}"
@@ -264,7 +264,7 @@ module IdentityCache
           def #{options[:cached_accessor_name]}
             if IdentityCache.should_use_cache? || #{association}.loaded?
               #{options[:population_method_name]} unless @#{options[:ids_variable_name]} || @#{options[:records_variable_name]}
-              @#{options[:records_variable_name]} ||= #{options[:association_class]}.fetch_multi(@#{options[:ids_variable_name]})
+              @#{options[:records_variable_name]} ||= #{options[:association_reflection].klass}.fetch_multi(@#{options[:ids_variable_name]})
             else
               #{association}
             end
@@ -285,7 +285,7 @@ module IdentityCache
       end
 
       def add_parent_expiry_hook(options)
-        child_class = options[:association_class]
+        child_class = options[:association_reflection].klass
 
         child_class.send(:include, ArTransactionChanges) unless child_class.include?(ArTransactionChanges)
         child_class.send(:include, ParentModelExpiration) unless child_class.include?(ParentModelExpiration)

--- a/test/normalized_belongs_to_test.rb
+++ b/test/normalized_belongs_to_test.rb
@@ -51,4 +51,12 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
       StiRecordTypeA.cache_belongs_to :item, :embed => false
     end
   end
+
+  def test_fetching_polymorphic_belongs_to_association
+    PolymorphicRecord.include IdentityCache
+    PolymorphicRecord.cache_belongs_to :owner
+    PolymorphicRecord.create!(owner: @parent_record)
+
+    assert_equal @parent_record, PolymorphicRecord.first.fetch_owner
+  end
 end


### PR DESCRIPTION
@alexandcote does this fix #225 for you?
@lolownia & @lrajlich does this fix #215 for you?

## Problem

In cache_belongs_to we were assuming that a belongs_to association has a single association class that could be retrieved from the association reflection, but this isn't the case for polymorphic belongs_to associations, where a record is needed to get the actual class.

## Solution

Get the class from the association rather than the association reflection in the `fetch_#{association}` method.

This still needs some regression tests.