### PR TITLE
There is no try

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -176,7 +176,7 @@ module IdentityCache
       end
 
       def resolve_cache_miss(id)
-        object = self.includes(cache_fetch_includes).reorder(nil).where(primary_key => id).try(:first)
+        object = self.includes(cache_fetch_includes).reorder(nil).where(primary_key => id).first
         object.send(:populate_association_caches) if object
         object
       end


### PR DESCRIPTION
The return of `where` is always an `ActiveRecord::Relation`, so there is no need for using try here if it is always present and always respond to `first`.