### PR TITLE
Prevent encode_with from overriding :class

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -134,8 +134,9 @@ module IdentityCache
 
       def coder_from_record(record) #:nodoc:
         unless record.nil?
-          coder = {:class => record.class }
+          coder = {}
           record.encode_with(coder)
+          coder[:class] = record.class
           add_cached_associations_to_coder(record, coder)
           coder
         end


### PR DESCRIPTION
Custom `encode_with` shouldn't be able to mess with reserved IDC attributes.

@rafaelfranca for review please.