### PR TITLE
Raise if id embedded associated class hasn't included IdentityCache

### DIFF
--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -315,6 +315,9 @@ module IdentityCache
         options[:inverse_name] ||= self.name.underscore.to_sym
         child_class = association_reflection.klass
         raise InverseAssociationError unless child_class.reflect_on_association(options[:inverse_name])
+        unless options[:embed] == true || child_class.include?(IdentityCache)
+          raise UnsupportedAssociationError, "associated class #{child_class} must include IdentityCache to be cached without full embedding"
+        end
       end
     end
   end

--- a/test/deeply_nested_associated_record_test.rb
+++ b/test/deeply_nested_associated_record_test.rb
@@ -10,6 +10,7 @@ class DeeplyNestedAssociatedRecordHasOneTest < IdentityCache::TestCase
 
   def test_deeply_nested_models_can_cache_has_many_associations
     assert_nothing_raised do
+      PolymorphicRecord.include(IdentityCache)
       Deeply::Nested::AssociatedRecord.has_many :polymorphic_records, as: 'owner'
       Deeply::Nested::AssociatedRecord.cache_has_many :polymorphic_records, inverse_name: :owner
     end

--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -83,6 +83,7 @@ class SchemaChangeTest < IdentityCache::TestCase
   end
 
   def test_embed_existing_cache_has_many
+    PolymorphicRecord.include(IdentityCache)
     Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => :ids
     read_new_schema
 
@@ -96,6 +97,7 @@ class SchemaChangeTest < IdentityCache::TestCase
   end
 
   def test_add_non_embedded_cache_has_many
+    PolymorphicRecord.include(IdentityCache)
     record = Item.fetch(@record.id)
 
     Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => :ids


### PR DESCRIPTION
@byroot for review

Fixes #203

## Problem

Changing the the `embed` option on a cache_has_many from `embed: true` to `embed: :ids` can result in missing method errors, which can be confusing.  This can happen when the associated class hasn't included IdentityCache, which is needed to fetch the associated record when only the id is embedded.

## Solution

Raise in cache_has_many with a clear exception message so the problem can quickly be identified and resolved.