### PR TITLE
Raise when calling a class method on a subclass.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Raise when trying to cache a through association. Previously it wouldn't be invalidated properly.
 - Raise if a class method is called on a scope.  Previously the scope was ignored.
+- Raise if a class method is called on a subclass of one that included IdentityCache. This never worked properly.
 
 #### 0.2.5
 

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -29,6 +29,7 @@ module IdentityCache
   end
   class UnsupportedScopeError < StandardError; end
   class UnsupportedAssociationError < StandardError; end
+  class DerivedModelError < StandardError; end
 
   class << self
     include IdentityCache::CacheHash

--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -9,6 +9,7 @@ module IdentityCache
 
     module ClassMethods
       def cache_belongs_to(association, options = {})
+        ensure_base_model
         raise NotImplementedError if options[:embed]
 
         unless association_reflection = reflect_on_association(association)
@@ -26,6 +27,8 @@ module IdentityCache
 
         build_normalized_belongs_to_cache(association, options)
       end
+
+      private
 
       def build_normalized_belongs_to_cache(association, options)
         self.class_eval(<<-CODE, __FILE__, __LINE__ + 1)

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -20,6 +20,7 @@ module IdentityCache
       # Default fetcher added to the model on inclusion, it behaves like
       # ActiveRecord::Base.where(id: id).first
       def fetch_by_id(id)
+        ensure_base_model
         raise_if_scoped
         return unless id
         raise NotImplementedError, "fetching needs the primary index enabled" unless primary_cache_index_enabled
@@ -48,6 +49,7 @@ module IdentityCache
       # Default fetcher added to the model on inclusion, if behaves like
       # ActiveRecord::Base.find_all_by_id
       def fetch_multi(*ids)
+        ensure_base_model
         raise_if_scoped
         raise NotImplementedError, "fetching needs the primary index enabled" unless primary_cache_index_enabled
         options = ids.extract_options!

--- a/test/attribute_cache_test.rb
+++ b/test/attribute_cache_test.rb
@@ -101,6 +101,12 @@ class AttributeCacheTest < IdentityCache::TestCase
     assert_equal "Jim", AssociatedRecord.fetch_name_by_id(2)
   end
 
+  def test_cache_attribute_on_derived_model_raises
+    assert_raises(IdentityCache::DerivedModelError) do
+      StiRecordTypeA.cache_attribute :name
+    end
+  end
+
   private
 
   def blob_key_for_associated_record(id)

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -100,4 +100,10 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
       Item.cache_has_many :deeply_through_associated_records, :embed => true
     end
   end
+
+  def test_cache_has_many_on_derived_model_raises
+    assert_raises(IdentityCache::DerivedModelError) do
+      StiRecordTypeA.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => true
+    end
+  end
 end

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -117,4 +117,10 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
       Item.cache_has_one :deeply_associated, :embed => true
     end
   end
+
+  def test_cache_has_one_on_derived_model_raises
+    assert_raises(IdentityCache::DerivedModelError) do
+      StiRecordTypeA.cache_has_one :polymorphic_record, :inverse_name => :owner, :embed => true
+    end
+  end
 end

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -205,6 +205,12 @@ class FetchMultiTest < IdentityCache::TestCase
     end
   end
 
+  def test_fetch_multi_on_derived_model_raises
+    assert_raises(IdentityCache::DerivedModelError) do
+      StiRecordTypeA.fetch_multi(1, 2)
+    end
+  end
+
   private
 
   def populate_only_fred

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -211,4 +211,10 @@ class FetchTest < IdentityCache::TestCase
       Item.where(updated_at: nil).fetch_by_id(1)
     end
   end
+
+  def test_fetch_on_derived_model_raises
+    assert_raises(IdentityCache::DerivedModelError) do
+      StiRecordTypeA.fetch(1)
+    end
+  end
 end

--- a/test/helpers/active_record_objects.rb
+++ b/test/helpers/active_record_objects.rb
@@ -76,6 +76,14 @@ module ActiveRecordObjects
       include IdentityCache
       self.primary_key = "hashed_key"
     }
+
+    Object.send :const_set, 'StiRecord', Class.new(base) {
+      include IdentityCache
+      has_many :polymorphic_records, :as => 'owner'
+    }
+
+    Object.send :const_set, 'StiRecordTypeA', Class.new(StiRecord) {
+    }
   end
 
   def teardown_models
@@ -89,6 +97,8 @@ module ActiveRecordObjects
     Object.send :remove_const, 'Item'
     Object.send :remove_const, 'ItemTwo'
     Object.send :remove_const, 'KeyedRecord'
+    Object.send :remove_const, 'StiRecord'
+    Object.send :remove_const, 'StiRecordTypeA'
     Deeply::Nested.send :remove_const, 'AssociatedRecord'
     Deeply.send :remove_const, 'Nested'
     Object.send :remove_const, 'Deeply'

--- a/test/helpers/database_connection.rb
+++ b/test/helpers/database_connection.rb
@@ -39,6 +39,7 @@ module DatabaseConnection
     :items                         => [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
     :items2                        => [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
     :keyed_records                 => [[:string, :value], :primary_key => "hashed_key"],
+    :sti_records                   => [[:string, :type], [:string, :name]],
   }
 
   DEFAULT_CONFIG = {

--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -135,4 +135,10 @@ class IndexCacheTest < IdentityCache::TestCase
       Item.where(updated_at: nil).fetch_by_title_and_id('bob', 2)
     end
   end
+
+  def test_cache_index_on_derived_model_raises
+    assert_raises(IdentityCache::DerivedModelError) do
+      StiRecordTypeA.cache_index :name, :id
+    end
+  end
 end

--- a/test/normalized_belongs_to_test.rb
+++ b/test/normalized_belongs_to_test.rb
@@ -45,4 +45,10 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
     Item.expects(:fetch_by_id).with(@parent_record.id).returns(nil)
     assert_equal nil, @record.fetch_item
   end
+
+  def test_cache_belongs_to_on_derived_model_raises
+    assert_raises(IdentityCache::DerivedModelError) do
+      StiRecordTypeA.cache_belongs_to :item, :embed => false
+    end
+  end
 end


### PR DESCRIPTION
@camilo & @byroot for review

Fixes #182

## Problem

When IdentityCache is included in the base class for a model that uses single-table inheritance, then calling `.fetch` on a subclass could result in us caching `nil` when the record exists when the subclass doesn't match the `type` of the record.

E.g. if we have the following models

```
class Company < ActiveRecord::Base
  include IdentityCache
end
class Firm < Company; end
class Client < Company; end
```

and row id 1 is for type Client, then calling `Firm.fetch(1)` will cache `nil` for id 1, resulting in `Client.fetch(1)` to not find the record that actually exists.

Additionally, caching associations on a derived class actually caches the association on the base class.

We never intended to support calling IDC class methods on derived classes, so it would be best to have them fail hard rather than in subtle ways from being misused.

## Solution

Store the model that IdentityCache is included on, and check the model when IdentityCache class methods are called.