### PR TITLE
Avoid using mysql2 0.4 in CI which doesn't work released versions of rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'mysql2', '~> 0.3.13'

--- a/Gemfile.rails32
+++ b/Gemfile.rails32
@@ -3,3 +3,4 @@ gemspec
 
 gem 'activerecord', '~> 3.2.16'
 gem 'activesupport', '~> 3.2.16'
+gem 'mysql2', '~> 0.3.13'

--- a/Gemfile.rails40
+++ b/Gemfile.rails40
@@ -3,3 +3,4 @@ gemspec
 
 gem 'activerecord', '~> 4.0.4'
 gem 'activesupport', '~> 4.0.4'
+gem 'mysql2', '~> 0.3.13'

--- a/Gemfile.rails41
+++ b/Gemfile.rails41
@@ -3,3 +3,4 @@ gemspec
 
 gem 'activerecord', '~> 4.1.0'
 gem 'activesupport', '~> 4.1.0'
+gem 'mysql2', '~> 0.3.13'

--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -3,3 +3,4 @@ gemspec
 
 gem 'activerecord', '~> 4.2.0'
 gem 'activesupport', '~> 4.2.0'
+gem 'mysql2', '~> 0.3.13'


### PR DESCRIPTION
@rafaelfranca for review

[CI is failing on master](https://travis-ci.org/Shopify/identity_cache/builds/79304602) because it is trying to use mysql2 version 0.4 which was released yesterday, but [active record only loads mysql2 0.3.x](https://github.com/rails/rails/blob/v4.2.4/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L3)