### PR TITLE
Don't store IDC loaded records in the belongs to association.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Raise if a class method is called on a scope.  Previously the scope was ignored.
 - Raise if a class method is called on a subclass of one that included IdentityCache. This never worked properly.
 - Fix cache_belongs_to on polymorphic assocations.
+- Fetching a cache_belongs_to association no longer loads the belongs_to association
 
 #### 0.2.5
 

--- a/test/normalized_belongs_to_test.rb
+++ b/test/normalized_belongs_to_test.rb
@@ -34,16 +34,17 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
     assert_equal @parent_record, @record.fetch_item
   end
 
-  def test_fetching_the_association_should_assign_the_result_to_the_association_so_that_successive_accesses_are_cached
+  def test_fetching_the_association_should_assign_the_result_to_an_instance_variable_so_that_successive_accesses_are_cached
     Item.expects(:fetch_by_id).with(@parent_record.id).returns(@parent_record)
-    @record.fetch_item
-    assert @record.association(:item).loaded?
-    assert_equal @parent_record, @record.item
+    assert_equal @parent_record, @record.fetch_item
+    assert_equal false, @record.association(:item).loaded?
+    assert_equal @parent_record, @record.fetch_item
   end
 
-  def test_fetching_the_association_shouldnt_raise_if_the_record_cant_be_found
+  def test_fetching_the_association_should_cache_nil_and_not_raise_if_the_record_cant_be_found
     Item.expects(:fetch_by_id).with(@parent_record.id).returns(nil)
-    assert_equal nil, @record.fetch_item
+    assert_equal nil, @record.fetch_item # miss
+    assert_equal nil, @record.fetch_item # hit
   end
 
   def test_cache_belongs_to_on_derived_model_raises


### PR DESCRIPTION
@byroot & @rafaelfranca for review

## Problem

IdentityCache tries to make a point of being opt-in.  As such, accessing the association directly shouldn't return records loaded from IdentityCache.

However, fetching a `cache_belongs_to` association with IdentityCache will store the result in the underlying `belongs_to` association.

## Solution

Use the `@cached_#{association}` instance variable to store the result of fetching a cache_belongs_to association, the same way we do it for cache_has_many and cache_has_one.