### PR TITLE
Fix N+1 from fetching embedded ids on a cache miss.

### DIFF
--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -29,7 +29,6 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     @record.associated = nil
     @record.save!
     @record.reload
-    @record.send(:populate_association_caches)
     Item.expects(:resolve_cache_miss).with(@record.id).once.returns(@record)
 
     fetch = Spy.on(IdentityCache.cache, :fetch).and_call_through
@@ -53,7 +52,6 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
   end
 
   def test_on_cache_hit_record_should_come_back_with_cached_association
-    @record.send(:populate_association_caches)
     Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
     Item.fetch_by_title('foo')
 
@@ -69,7 +67,6 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     @record.save!
     @record.reload
 
-    @record.send(:populate_association_caches)
     Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
     Item.fetch_by_title('foo')
 

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -29,6 +29,19 @@ class NormalizedHasManyTest < IdentityCache::TestCase
     assert_equal false, fetched_record.associated_records.loaded?
   end
 
+  def test_batch_fetching_of_association_for_multiple_parent_records
+    record2 = Item.new(:title => 'two')
+    record2.associated_records << AssociatedRecord.new(:name => 'a')
+    record2.associated_records << AssociatedRecord.new(:name => 'b')
+    record2.save!
+
+    fetched_records = assert_queries(2) do
+      Item.fetch_multi(@record.id, record2.id)
+    end
+    assert_equal [[2, 1], [4, 3]], fetched_records.map(&:cached_associated_record_ids)
+    assert_equal false, fetched_records.any?{ |record| record.associated_records.loaded? }
+  end
+
   def test_fetching_associated_ids_will_populate_the_value_if_the_record_isnt_from_the_cache
     assert_equal [2, 1], @record.fetch_associated_record_ids
   end


### PR DESCRIPTION
@rafaelfranca & @sgrif for review

## Problem

On a cache miss, the embedded associations are preloaded using `.includes`, but the id embedded associations are just preloaded by loading the ids for each parent record.

E.g. If a Product model has `cache_has_many :images, embed: :ids`, then multiple products are loaded with `Product.fetch_multi(*ids)`, then `product.image_ids` will get called on each product, causing a query per product.

## Solution

Query the associated model using a where condition on the foreign key, and selecting both the primary key and foreign key in the query, so the list of ids can be grouped by the parent record's id.