### PR TITLE
Remove code for rails 3.2 compatibility.

### DIFF
--- a/Gemfile.rails32
+++ b/Gemfile.rails32
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-gemspec
-
-gem 'activerecord', '~> 3.2.16'
-gem 'activesupport', '~> 3.2.16'
-gem 'mysql2', '~> 0.3.13'

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = IdentityCache::VERSION
 
   gem.add_dependency('ar_transaction_changes', '~> 1.0')
-  gem.add_dependency('activerecord', '>= 3.2')
+  gem.add_dependency('activerecord', '>= 4.0.4')
   gem.add_development_dependency('memcached', '~> 1.8.0')
 
   gem.add_development_dependency('memcached_store', '~> 0.12.6')

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -292,12 +292,7 @@ module IdentityCache
 
         child_class.parent_expiration_entries[options[:inverse_name]] << [self, options[:only_on_foreign_key_change]]
 
-        child_class.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
-          after_commit :expire_parent_caches
-          if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new("4.0.4")
-            after_touch :expire_parent_caches
-          end
-        CODE
+        child_class.after_commit :expire_parent_caches
       end
 
       def identity_cache_conditions(fields, values)

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -4,9 +4,6 @@ module IdentityCache
 
     included do |base|
       base.after_commit :expire_cache
-      if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new("4.0.4")
-        base.after_touch :expire_cache
-      end
     end
 
     module ClassMethods


### PR DESCRIPTION
@sgrif & @rafaelfranca for review

## Problem

Pull request #209 stopped testing rails 3.2 in CI, because we wanted to stop supporting that old a version of rails.  However, we never bumped the minimum activerecord gem version.  Since then, the test suite has stopped passing with rails 3.2, so let's make this lack of support for that version of rails more explicit.

## Solution

* Bumped the activerecord version in the gemspec
* Removed the gemfile for testing against rails 3.2
* Removed some code for active record versions lower than 4.0.4, where after_commit wasn't being called for touching a record.