### PR TITLE
Fix exec_query expectation test failures on rails 4.2 with postgres.

### DIFF
--- a/test/attribute_cache_test.rb
+++ b/test/attribute_cache_test.rb
@@ -13,85 +13,76 @@ class AttributeCacheTest < IdentityCache::TestCase
     IdentityCache.cache.clear
   end
 
-  def test_attribute_values_are_returned_on_cache_hits
-    IdentityCache.cache.expects(:fetch).with(@name_attribute_key).returns('foo')
-    assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
-  end
-
   def test_attribute_values_are_fetched_and_returned_on_cache_misses
     fetch = Spy.on(IdentityCache.cache, :fetch).and_call_through
-    expects_fetch_associated_record_name_by_id(1, returns: 'foo')
 
-    assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
+    assert_queries(1) do
+      assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
+    end
     assert fetch.has_been_called_with?(@name_attribute_key)
   end
 
-  def test_attribute_values_are_stored_in_the_cache_on_cache_misses
-    # Cache miss, so
-    fetch = Spy.on(IdentityCache.cache, :fetch).and_call_through
-
-    # Grab the value of the attribute from the DB
-    expects_fetch_associated_record_name_by_id(1, returns: 'foo')
-
-    # And write it back to the cache
-    add = Spy.on(fetcher, :add).and_call_through
-
+  def test_attribute_values_are_returned_on_cache_hits
     assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
-    assert fetch.has_been_called_with?(@name_attribute_key)
-    assert add.has_been_called_with?(@name_attribute_key, 'foo')
-    assert_equal 'foo', IdentityCache.cache.fetch(@name_attribute_key)
+
+    assert_queries(0) do
+      assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
+    end
   end
 
   def test_nil_is_stored_in_the_cache_on_cache_misses
-    # Cache miss, so
-    fetch = Spy.on(IdentityCache.cache, :fetch).and_call_through
+    assert_equal nil, AssociatedRecord.fetch_name_by_id(2)
 
-    # Grab the value of the attribute from the DB
-    expects_fetch_associated_record_name_by_id(1, returns: nil)
-
-    # And write it back to the cache
-    add = Spy.on(fetcher, :add).and_call_through
-
-    assert_equal nil, AssociatedRecord.fetch_name_by_id(1)
-    assert fetch.has_been_called_with?(@name_attribute_key)
-    assert add.has_been_called_with?(@name_attribute_key, IdentityCache::CACHED_NIL)
+    assert_queries(0) do
+      assert_equal nil, AssociatedRecord.fetch_name_by_id(2)
+    end
   end
 
   def test_cached_attribute_values_are_expired_from_the_cache_when_an_existing_record_is_saved
-    IdentityCache.cache.expects(:delete).with(@name_attribute_key)
-    IdentityCache.cache.expects(:delete).with(blob_key_for_associated_record(1))
+    assert_queries(1) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
+    assert_queries(0) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
+
     @record.save!
+
+    assert_queries(1) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
   end
 
   def test_cached_attribute_values_are_expired_from_the_cache_when_an_existing_record_with_changed_attributes_is_saved
-    IdentityCache.cache.expects(:delete).with(@name_attribute_key)
-    IdentityCache.cache.expects(:delete).with(blob_key_for_associated_record(1))
+    assert_queries(1) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
+    assert_queries(0) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
+
     @record.name = 'bar'
     @record.save!
+
+    assert_queries(1) { assert_equal 'bar', AssociatedRecord.fetch_name_by_id(1) }
   end
 
   def test_cached_attribute_values_are_expired_from_the_cache_when_an_existing_record_is_destroyed
-    IdentityCache.cache.expects(:delete).with(@name_attribute_key)
-    IdentityCache.cache.expects(:delete).with(blob_key_for_associated_record(1))
+    assert_queries(1) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
+    assert_queries(0) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
+
     @record.destroy
+
+    assert_queries(1) { assert_equal nil, AssociatedRecord.fetch_name_by_id(1) }
   end
 
   def test_cached_attribute_values_are_expired_from_the_cache_when_a_new_record_is_saved
-    new_id = 2.to_s
-    # primary index delete
-    IdentityCache.cache.expects(:delete).with(blob_key_for_associated_record(new_id))
-    # attribute cache delete
-    IdentityCache.cache.expects(:delete).with("#{NAMESPACE}attribute:AssociatedRecord:name:id:#{cache_hash(new_id)}")
+    new_id = 2
+    assert_queries(1) { assert_equal nil, AssociatedRecord.fetch_name_by_id(new_id) }
+    assert_queries(0) { assert_equal nil, AssociatedRecord.fetch_name_by_id(new_id) }
+
     @parent.associated_records.create(:name => 'bar')
+
+    assert_queries(1) { assert_equal 'bar', AssociatedRecord.fetch_name_by_id(new_id) }
   end
 
   def test_fetching_by_attribute_delegates_to_block_if_transactions_are_open
-    IdentityCache.cache.expects(:read).with(@name_attribute_key).never
-
-    expects_fetch_associated_record_name_by_id(1, returns: 'foo')
+    IdentityCache.cache.expects(:read).never
 
     @record.transaction do
-      assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
+      assert_queries(1) do
+        assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
+      end
     end
   end
 
@@ -105,23 +96,5 @@ class AttributeCacheTest < IdentityCache::TestCase
     assert_raises(IdentityCache::DerivedModelError) do
       StiRecordTypeA.cache_attribute :name
     end
-  end
-
-  private
-
-  def blob_key_for_associated_record(id)
-    cache_hash = cache_hash('id:integer,item_id:integer,item_two_id:integer,name:string')
-    "#{NAMESPACE}blob:AssociatedRecord:#{cache_hash}:#{id}"
-  end
-
-  def quoted_table_column(model, column_name)
-    "#{model.quoted_table_name}.#{model.connection.quote_column_name(column_name)}"
-  end
-
-  def expects_fetch_associated_record_name_by_id(id, options={})
-    result = options[:returns] ? [options[:returns]] : []
-    Item.connection.expects(:exec_query)
-      .with(AssociatedRecord.unscoped.select(quoted_table_column(AssociatedRecord, :name)).where(id: id).limit(1).to_sql, any_parameters)
-      .returns(ActiveRecord::Result.new(['name'], [result]))
   end
 end

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -18,10 +18,6 @@ class FetchTest < IdentityCache::TestCase
   end
 
   def test_fetch_with_garbage_input
-    Item.connection.expects(:exec_query)
-      .with(Item.where(id: 0).limit(1).to_sql, any_parameters)
-      .returns(ActiveRecord::Result.new([], []))
-
     assert_equal nil, Item.fetch_by_id('garbage')
   end
 

--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -11,14 +11,12 @@ class IndexCacheTest < IdentityCache::TestCase
     @cache_key = "#{NAMESPACE}index:Item:title:#{cache_hash(@record.title)}"
   end
 
-  def test_fetch_with_garbage_input_should_use_properly_typed_sql
+  def test_fetch_with_garbage_input
     Item.cache_index :title, :id
 
-    Item.connection.expects(:exec_query)
-      .with(Item.select(:id).where(title: 'garbage', id: 0).to_sql, any_parameters)
-      .returns(ActiveRecord::Result.new([], []))
-
-    assert_equal [], Item.fetch_by_title_and_id('garbage', 'garbage')
+    assert_queries(1) do
+      assert_equal [], Item.fetch_by_title_and_id('garbage', 'garbage')
+    end
   end
 
   def test_fetch_with_unique_adds_limit_clause

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -101,7 +101,7 @@ end
 
 class SQLCounter
   cattr_accessor :ignored_sql
-  self.ignored_sql = [/^PRAGMA (?!(table_info))/, /^SELECT currval/, /^SELECT CAST/, /^SELECT @@IDENTITY/, /^SELECT @@ROWCOUNT/, /^SAVEPOINT/, /^ROLLBACK TO SAVEPOINT/, /^RELEASE SAVEPOINT/, /^SHOW max_identifier_length/, /^BEGIN/, /^COMMIT/]
+  self.ignored_sql = [/^PRAGMA (?!(table_info))/, /^SELECT currval/, /^SELECT CAST/, /^SELECT @@IDENTITY/, /^SELECT @@ROWCOUNT/, /^SAVEPOINT/, /^ROLLBACK TO SAVEPOINT/, /^RELEASE SAVEPOINT/, /^SHOW max_identifier_length/, /^BEGIN/, /^COMMIT/, /^SHOW /]
 
   # FIXME: this needs to be refactored so specific database can add their own
   # ignored SQL.  This ignored SQL is for Oracle.


### PR DESCRIPTION
@byroot & @rafaelfranca for review

## Problem

When running the tests with rails 4.2 and postgres, there are test failures from some `connection.expects(:exec_query)` expectations.  E.g.

```
  1) Failure:
FetchTest#test_fetch_with_garbage_input [/home/travis/.rvm/gems/ruby-2.1.5/gems/activerecord-4.2.4/lib/active_record/connection_adapters/abstract/database_statements.rb:351]:
unexpected invocation: #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter:0x2438f08>.exec_query('SELECT  \'items\'.* FROM \'items\' WHERE \'items\'.\'id\' = $1 LIMIT 1', 'Item Load', [[#<ActiveRecord::ConnectionAdapters::PostgreSQLColumn:0x26f0318>, 'garbage']])
unsatisfied expectations:
- expected exactly once, not yet invoked: #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter:0x2438f08>.exec_query('SELECT  \'items\'.* FROM \'items\' WHERE \'items\'.\'id\' = 0 LIMIT 1', any_parameters)
```

These tests seem quite fragile, by testing internal method calls in rails.  They are also intrusive, by stubbing out those methods and returning a fake value, rather than performing a integrated test of the actual behaviour of dependant components.

## Solution

Setup datastores into the right state so mocked values don't need to be returned to test different code paths, and use `assert_queries` to make sure the right number of queries are made to the database.