### PR TITLE
Fix a usage of respond_to? for a private method.

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -189,9 +189,9 @@ module IdentityCache
         end
         recursively_embedded_associations.each_value do |options|
           child_model = options.fetch(:association_reflection).klass
-          if child_model.respond_to?(:preload_id_embedded_associations)
+          if child_model.include?(IdentityCache)
             child_records = records.flat_map(&options.fetch(:cached_accessor_name).to_sym)
-            child_model.preload_id_embedded_associations(child_records)
+            child_model.send(:preload_id_embedded_associations, child_records)
           end
         end
       end


### PR DESCRIPTION
@rafaelfranca for review

Pull #238 introduced this check for `child_model.respond_to?(:preload_id_embedded_associations)`, but `preload_id_embedded_associations` is a private method, so it always returned `false`.  This wasn't caught by the tests, since it would just result it the same N+1 it was trying to fix, just in the case of fetching ids for deeply associated records.

I used `child_model.include?(IdentityCache)` instead, since I think that check it is a less fragile check than changing it to `child_model.respond_to?(:preload_id_embedded_associations, true)`.  I also added a regression test for this case.