### PR TITLE
Compact nils when preloading id embedded associations

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -190,7 +190,7 @@ module IdentityCache
         recursively_embedded_associations.each_value do |options|
           child_model = options.fetch(:association_reflection).klass
           if child_model.include?(IdentityCache)
-            child_records = records.flat_map(&options.fetch(:cached_accessor_name).to_sym)
+            child_records = records.flat_map(&options.fetch(:cached_accessor_name).to_sym).compact
             child_model.send(:preload_id_embedded_associations, child_records)
           end
         end

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -59,6 +59,20 @@ class NormalizedHasManyTest < IdentityCache::TestCase
     end
   end
 
+  def test_batch_fetching_stops_with_nil_parent
+    Item.cache_has_one :associated, embed: true
+    AssociatedRecord.cache_has_many :deeply_associated_records, embed: :ids
+    AssociatedRecord.delete_all
+
+    fetched_records = assert_queries(3) do
+      Item.fetch(@record.id)
+    end
+    assert_no_queries do
+      assert_equal @record, fetched_records
+      assert_nil fetched_records.fetch_associated
+    end
+  end
+
   def test_fetching_associated_ids_will_populate_the_value_if_the_record_isnt_from_the_cache
     assert_equal [2, 1], @record.fetch_associated_record_ids
   end


### PR DESCRIPTION
@rafaelfranca for review

## Problem

I got `NoMethodError: undefined method 'fetch_association' for nil:NilClass` like errors when testing identity_cache master on Shopify.  This can happen when preloading an id embedded association through a embedded has_one association, since `records.flat_map(&options.fetch(:cached_accessor_name).to_sym)` was returning `[nil]` when the has_one association is `nil`.

## Solution

Compact the array and add a regression test.