### PR TITLE
[fetch_multi] Only call cache fetcher once per unique key

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -115,7 +115,7 @@ module IdentityCache
       return {} if keys.size == 0
 
       result = if should_use_cache?
-        fetch_in_batches(keys) do |missed_keys|
+        fetch_in_batches(keys.uniq) do |missed_keys|
           results = yield missed_keys
           results.map {|e| map_cached_nil_for e }
         end

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -121,6 +121,18 @@ class FetchMultiTest < IdentityCache::TestCase
     assert_equal [@joe, @bob, @joe], Item.fetch_multi(@joe.id, @bob.id, @joe.id)
   end
 
+  def test_fetch_multi_with_duplicate_ids_hits_backend_once_per_id
+    cache_response = {
+      @joe_blob_key => cache_response_for(@joe),
+      @bob_blob_key => cache_response_for(@bob),
+    }
+
+    fetcher.expects(:fetch_multi).with([@joe_blob_key, @bob_blob_key]).returns(cache_response)
+    result = Item.fetch_multi(@joe.id, @bob.id, @joe.id)
+
+    assert_equal [@joe, @bob, @joe], result
+  end
+
   def test_fetch_multi_with_open_transactions_hits_the_database
     Item.connection.expects(:open_transactions).at_least_once.returns(1)
     fetcher.expects(:fetch_multi).never


### PR DESCRIPTION
When calling `#fetch_multi` with an array that contains duplicates, these duplicates are passed all the way into the cache backend. This PR only sends the unique values.

What do you think @gmalette ?