### PR TITLE
Fixed an issue that is unique cache_index keys are returned as array

### DIFF
--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -199,7 +199,7 @@ module IdentityCache
         cache_key = rails_cache_index_key_for_fields_and_values(fields, values)
         id = IdentityCache.fetch(cache_key) { identity_cache_conditions(fields, values).limit(1).pluck(primary_key).first }
         unless id.nil?
-          record = fetch_by_id(id)
+          record = fetch_by_id(id.is_a?(Array) ? id.first : id)
           IdentityCache.cache.delete(cache_key) unless record
         end
 


### PR DESCRIPTION
https://github.com/Shopify/identity_cache/blob/master/lib/identity_cache/fallback_fetcher.rb#L34-L41

key = "hello"
result = @cache_backend.read(key)
expected result was "world" but returned ["world"]

'dalli', '~> 2.7.5'
'identity_cache', '~> 0.2.5'
'cityhash', '~> 0.8.1'