### PR TITLE
Add support for includes option on fetch methods

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -19,10 +19,9 @@ module IdentityCache
       def fetch_by_id(id)
         ensure_base_model
         raise_if_scoped
-        return unless id
         raise NotImplementedError, "fetching needs the primary index enabled" unless primary_cache_index_enabled
+        return unless id
         if IdentityCache.should_use_cache?
-
           require_if_necessary do
             object = nil
             coder = IdentityCache.fetch(rails_cache_key(id)){ coder_from_record(object = resolve_cache_miss(id)) }
@@ -30,9 +29,8 @@ module IdentityCache
             IdentityCache.logger.error "[IDC id mismatch] fetch_by_id_requested=#{id} fetch_by_id_got=#{object.id} for #{object.inspect[(0..100)]} " if object && object.id != id.to_i
             object
           end
-
         else
-          self.reorder(nil).where(primary_key => id).first
+          resolve_cache_miss(id)
         end
       end
 

--- a/test/prefetch_normalized_associations_test.rb
+++ b/test/prefetch_normalized_associations_test.rb
@@ -14,19 +14,19 @@ class PrefetchNormalizedAssociationsTest < IdentityCache::TestCase
     @tenth_blob_key = "#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:10"
   end
 
-  def test_fetch_with_includes_option_preloads_associations
+  def test_fetch_with_includes_option
     Item.send(:cache_belongs_to, :item)
     john = Item.create!(title: 'john')
     @bob.update_column(:item_id, john)
 
     spy = Spy.on(Item, :fetch_multi).and_call_through
 
-    items = Item.fetch(@bob.id, includes: :item)
+    assert_equal @bob, Item.fetch(@bob.id, includes: :item)
 
     assert spy.calls.one?{ |call| call.args == [[john.id]] }
   end
 
-  def test_fetch_multi_with_includes_option_preloads_associations
+  def test_fetch_multi_with_includes_option
     Item.send(:cache_belongs_to, :item)
     john = Item.create!(:title => 'john')
     jim = Item.create!(:title => 'jim')
@@ -35,7 +35,7 @@ class PrefetchNormalizedAssociationsTest < IdentityCache::TestCase
 
     spy = Spy.on(Item, :fetch_multi).and_call_through
 
-    items = Item.fetch_multi(@bob.id, @joe.id, @fred.id, :includes => :item)
+    assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id, :includes => :item)
 
     assert spy.calls.one?{ |call| call.args == [[john.id, jim.id]] }
   end
@@ -194,6 +194,32 @@ class PrefetchNormalizedAssociationsTest < IdentityCache::TestCase
     mock_relation.expects(:includes).returns(stub(:to_a => [@bob, @joe, @fred]))
 
     Item.send(:find_batch, [@bob, @joe, @fred].map(&:id).map(&:to_s))
+  end
+
+  def test_fetch_by_index_with_includes_option
+    Item.send(:cache_belongs_to, :item)
+    Item.cache_index :title
+    john = Item.create!(title: 'john')
+    @bob.update_column(:item_id, john)
+
+    spy = Spy.on(Item, :fetch_multi).and_call_through
+
+    assert_equal [@bob], Item.fetch_by_title('bob', includes: :item)
+
+    assert spy.calls.one?{ |call| call.args == [[john.id]] }
+  end
+
+  def test_fetch_by_unique_index_with_includes_option
+    Item.send(:cache_belongs_to, :item)
+    Item.cache_index :title, :unique => true
+    john = Item.create!(title: 'john')
+    @bob.update_column(:item_id, john)
+
+    spy = Spy.on(Item, :fetch_multi).and_call_through
+
+    assert_equal @bob, Item.fetch_by_title('bob', includes: :item)
+
+    assert spy.calls.one?{ |call| call.args == [[john.id]] }
   end
 
   private


### PR DESCRIPTION
@rafaelfranca & @richardmonette for review

## Problem

When there is a need to fetch a deeply associated belongs to association, then we can't rely on embedding to avoid an N+1, since cache_belongs_to doesn't support embedding.  However, `fetch_multi` supports an `:includes` option to batch the fetching of that association for multiple parent records, e.g. `Item.fetch_multi(ids, include: { associated_records: :deeply_associated_record })` where `:deeply_associated_record` is a belongs_to association.

The problem is that the `:includes` option is only support on fetch_multi, but not `fetch`, `fetch_by_id` or the cache index generated `fetch_by_`* methods.  This is inconsistent and could lead to ugly workarounds where `fetch_multi` is used where `fetch` or `fetch_by_id` are more appropriate.  Or where `cache_attribute :id, by:` is used instead of `cache_index` to get access to the `id`, since `cache_index` doesn't provide access to the `id` in its `fetch_by_`* methods and uses `fetch_by_id` internally.

## Solution

Support the `:includes` option on the above mentioned fetch methods.

I noticed that `fetch_by_id` wasn't preloading all the embedded associations when `IdentityCache.should_use_cache?` returns `false` (i.e. during a database transaction).  I needed to change this inconsistency because `prefetch_association` assumes all embedded associations have already been loaded.

## Future Work

I noticed that `cache_attribute` could be used to implement `cache_index`, if it had a concept of a non-unique index.  This would also provide `fetch_id_by_`* methods for cache_index, which would make it more flexible. **Edit: https://github.com/Shopify/identity_cache/pull/250 does this**

It might also be useful to expose `prefetch_associations` for fetching associations on a record that was already loaded.  Although, then `prefetch_associations` could be called on a record that doesn't have all its embedded associations loaded, which is an assumption it can currently make.