### PR TITLE
Implement cache_index using cache_attribute.

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -41,7 +41,7 @@ module IdentityCache
     self.cache_namespace = "IDC:#{CACHE_VERSION}:".freeze
 
     def included(base) #:nodoc:
-      raise AlreadyIncludedError if base.respond_to? :cache_indexes
+      raise AlreadyIncludedError if base.include?(IdentityCache::ConfigurationDSL)
 
       base.send(:include, ArTransactionChanges) unless base.include?(ArTransactionChanges)
       base.send(:include, IdentityCache::BelongsToCaching)

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -35,12 +35,12 @@ module IdentityCache
         "#{rails_cache_key_namespace}blob:#{base_class.name}:#{rails_cache_key_prefix}:"
       end
 
-      def rails_cache_index_key_for_fields_and_values(fields, values)
-        "#{rails_cache_key_namespace}index:#{base_class.name}:#{rails_cache_string_for_fields_and_values(fields, values)}"
-      end
-
-      def rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, values)
-        "#{rails_cache_key_namespace}attribute:#{base_class.name}:#{attribute}:#{rails_cache_string_for_fields_and_values(fields, values)}"
+      def rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, values, unique)
+        "#{rails_cache_key_namespace}" \
+          "attr#{unique ? '' : 's' }" \
+          ":#{base_class.name}" \
+          ":#{attribute}" \
+          ":#{rails_cache_string_for_fields_and_values(fields, values)}"
       end
 
       def rails_cache_key_namespace
@@ -58,20 +58,12 @@ module IdentityCache
       self.class.rails_cache_key(id)
     end
 
-    def secondary_cache_index_key_for_current_values(fields) # :nodoc:
-      self.class.rails_cache_index_key_for_fields_and_values(fields, current_values_for_fields(fields))
+    def attribute_cache_key_for_attribute_and_current_values(attribute, fields, unique) # :nodoc:
+      self.class.rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, current_values_for_fields(fields), unique)
     end
 
-    def secondary_cache_index_key_for_previous_values(fields) # :nodoc:
-      self.class.rails_cache_index_key_for_fields_and_values(fields, old_values_for_fields(fields))
-    end
-
-    def attribute_cache_key_for_attribute_and_current_values(attribute, fields) # :nodoc:
-      self.class.rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, current_values_for_fields(fields))
-    end
-
-    def attribute_cache_key_for_attribute_and_previous_values(attribute, fields) # :nodoc:
-      self.class.rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, old_values_for_fields(fields))
+    def attribute_cache_key_for_attribute_and_previous_values(attribute, fields, unique) # :nodoc:
+      self.class.rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, old_values_for_fields(fields), unique)
     end
 
     def current_values_for_fields(fields) # :nodoc:

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -36,8 +36,9 @@ module IdentityCache
       end
 
       def rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, values, unique)
+        unique_indicator = unique ? '' : 's' 
         "#{rails_cache_key_namespace}" \
-          "attr#{unique ? '' : 's' }" \
+          "attr#{unique_indicator}" \
           ":#{base_class.name}" \
           ":#{attribute}" \
           ":#{rails_cache_string_for_fields_and_values(fields, values)}"

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -376,7 +376,7 @@ module IdentityCache
     end
 
     def expire_attribute_indexes # :nodoc:
-      cache_attributes.try(:each) do |(attribute, fields, unique)|
+      cache_attributes.each do |(attribute, fields, unique)|
         unless was_new_record?
           old_cache_attribute_key = attribute_cache_key_for_attribute_and_previous_values(attribute, fields, unique)
           IdentityCache.cache.delete(old_cache_attribute_key)

--- a/test/attribute_cache_test.rb
+++ b/test/attribute_cache_test.rb
@@ -9,7 +9,7 @@ class AttributeCacheTest < IdentityCache::TestCase
 
     @parent = Item.create!(:title => 'bob')
     @record = @parent.associated_records.create!(:name => 'foo')
-    @name_attribute_key = "#{NAMESPACE}attribute:AssociatedRecord:name:id:#{cache_hash(@record.id.to_s)}"
+    @name_attribute_key = "#{NAMESPACE}attr:AssociatedRecord:name:id:#{cache_hash(@record.id.to_s)}"
     IdentityCache.cache.clear
   end
 

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -20,7 +20,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     assert_equal @record, record_from_cache_miss
     assert_not_nil @record.fetch_associated
     assert_equal @record.associated, record_from_cache_miss.fetch_associated
-    assert fetch.has_been_called_with?(@record.secondary_cache_index_key_for_current_values([:title]))
+    assert fetch.has_been_called_with?(@record.attribute_cache_key_for_attribute_and_current_values(:id, [:title], true))
     assert fetch.has_been_called_with?(@record.primary_cache_index_key)
   end
 
@@ -40,7 +40,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     5.times do
       assert_nil record_from_cache_miss.fetch_associated
     end
-    assert fetch.has_been_called_with?(@record.secondary_cache_index_key_for_current_values([:title]))
+    assert fetch.has_been_called_with?(@record.attribute_cache_key_for_attribute_and_current_values(:id, [:title], true))
     assert fetch.has_been_called_with?(@record.primary_cache_index_key)
   end
 

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -13,7 +13,7 @@ class FetchTest < IdentityCache::TestCase
     @record.title = 'bob'
     @cached_value = {class: @record.class, attributes: @record.attributes_before_type_cast}
     @blob_key = "#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:1"
-    @index_key = "#{NAMESPACE}index:Item:title:#{cache_hash('bob')}"
+    @index_key = "#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}"
   end
 
   def test_fetch_with_garbage_input

--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -8,7 +8,6 @@ class IndexCacheTest < IdentityCache::TestCase
     @record = Item.new
     @record.id = 1
     @record.title = 'bob'
-    @cache_key = "#{NAMESPACE}index:Item:title:#{cache_hash(@record.title)}"
   end
 
   def test_fetch_with_garbage_input
@@ -32,54 +31,55 @@ class IndexCacheTest < IdentityCache::TestCase
   def test_unique_index_caches_nil
     Item.cache_index :title, :unique => true
     assert_equal nil, Item.fetch_by_title('bob')
-    assert_equal IdentityCache::CACHED_NIL, backend.read(@cache_key)
+    assert_equal IdentityCache::CACHED_NIL, backend.read(cache_key(unique: true))
   end
 
   def test_unique_index_expired_by_new_record
     Item.cache_index :title, :unique => true
-    IdentityCache.cache.write(@cache_key, IdentityCache::CACHED_NIL)
+    IdentityCache.cache.write(cache_key(unique: true), IdentityCache::CACHED_NIL)
     @record.save!
-    assert_equal IdentityCache::DELETED, backend.read(@cache_key)
+    assert_equal IdentityCache::DELETED, backend.read(cache_key(unique: true))
   end
 
   def test_unique_index_filled_on_fetch_by
     Item.cache_index :title, :unique => true
     @record.save!
     assert_equal @record, Item.fetch_by_title('bob')
-    assert_equal @record.id, backend.read(@cache_key)
+    assert_equal @record.id, backend.read(cache_key(unique: true))
   end
 
   def test_unique_index_expired_by_updated_record
     Item.cache_index :title, :unique => true
     @record.save!
-    IdentityCache.cache.write(@cache_key, @record.id)
+    old_cache_key = cache_key(unique: true)
+    IdentityCache.cache.write(old_cache_key, @record.id)
 
     @record.title = 'robert'
-    new_cache_key = "#{NAMESPACE}index:Item:title:#{cache_hash(@record.title)}"
+    new_cache_key = cache_key(unique: true)
     IdentityCache.cache.write(new_cache_key, IdentityCache::CACHED_NIL)
     @record.save!
-    assert_equal IdentityCache::DELETED, backend.read(@cache_key)
+    assert_equal IdentityCache::DELETED, backend.read(old_cache_key)
     assert_equal IdentityCache::DELETED, backend.read(new_cache_key)
   end
 
   def test_non_unique_index_caches_empty_result
     Item.cache_index :title
     assert_equal [], Item.fetch_by_title('bob')
-    assert_equal [], backend.read(@cache_key)
+    assert_equal [], backend.read(cache_key)
   end
 
   def test_non_unique_index_expired_by_new_record
     Item.cache_index :title
-    IdentityCache.cache.write(@cache_key, [])
+    IdentityCache.cache.write(cache_key, [])
     @record.save!
-    assert_equal IdentityCache::DELETED, backend.read(@cache_key)
+    assert_equal IdentityCache::DELETED, backend.read(cache_key)
   end
 
   def test_non_unique_index_filled_on_fetch_by
     Item.cache_index :title
     @record.save!
     assert_equal [@record], Item.fetch_by_title('bob')
-    assert_equal [@record.id], backend.read(@cache_key)
+    assert_equal [@record.id], backend.read(cache_key)
   end
 
   def test_non_unique_index_fetches_multiple_records
@@ -88,28 +88,29 @@ class IndexCacheTest < IdentityCache::TestCase
     record2 = Item.create(:title => 'bob') { |item| item.id = 2 }
 
     assert_equal [@record, record2], Item.fetch_by_title('bob')
-    assert_equal [1, 2], backend.read(@cache_key)
+    assert_equal [1, 2], backend.read(cache_key)
   end
 
   def test_non_unique_index_expired_by_updating_record
     Item.cache_index :title
     @record.save!
-    IdentityCache.cache.write(@cache_key, [@record.id])
+    old_cache_key = cache_key
+    IdentityCache.cache.write(old_cache_key, [@record.id])
 
     @record.title = 'robert'
-    new_cache_key = "#{NAMESPACE}index:Item:title:#{cache_hash(@record.title)}"
+    new_cache_key = cache_key
     IdentityCache.cache.write(new_cache_key, [])
     @record.save!
-    assert_equal IdentityCache::DELETED, backend.read(@cache_key)
+    assert_equal IdentityCache::DELETED, backend.read(old_cache_key)
     assert_equal IdentityCache::DELETED, backend.read(new_cache_key)
   end
 
   def test_non_unique_index_expired_by_destroying_record
     Item.cache_index :title
     @record.save!
-    IdentityCache.cache.write(@cache_key, [@record.id])
+    IdentityCache.cache.write(cache_key, [@record.id])
     @record.destroy
-    assert_equal IdentityCache::DELETED, backend.read(@cache_key)
+    assert_equal IdentityCache::DELETED, backend.read(cache_key)
   end
 
   def test_set_table_name_cache_fetch
@@ -117,7 +118,7 @@ class IndexCacheTest < IdentityCache::TestCase
     Item.table_name = 'items2'
     @record.save!
     assert_equal [@record], Item.fetch_by_title('bob')
-    assert_equal [@record.id], backend.read(@cache_key)
+    assert_equal [@record.id], backend.read(cache_key)
   end
 
   def test_fetch_by_index_raises_when_called_on_a_scope
@@ -138,5 +139,11 @@ class IndexCacheTest < IdentityCache::TestCase
     assert_raises(IdentityCache::DerivedModelError) do
       StiRecordTypeA.cache_index :name, :id
     end
+  end
+
+  private
+
+  def cache_key(unique: false)
+    "#{NAMESPACE}attr#{unique ? '' : 's'}:Item:id:title:#{cache_hash(@record.title)}"
   end
 end

--- a/test/save_test.rb
+++ b/test/save_test.rb
@@ -16,21 +16,21 @@ class SaveTest < IdentityCache::TestCase
     @record = Item.new
     @record.title = 'bob'
 
-    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('2/bob')}")
-    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('2/bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
     expect_cache_delete("#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:2").once
     @record.save
   end
 
   def test_update
     # Regular flow, write index id, write index id/tile, delete data blob since Record has changed
-    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/fred')}")
-    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('fred')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/fred')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('fred')}")
     expect_cache_delete(@blob_key)
 
     # Delete index id, delete index id/title
-    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
 
     @record.title = 'fred'
     @record.save
@@ -38,8 +38,8 @@ class SaveTest < IdentityCache::TestCase
 
   def test_destroy
     # Regular flow: delete data blob, delete index id, delete index id/tile
-    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
     expect_cache_delete(@blob_key)
 
     @record.destroy
@@ -47,8 +47,8 @@ class SaveTest < IdentityCache::TestCase
 
   def test_destroy_with_changed_attributes
     # Make sure to delete the old cache index key, since the new title never ended up in an index
-    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
     expect_cache_delete(@blob_key)
 
     @record.title = 'fred'
@@ -57,16 +57,16 @@ class SaveTest < IdentityCache::TestCase
 
   def test_touch_will_expire_the_caches
     # Regular flow: delete data blob, delete index id, delete index id/tile
-    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
     expect_cache_delete(@blob_key)
 
     @record.touch
   end
 
   def test_expire_cache_works_in_a_transaction
-    expect_cache_delete("#{NAMESPACE}index:Item:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}index:Item:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
     expect_cache_delete(@blob_key)
 
     ActiveRecord::Base.transaction do


### PR DESCRIPTION
@rafaelfranca, @camilo for review

## Problem

`cache_index *columns, unique: true` cache the same thing as `cache_attribute :id, by: columns` so we should just use cache_attribute to implement cache_index to simplify the codebase.

## Solution

This PR adds a `:unique` option to cache_attribute, because that is an option `cache_index` supports and `cache_attribute` used to assume the index was always unique.

`cache_index` uses the `cache_attribute` by calling the `fetch_id_by_`* for the index to get the record ids, then uses `fetch_by_id` or `fetch_multi` to get the record itself.  This means there are new `fetch_id_by_`* methods defined for each cache_index.

The cache key for cache_attribute now changes when the `:unique` option changes to fix #248.