### PR TITLE
Rename cache_attributes to cache_indexes to avoid method name conflict.

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -376,7 +376,7 @@ module IdentityCache
     end
 
     def expire_attribute_indexes # :nodoc:
-      cache_attributes.each do |(attribute, fields, unique)|
+      cache_indexes.each do |(attribute, fields, unique)|
         unless was_new_record?
           old_cache_attribute_key = attribute_cache_key_for_attribute_and_previous_values(attribute, fields, unique)
           IdentityCache.cache.delete(old_cache_attribute_key)


### PR DESCRIPTION
@rafaelfranca for review

When testing with pull #250 I noticed ```DEPRECATION WARNING: Calling `cache_attributes` is no longer necessary.``` warnings. This is because active record defines a deprecated class method named `cache_attributes`, and identity cache has a class_attribute of the same name to store the options given to the `cache_attribute` DSL method.

This naming conflict somehow resulted in problems with IDC finding the inverse name of associations.  I'm not sure why this was a symptom of the problem, but fixing the naming conflict resolved the issue.  I'm also not sure why this problem didn't turn in up the IDC test suite.

I chose to rename the `cache_attributes` class attribute to `cache_indexes`.  The naming is still appropriate, since it is basically an index used to look up an attribute.