### PR TITLE
Allow prefetch_associations to be used on existing records.

### DIFF
--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -201,17 +201,14 @@ module IdentityCache
         options[:cached_accessor_name]   = "fetch_#{association}"
         options[:records_variable_name]  = "cached_#{association}"
 
+        self.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
+          def #{options[:cached_accessor_name]}
+            fetch_recursively_cached_association('#{options[:records_variable_name]}', :#{association})
+          end
+        CODE
 
-        unless instance_methods.include?(options[:cached_accessor_name].to_sym)
-          self.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
-            def #{options[:cached_accessor_name]}
-              fetch_recursively_cached_association('#{options[:records_variable_name]}', :#{association})
-            end
-          CODE
-
-          options[:only_on_foreign_key_change] = false
-          add_parent_expiry_hook(options)
-        end
+        options[:only_on_foreign_key_change] = false
+        add_parent_expiry_hook(options)
       end
 
       def build_id_embedded_has_many_cache(association, options) #:nodoc:

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -275,16 +275,15 @@ module IdentityCache
 
       def fetch_embedded_associations(records)
         associations = embedded_associations
-        return true if associations.empty?
+        return if associations.empty?
 
-        return false unless primary_cache_index_enabled
+        return unless primary_cache_index_enabled
 
-        records_by_id = records.index_by(&:id)
-        cached_records = fetch_multi(records.map(&:id))
+        cached_records_by_id = fetch_multi(records.map(&:id)).index_by(&:id)
 
         associations.each_value do |options|
-          cached_records.each do |cached_record|
-            record = records_by_id.fetch(cached_record.id)
+          records.each do |record|
+            next unless cached_record = cached_records_by_id[record.id]
             if options[:embed] == :ids
               cached_association = cached_record.public_send(options.fetch(:cached_ids_name))
               record.instance_variable_set(:"@#{options.fetch(:ids_variable_name)}", cached_association)
@@ -294,7 +293,6 @@ module IdentityCache
             end
           end
         end
-        true
       end
 
       def prefetch_embedded_association(records, association, details)

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -297,6 +297,9 @@ module IdentityCache
       end
 
       def prefetch_embedded_association(records, association, details)
+        # Make the same assumption as ActiveRecord::Associations::Preloader, which is
+        # that all the records have the same associations loaded, so we can just check
+        # the first record to see if an association is loaded.
         first_record = records.first
         return if first_record.association(association).loaded?
         iv_name_key = details[:embed] == true ? :records_variable_name : :ids_variable_name

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -79,6 +79,7 @@ module IdentityCache
 
         case associations
         when nil
+          # do nothing
         when Symbol
           prefetch_one_association(associations, records)
         when Array


### PR DESCRIPTION
@boourns & @eapache for review

## Problem

I would like to be able to prefetch associations on records which have already been loaded.

An example of where this can be useful is when performing an update on a record.  The record needs to be loaded from the database to avoid propagating cache corruption, but that prevents prefetching unloaded associations using the existing record when creating an HTTP response that corresponds to that update.

This can also be useful for normalized associations, like when calling `fetch_#{association}` on a `cache_belongs_to` association or on an id embedded association, which doesn't support the `:includes` option, since it would complicate memorization.

## Solution

I made the `prefetch_associations` method public and made it work with records not loaded from IDC.  Embedded associations are loaded by fetching the owner of the association from the cache, then moving the loaded association records onto the records passed to `prefetch_associations`.