### PR TITLE
Raise an exception when trying to cache an association scoped with a join

### DIFF
--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -291,9 +291,13 @@ module IdentityCache
         if association_reflection.options[:through]
           raise UnsupportedAssociationError, "caching through associations isn't supported"
         end
+        child_class = association_reflection.klass
+        scope = association_reflection.scope
+        if scope && !child_class.all.instance_exec(&scope).joins_values.empty?
+          raise UnsupportedAssociationError, "caching association scoped with a join isn't supported"
+        end
         options[:inverse_name] ||= association_reflection.inverse_of.name if association_reflection.inverse_of
         options[:inverse_name] ||= self.name.underscore.to_sym
-        child_class = association_reflection.klass
         raise InverseAssociationError unless child_class.reflect_on_association(options[:inverse_name])
         unless options[:embed] == true || child_class.include?(IdentityCache)
           raise UnsupportedAssociationError, "associated class #{child_class} must include IdentityCache to be cached without full embedding"

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -101,6 +101,14 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     end
   end
 
+  def test_unsupported_joins_in_assocation_scope
+    assert_raises IdentityCache::UnsupportedAssociationError, "caching association scoped with a join isn't supported" do
+      scope = -> { joins(:associated_records).where(associated_record: { name: 'contrived example' }) }
+      Item.has_many :deeply_joined_associated_records, scope, class_name: 'DeeplyAssociatedRecord'
+      Item.cache_has_many :deeply_joined_associated_records, :embed => true
+    end
+  end
+
   def test_cache_has_many_on_derived_model_raises
     assert_raises(IdentityCache::DerivedModelError) do
       StiRecordTypeA.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => true


### PR DESCRIPTION
@Thibaut & @richardmonette for review

## Problem

I caught an attempt to cache an association that was scoped with a join in Shopify, which wouldn't have been properly invalidated if the joined table changed.  We should check for this when attempting to cache these associations and raise an exception so that we don't catch this problem in production, which would be hard to debug.

## Solution

Apply the scope to the associated class, then check to see if the relation has any `joins_values`