### PR TITLE
Delay association scope check out of initialization.

### DIFF
--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -11,6 +11,7 @@ module IdentityCache
       schema_string = schema_to_string(klass.columns)
       if klass.include?(IdentityCache)
         klass.send(:all_cached_associations).sort.each do |name, options|
+          klass.send(:check_association_scope, name)
           case options[:embed]
           when true
             schema_string << ",#{name}:(#{denormalized_schema_hash(options[:association_reflection].klass)})"

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -291,13 +291,9 @@ module IdentityCache
         if association_reflection.options[:through]
           raise UnsupportedAssociationError, "caching through associations isn't supported"
         end
-        child_class = association_reflection.klass
-        scope = association_reflection.scope
-        if scope && !child_class.all.instance_exec(&scope).joins_values.empty?
-          raise UnsupportedAssociationError, "caching association scoped with a join isn't supported"
-        end
         options[:inverse_name] ||= association_reflection.inverse_of.name if association_reflection.inverse_of
         options[:inverse_name] ||= self.name.underscore.to_sym
+        child_class = association_reflection.klass
         raise InverseAssociationError unless child_class.reflect_on_association(options[:inverse_name])
         unless options[:embed] == true || child_class.include?(IdentityCache)
           raise UnsupportedAssociationError, "associated class #{child_class} must include IdentityCache to be cached without full embedding"

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -109,6 +109,14 @@ module IdentityCache
         end
       end
 
+      def check_association_scope(association_name)
+        association_reflection = reflect_on_association(association_name)
+        scope = association_reflection.scope
+        if scope && !association_reflection.klass.all.instance_exec(&scope).joins_values.empty?
+          raise UnsupportedAssociationError, "caching association #{self}.#{association_name} scoped with a join isn't supported"
+        end
+      end
+
       def record_from_coder(coder) #:nodoc:
         if coder
           klass = coder[:class]

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -94,24 +94,29 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     child.save!
   end
 
-  def test_unsupported_through_assocation
-    assert_raises IdentityCache::UnsupportedAssociationError, "caching through associations isn't supported" do
-      Item.has_many :deeply_through_associated_records, :through => :associated_records, foreign_key: 'associated_record_id', inverse_of: :item, :class_name => 'DeeplyAssociatedRecord'
-      Item.cache_has_many :deeply_through_associated_records, :embed => true
+  class CheckAssociationTest < IdentityCache::TestCase
+    def test_unsupported_through_assocation
+      assert_raises IdentityCache::UnsupportedAssociationError, "caching through associations isn't supported" do
+        Item.has_many :deeply_through_associated_records, :through => :associated_records, foreign_key: 'associated_record_id', inverse_of: :item, :class_name => 'DeeplyAssociatedRecord'
+        Item.cache_has_many :deeply_through_associated_records, :embed => true
+      end
     end
-  end
 
-  def test_unsupported_joins_in_assocation_scope
-    assert_raises IdentityCache::UnsupportedAssociationError, "caching association scoped with a join isn't supported" do
-      scope = -> { joins(:associated_records).where(associated_record: { name: 'contrived example' }) }
-      Item.has_many :deeply_joined_associated_records, scope, class_name: 'DeeplyAssociatedRecord'
+    def test_unsupported_joins_in_assocation_scope
+      scope = -> { joins(:associated_record).where(associated_records: { name: 'contrived example' }) }
+      Item.has_many :deeply_joined_associated_records, scope, inverse_of: :item, class_name: 'DeeplyAssociatedRecord'
       Item.cache_has_many :deeply_joined_associated_records, :embed => true
-    end
-  end
 
-  def test_cache_has_many_on_derived_model_raises
-    assert_raises(IdentityCache::DerivedModelError) do
-      StiRecordTypeA.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => true
+      message = "caching association Item.deeply_joined_associated_records scoped with a join isn't supported"
+      assert_raises IdentityCache::UnsupportedAssociationError, message do
+        Item.fetch(1)
+      end
+    end
+
+    def test_cache_has_many_on_derived_model_raises
+      assert_raises(IdentityCache::DerivedModelError) do
+        StiRecordTypeA.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => true
+      end
     end
   end
 end


### PR DESCRIPTION
@richardmonette & @Thibaut for review
cc @fw42

## Problem

https://github.com/Shopify/identity_cache/pull/259 broke Shopify production container builds since it uses a dummy database configuration and active record makes schema queries when building a relation.  That means we can't really check the cached association when it is defined.

## Solution

I moved the check into the cache key generation, since that is done just before reading or writing to the cache.