### PR TITLE
Avoid re-fetching a cache_belongs_to association in prefetch_associations

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -359,9 +359,12 @@ module IdentityCache
               raise ArgumentError.new("Polymorphic belongs_to associations do not support prefetching yet.")
             end
 
+            cached_iv_name = :"@#{details.fetch(:records_variable_name)}"
             ids_to_child_record = records.each_with_object({}) do |child_record, hash|
               parent_id = child_record.send(reflection.foreign_key)
-              hash[parent_id] = child_record if parent_id.present?
+              if parent_id && !child_record.instance_variable_defined?(cached_iv_name)
+                hash[parent_id] = child_record
+              end
             end
             parent_records = reflection.klass.fetch_multi(ids_to_child_record.keys)
             parent_records.each do |parent_record|

--- a/test/prefetch_associations_test.rb
+++ b/test/prefetch_associations_test.rb
@@ -72,6 +72,39 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
     end
   end
 
+  def test_prefetch_associations_cached_belongs_to
+    Item.send(:cache_belongs_to, :item)
+    @bob.update_attributes!(item_id: @joe.id)
+    @joe.update_attributes!(item_id: @fred.id)
+    @bob.fetch_item
+    @joe.fetch_item
+    items = [@bob, @joe].map(&:reload)
+
+    assert_no_queries do
+      assert_memcache_operations(1) do
+        Item.prefetch_associations(:item, items)
+      end
+      assert_memcache_operations(0) do
+        items.each { |item| item.fetch_item }
+      end
+      assert_memcache_operations(0) do
+        Item.prefetch_associations(:item, items)
+      end
+    end
+  end
+
+  def test_prefetch_associations_with_nil_cached_belongs_to
+    Item.send(:cache_belongs_to, :item)
+    @bob.update_attributes!(item_id: 1234)
+    assert_equal nil, @bob.fetch_item
+
+    assert_no_queries do
+      assert_memcache_operations(0) do
+        Item.prefetch_associations(:item, [@bob])
+      end
+    end
+  end
+
   def test_fetch_with_includes_option
     Item.send(:cache_belongs_to, :item)
     john = Item.create!(title: 'john')


### PR DESCRIPTION
@boourns & @eapache for review

## Problem

There was a bug in prefetch_associations (introduced in pull #252) where it didn't check if a cache_belongs_to association was already fetched before fetching it, so the association can end up being double fetched.

## Solution

Check if the instance variable that holds the cached record has been set and avoid calling fetch_multi to get it if it is there.