### PR TITLE
fix(prefetch_associations): Avoid exists query on a collection proxy.

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -75,6 +75,7 @@ module IdentityCache
       end
 
       def prefetch_associations(associations, records)
+        records = records.to_a
         return if records.empty?
         unless IdentityCache.should_use_cache?
           if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0


### PR DESCRIPTION
@boourns & @eapache for review

## Problem

When passing an unloaded association (i.e. a ActiveRecord::Associations::CollectionProxy object) directly into `prefetch_associations` as the records parameter, the `records.empty?` check causes an `exists?` query.  This is useless query, since the association is still going to be loaded after that empty check.

## Solution

Convert `records` to an array to avoid the extra query.