### PR TITLE
fix(prefetch_associations): Preload using database in a transaction.

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -76,6 +76,14 @@ module IdentityCache
 
       def prefetch_associations(associations, records)
         return if records.empty?
+        unless IdentityCache.should_use_cache?
+          if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0
+            ActiveRecord::Associations::Preloader.new(records, associations).run
+          else
+            ActiveRecord::Associations::Preloader.new.preload(records, associations)
+          end
+          return
+        end
 
         case associations
         when nil


### PR DESCRIPTION
@boourns & @eapache for review

## Problem

If prefetch_associations gets called in a transaction, then it would load the associations from the cache and store them in an instance variable that the cached accessors (i.e. `fetch_#{association}`) wouldn't use inside the transaction.  This will also lead to an N+1 when the code uses it with the assumption that the cached associations are loaded.

## Solution

Use active record to preload the associations when `IdentityCache.should_use_cache?` returns false.