### PR TITLE
Use instance_variable_defined? instead of storing mapped nils

### DIFF
--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -21,7 +21,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
     assert_equal [@baz.id, @bar.id], @record.instance_variable_get(variable_name)
 
     @record.reload
-    assert_equal nil, @record.instance_variable_get(variable_name)
+    assert_equal false, @record.instance_variable_defined?(variable_name)
 
     @record.fetch_associated_record_ids
     assert_equal [@baz.id, @bar.id], @record.instance_variable_get(variable_name)
@@ -36,7 +36,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
     assert_equal [@baz, @bar], @record.instance_variable_get(variable_name)
 
     @record.reload
-    assert_equal nil, @record.instance_variable_get(variable_name)
+    assert_equal false, @record.instance_variable_defined?(variable_name)
 
     @record.fetch_associated_records
     assert_equal [@baz, @bar], @record.instance_variable_get(variable_name)


### PR DESCRIPTION
For issue #163 and pull #265
cc @hirocaster

@rafaelfranca please review

We needed to distinguish between `nil` and uncached in the response to memcache queries by storing a special symbol instead of `nil` in memcached.  However, we don't need to do the same thing when storing cached values in instance variables, since an undefined instance variable can represent an unloaded value.

This should also help reduce warnings when running with `ruby -w` that `rake` now uses by default, since we won't be accessing these instance variables before they are defined.