### PR TITLE
Copy attributes hash before writing memoized cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # IdentityCache changelog
 
+#### Unreleased
+
+- Stop sharing the same attributes hash between the fetched record and the memoized cache, which could interfere with dirty tracking
+
 #### 0.3.1
 
 - Fix cache_index for non-id primary key

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -164,7 +164,7 @@ module IdentityCache
       def coder_from_record(record) #:nodoc:
         unless record.nil?
           coder = {
-            attributes: record.attributes_before_type_cast,
+            attributes: record.attributes_before_type_cast.dup,
             class: record.class,
           }
           add_cached_associations_to_coder(record, coder)

--- a/test/memoized_attributes_test.rb
+++ b/test/memoized_attributes_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class MemoizedAttributesTest < IdentityCache::TestCase
+  def test_memoization_should_not_break_dirty_tracking_with_empty_cache
+    item = Item.create!
+
+    IdentityCache.cache.with_memoization do
+      Item.fetch(item.id).title = "my title"
+      Item.fetch(item.id).update!(title: "my title")
+    end
+
+    assert_equal "my title", Item.find(item.id).title
+  end
+
+  def test_memoization_should_not_break_dirty_tracking_with_filled_cache
+    item = Item.create!
+
+    IdentityCache.cache.with_memoization do
+      Item.fetch(item.id)
+      Item.fetch(item.id).title = "my title"
+      Item.fetch(item.id).update!(title: "my title")
+    end
+
+    assert_equal "my title", Item.find(item.id).title
+  end
+
+  def test_memoization_with_fetch_multi_should_not_break_dirty_tracking_with_empty_cache
+    item = Item.create!
+
+    IdentityCache.cache.with_memoization do
+      Item.fetch_multi(item.id).first.title = "my title"
+      Item.fetch_multi(item.id).first.update!(title: "my title")
+    end
+
+    assert_equal "my title", Item.find(item.id).title
+  end
+
+  def test_memoization_with_fetch_multi_should_not_break_dirty_tracking_with_filled_cache
+    item = Item.create!
+
+    IdentityCache.cache.with_memoization do
+      Item.fetch_multi(item.id)
+      Item.fetch_multi(item.id).first.title = "my title"
+      Item.fetch_multi(item.id).first.update!(title: "my title")
+    end
+
+    assert_equal "my title", Item.find(item.id).title
+  end
+end


### PR DESCRIPTION
These tests will fail if [the code that copies the attributes hash before instantiating the model](https://github.com/Shopify/identity_cache/blob/v0.3.1/lib/identity_cache/query_api.rb#L88) is removed.

Removing that code would cause multiple records to share an attributes hash when memoization is enabled, which would break dirty tracking. This was the case in versions before v0.3.0: https://github.com/Shopify/identity_cache/issues/246