### PR TITLE
Fix id mismatch check for string primary keys.

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -26,7 +26,9 @@ module IdentityCache
             object = nil
             coder = IdentityCache.fetch(rails_cache_key(id)){ coder_from_record(object = resolve_cache_miss(id)) }
             object ||= record_from_coder(coder)
-            IdentityCache.logger.error "[IDC id mismatch] fetch_by_id_requested=#{id} fetch_by_id_got=#{object.id} for #{object.inspect[(0..100)]} " if object && object.id != id.to_i
+            if object && object.id.to_s != id.to_s
+              IdentityCache.logger.error "[IDC id mismatch] fetch_by_id_requested=#{id} fetch_by_id_got=#{object.id} for #{object.inspect[(0..100)]}"
+            end
             object
           end
         else


### PR DESCRIPTION
@camilo 

Fixes #270

Coerce integers to strings rather than coercing string to integers for the mismatch check.