### PR TITLE
Using cache when within a transaction if already loaded

### DIFF
--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -34,12 +34,12 @@ module IdentityCache
         foreign_key = options[:association_reflection].foreign_key
         self.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
           def #{options[:cached_accessor_name]}
-            if IdentityCache.should_use_cache? && #{foreign_key}.present? && !association(:#{association}).loaded?
-              if instance_variable_defined?(:@#{options[:records_variable_name]})
-                @#{options[:records_variable_name]}
-              else
-                @#{options[:records_variable_name]} = association(:#{association}).klass.fetch_by_id(#{foreign_key})
-              end
+            if association(:#{association}).loaded? || #{foreign_key}.blank?
+              #{association}
+            elsif instance_variable_defined?(:@#{options[:records_variable_name]})
+              @#{options[:records_variable_name]}
+            elsif IdentityCache.should_use_cache?
+              @#{options[:records_variable_name]} = association(:#{association}).klass.fetch_by_id(#{foreign_key})
             else
               #{association}
             end


### PR DESCRIPTION
I don't have the full context, but it is my understanding we do not want to send the cache backend destructive request while within a transaction for fear of corrupting with an operation that would never be commit on mysql.

We are hitting some code behaviours that are hard to diagnose and counter intuitive in active record callback code paths (those that imply transactions)

Here would be the current behaviour without these changes:
```ruby
class Brand < ActiveRecord::Base
end

class Car < ActiveRecord::Base
  include IdentityCache

  belongs_to :brand
  cache_belongs_to :brand
end
```

```ruby
brand = Brand.create!(color: 'red')
car = Car.create!(brand: brand)

car.fetch_brand
# Attempt to load from cache, IDC miss then MySql
car.fetch_brand
# Attempt to load from cache, IDC hit

Car.transaction do
  car.fetch_brand
end
# Attempt to load directly from MySql, even if IDC cache is present (IdentityCache.should_use_cache? is false)
```

This lead to extra mysql calls for no reasons.

A "worst" example would be where you want to load data from IDC to edit it. 
```ruby
brand = Brand.create!(color: 'red')
car = Car.create!(brand: brand)

car.fetch_brand.color = 'green'
puts car.fetch_brand.color
=> 'green'

Car.transaction do
  puts car.fetch_brand.color
end
=> 'red'
```
It somewhat counter intuitive to "rollback" the cached relation to a state pre-transaction.

Is there any pitfalls to use the cache if already populated even within a transaction? Is there a proper work around?

Thoughts? @dylanahsmith @chrisdonaldson 
cc: @christianblais 