### PR TITLE
Configurable fetch association behaviour [return array/relation]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # IdentityCache changelog
 
-#### Unreleased
+#### 0.3.2
 
-- Stop sharing the same attributes hash between the fetched record and the memoized cache, which could interfere with dirty tracking
+- Fetch association returns relation or array depending on the configuration. It was only returning a relation for cache_has_many fetch association methods. (#276)
+- Stop sharing the same attributes hash between the fetched record and the memoized cache, which could interfere with dirty tracking (#267)
 
 #### 0.3.1
 

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -40,6 +40,9 @@ module IdentityCache
     mattr_accessor :cache_namespace
     self.cache_namespace = "IDC:#{CACHE_VERSION}:".freeze
 
+    mattr_accessor :fetch_returns_relation
+    self.fetch_returns_relation = true
+
     def included(base) #:nodoc:
       raise AlreadyIncludedError if base.include?(IdentityCache::ConfigurationDSL)
 
@@ -129,6 +132,14 @@ module IdentityCache
       end
 
       result
+    end
+
+    def with_fetch_returns_relation(value = true)
+      previous_value = self.fetch_returns_relation
+      self.fetch_returns_relation = value
+      yield
+    ensure
+      self.fetch_returns_relation = previous_value
     end
 
     private

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -236,7 +236,11 @@ module IdentityCache
             if IdentityCache.should_use_cache? || #{association}.loaded?
               @#{options[:records_variable_name]} ||= #{options[:association_reflection].klass}.fetch_multi(#{options[:cached_ids_name]})
             else
-              #{association}
+              if IdentityCache.fetch_returns_relation
+                #{association}
+              else
+                #{association}.to_a
+              end
             end
           end
 

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -156,7 +156,7 @@ module IdentityCache
 
       def get_embedded_association(record, association, options) #:nodoc:
         embedded_variable = record.public_send(options.fetch(:cached_accessor_name))
-        if record.class.reflect_on_association(association).collection?
+        if embedded_variable.respond_to?(:to_ary)
           embedded_variable.map {|e| coder_from_record(e) }
         else
           coder_from_record(embedded_variable)
@@ -398,7 +398,7 @@ module IdentityCache
     private
 
     def fetch_recursively_cached_association(ivar_name, association_name) # :nodoc:
-      if IdentityCache.should_use_cache?
+      assoc = if IdentityCache.should_use_cache?
         ivar_full_name = :"@#{ivar_name}"
 
         if instance_variable_defined?(ivar_full_name)
@@ -409,6 +409,8 @@ module IdentityCache
       else
         send(association_name.to_sym)
       end
+      assoc = assoc.to_ary if assoc.respond_to?(:to_ary) && !IdentityCache.fetch_returns_relation
+      assoc
     end
 
     def expire_primary_index # :nodoc:

--- a/lib/identity_cache/version.rb
+++ b/lib/identity_cache/version.rb
@@ -1,4 +1,4 @@
 module IdentityCache
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
   CACHE_VERSION = 6
 end

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -195,4 +195,11 @@ class NormalizedHasManyTest < IdentityCache::TestCase
     @not_cached.save!
   end
 
+  def test_fetch_association_does_not_allow_chaining_when_fetch_returns_array
+    IdentityCache.with_fetch_returns_relation(false) do
+      check = proc { assert_equal false, Item.fetch(@record.id).fetch_associated_records.respond_to?(:where) }
+      2.times { check.call } # for miss and hit
+      Item.transaction { check.call }
+    end
+  end
 end


### PR DESCRIPTION
Fetch association to return array or relation

@dylanahsmith & @tjoyal for review/thoughts. Cc @camilo 

## Problem

There is an [open PR](https://github.com/Shopify/identity_cache/pull/224) that prevents chaining by having fetch association to return an array. However, it was never merged since it requires changes on the Shopify side. The idea of this PR to have a version where fetch association returns an array but also supports the current behaviour, i.e. returning a relation. This will allow us to replace these relations dependencies gradually on the Shopify side while having the correct IDC default behaviour.

Once everything is cleaned up, we will plan a major release that only returns arrays.

## Solution

By default, return an Array from the fetch association method rather than a relation to prevent chaining.  Any time we need to support the old behaviour, use `IdentityCache.allow_fetch_to_return_relation` around the block. 

A first test was done on [this shopify branch](https://github.com/Shopify/shopify/compare/bump-IDC) to confirm that [tests pass](https://buildkite.com/shopify/shopify-branches/builds/112661) with these changes.  `IdentityCache.allow_fetch_to_return_relation`  will be used around tests that still depend on relations returned by fetch_association.