### PR TITLE
Consistently store the collection proxy for has many associations

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -146,7 +146,7 @@ module IdentityCache
           association = reflection.association_class.new(record, reflection)
           association.target = coder_or_array.map {|e| record_from_coder(e) }
           association.target.each {|e| association.set_inverse_instance(e) }
-          association
+          association.reader
         else
           record_from_coder(coder_or_array)
         end
@@ -401,13 +401,11 @@ module IdentityCache
       if IdentityCache.should_use_cache?
         ivar_full_name = :"@#{ivar_name}"
 
-        assoc = if instance_variable_defined?(ivar_full_name)
+        if instance_variable_defined?(ivar_full_name)
           instance_variable_get(ivar_full_name)
         else
           instance_variable_set(ivar_full_name, send(association_name))
         end
-
-        assoc.is_a?(ActiveRecord::Associations::CollectionAssociation) ? assoc.reader : assoc
       else
         send(association_name.to_sym)
       end


### PR DESCRIPTION
@daniellaniyo & @tjoyal for review, cc @camilo 

## Problem

IdentityCache::QueryApi#get_embedded_association was storing an active record collection proxy in the cached association instance variable, but IdentityCache::QueryApi#set_embedded_association was storing the association itself.  This resulted in an otherwise unnecessary `.is_a?(ActiveRecord::Associations::CollectionAssociation)` when using that instance variable.

## Solution

Store `association.reader` in set_embedded_association so the collection proxy is always stored for cache has many associations