### PR TITLE
Deprecate setting the inverse active record association on cache hit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### 0.3.2
 
-- Deprecate setting the inverse active record association on cache hits. Set IdentityCache.never_set_inverse_association to true to avoid this.
+- Deprecate setting the inverse active record association on cache hits. Set IdentityCache.never_set_inverse_association to true to avoid this. (#279)
 - Fetch association returns relation or array depending on the configuration. It was only returning a relation for cache_has_many fetch association methods. (#276)
 - Stop sharing the same attributes hash between the fetched record and the memoized cache, which could interfere with dirty tracking (#267)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 0.3.2
 
+- Deprecate setting the inverse active record association on cache hits. Set IdentityCache.never_set_inverse_association to true to avoid this.
 - Fetch association returns relation or array depending on the configuration. It was only returning a relation for cache_has_many fetch association methods. (#276)
 - Stop sharing the same attributes hash between the fetched record and the memoized cache, which could interfere with dirty tracking (#267)
 

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -45,7 +45,7 @@ module IdentityCache
     # fetch_#{association} for a cache_has_many association returns a relation
     # when fetch_returns_relation is set to true and an array when set to false.
     mattr_accessor :fetch_returns_relation
-    self.fetch_returns_relation = version >= Gem::Version.new("0.4")
+    self.fetch_returns_relation = version < Gem::Version.new("0.4")
 
     # Inverse active record associations are set when loading embedded
     # cache_has_many associations from the cache when never_set_inverse_association

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -40,8 +40,18 @@ module IdentityCache
     mattr_accessor :cache_namespace
     self.cache_namespace = "IDC:#{CACHE_VERSION}:".freeze
 
+    version = Gem::Version.new(IdentityCache::VERSION)
+
+    # fetch_#{association} for a cache_has_many association returns a relation
+    # when fetch_returns_relation is set to true and an array when set to false.
     mattr_accessor :fetch_returns_relation
-    self.fetch_returns_relation = true
+    self.fetch_returns_relation = version >= Gem::Version.new("0.4")
+
+    # Inverse active record associations are set when loading embedded
+    # cache_has_many associations from the cache when never_set_inverse_association
+    # is false. When set to true, it will only set the inverse cached association.
+    mattr_accessor :never_set_inverse_association
+    self.never_set_inverse_association = version >= Gem::Version.new("0.4")
 
     def included(base) #:nodoc:
       raise AlreadyIncludedError if base.include?(IdentityCache::ConfigurationDSL)
@@ -140,6 +150,14 @@ module IdentityCache
       yield
     ensure
       self.fetch_returns_relation = previous_value
+    end
+
+    def with_never_set_inverse_association(value = true)
+      old_value = self.never_set_inverse_association
+      self.never_set_inverse_association = value
+      yield
+    ensure
+      self.never_set_inverse_association = old_value
     end
 
     private

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -139,6 +139,18 @@ module IdentityCache
         end
       end
 
+      def set_inverse_of_cached_has_many(record, association_reflection, child_records)
+        associated_class = association_reflection.klass
+        return unless associated_class < IdentityCache
+
+        inverse_name = record.class.cached_has_manys.fetch(association_reflection.name).fetch(:inverse_name)
+        inverse_cached_association = associated_class.cached_belongs_tos[inverse_name]
+        return unless inverse_cached_association
+
+        prepopulate_method_name = inverse_cached_association.fetch(:prepopulate_method_name)
+        child_records.each { |child_record| child_record.send(prepopulate_method_name, record) }
+      end
+
       def set_embedded_association(record, association_name, coder_or_array) #:nodoc:
         value = if IdentityCache.unmap_cached_nil_for(coder_or_array).nil?
           nil
@@ -146,14 +158,7 @@ module IdentityCache
           association = reflection.association_class.new(record, reflection)
           association.target = coder_or_array.map {|e| record_from_coder(e) }
 
-          if reflection.klass < IdentityCache
-            inverse_association_name = record.class.cached_has_manys.fetch(association_name).fetch(:inverse_name)
-            cached_inverse_association = reflection.klass.cached_belongs_tos[inverse_association_name]
-            if cached_inverse_association
-              prepopulate_method_name = cached_inverse_association.fetch(:prepopulate_method_name)
-              association.target.each { |child_record| child_record.send(prepopulate_method_name, record) }
-            end
-          end
+          set_inverse_of_cached_has_many(record, reflection, association.target)
 
           unless IdentityCache.never_set_inverse_association
             association.target.each {|e| association.set_inverse_instance(e) }

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -119,7 +119,27 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
       2.times { check.call } # for miss and hit
       Item.transaction { check.call }
     end
-  end  
+  end
+
+  def test_never_set_inverse_association_on_cache_hit
+    Item.fetch(@record.id) # warm cache
+
+    item = IdentityCache.with_never_set_inverse_association do
+      Item.fetch(@record.id)
+    end
+
+    associated_record = item.fetch_associated_records.to_a.first
+    assert item.object_id != associated_record.item.object_id
+  end
+
+  def test_deprecated_set_inverse_association_on_cache_hit
+    Item.fetch(@record.id) # warm cache
+
+    item = Item.fetch(@record.id)
+
+    associated_record = item.fetch_associated_records.to_a.first
+    assert_equal item.object_id, associated_record.item.object_id
+  end
 
   class CheckAssociationTest < IdentityCache::TestCase
     def test_unsupported_through_assocation

--- a/test/recursive_denormalized_has_many_test.rb
+++ b/test/recursive_denormalized_has_many_test.rb
@@ -88,6 +88,22 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
     @deeply_associated_record.save!
   end
 
+  def test_set_inverse_associations
+    DeeplyAssociatedRecord.cache_belongs_to :associated_record
+    AssociatedRecord.cache_belongs_to :item
+    Item.fetch(@record.id) # warm cache
+
+    item = Item.fetch(@record.id)
+
+    assert_queries(0) do
+      assert_memcache_operations(0) do
+        associated_record = item.fetch_associated_records.to_a.first
+        deeply_associated_record = associated_record.fetch_deeply_associated_records.first
+        assert_equal item.id, deeply_associated_record.fetch_associated_record.fetch_item.id
+      end
+    end
+  end
+
 end
 
 class RecursiveNormalizedHasManyTest < IdentityCache::TestCase


### PR DESCRIPTION
@daniellaniyo & @camilo for review

## Problem

I noticed that we were doing `association.target.each {|e| association.set_inverse_instance(e) }` on a cache hit, which meant we were setting the active record association rather than just the cached association.

This is inconsistent with our philosophy of requiring code to explicitly use identity cache, since code like `associated_record.item` can implicitly return a cached record rather than requiring `associated_record.fetch_item`.  This could result in cache corruption accidentally being persisted to the database if the record retrieved through the belongs_to association is saved.

I'm not sure how often this is actually a problem in practice.  That will probably be easier to see once https://github.com/Shopify/identity_cache/issues/274 is implemented.

## Solution

Fixing this would be a breaking change, in fact it will cause test failures in Shopify, so I added IdentityCache.never_set_inverse_association which can be set to true to get the correct behaviour.  In that case it will still set the inverse cached association so `associated_record.item` can be changed to `associated_record.fetch_item` to avoid extra database queries.