### PR TITLE
Use loaded association first when fetching a cache_has_many association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 0.3.2
 
+- Use loaded association first when fetching a cache_has_many id embedded association
 - Deprecate setting the inverse active record association on cache hits. Set IdentityCache.never_set_inverse_association to true to avoid this. (#279)
 - Fetch association returns relation or array depending on the configuration. It was only returning a relation for cache_has_many fetch association methods. (#276)
 - Stop sharing the same attributes hash between the fetched record and the memoized cache, which could interfere with dirty tracking (#267)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### 0.3.2
 
-- Use loaded association first when fetching a cache_has_many id embedded association
+- Use loaded association first when fetching a cache_has_many id embedded association (#280)
 - Deprecate setting the inverse active record association on cache hits. Set IdentityCache.never_set_inverse_association to true to avoid this. (#279)
 - Fetch association returns relation or array depending on the configuration. It was only returning a relation for cache_has_many fetch association methods. (#276)
 - Stop sharing the same attributes hash between the fetched record and the memoized cache, which could interfere with dirty tracking (#267)

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -233,7 +233,7 @@ module IdentityCache
           end
 
           def #{options[:cached_accessor_name]}
-            if IdentityCache.should_use_cache? || #{association}.loaded?
+            if IdentityCache.should_use_cache? && !#{association}.loaded?
               @#{options[:records_variable_name]} ||= #{options[:association_reflection].klass}.fetch_multi(#{options[:cached_ids_name]})
             else
               if IdentityCache.fetch_returns_relation

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -10,6 +10,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
     @record.save
     @record.reload
     @baz, @bar = @record.associated_records[0], @record.associated_records[1]
+    @record.reload
   end
 
   def test_reload_invalidate_cached_ids

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -46,14 +46,14 @@ class CacheInvalidationTest < IdentityCache::TestCase
   def test_after_a_reload_the_cache_perform_as_expected
     Item.cache_has_many :associated_records, :embed => :ids
 
-    assert_equal [@baz, @bar], @record.associated_records
     assert_equal [@baz, @bar], @record.fetch_associated_records
+    assert_equal [@baz, @bar], @record.associated_records
 
     @baz.destroy
     @record.reload
 
-    assert_equal [@bar], @record.associated_records
     assert_equal [@bar], @record.fetch_associated_records
+    assert_equal [@bar], @record.associated_records
   end
 
   def test_cache_invalidation_expire_properly_if_child_is_embed_in_multiple_parents

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -111,9 +111,10 @@ class NormalizedHasManyTest < IdentityCache::TestCase
   def test_fetching_the_association_should_delegate_to_the_normal_association_fetcher_if_any_transaction_are_open
     @record = Item.fetch(@record.id)
 
-    Item.expects(:fetch_multi).never
-    @record.transaction do
-      assert_equal [@baz, @bar], @record.fetch_associated_records
+    assert_memcache_operations(0) do
+      @record.transaction do
+        assert_equal [@baz, @bar], @record.fetch_associated_records
+      end
     end
   end
 
@@ -121,8 +122,9 @@ class NormalizedHasManyTest < IdentityCache::TestCase
     # Warm the ActiveRecord association
     @record.associated_records.to_a
 
-    Item.expects(:fetch_multi).never
-    assert_equal [@baz, @bar], @record.fetch_associated_records
+    assert_memcache_operations(0) do
+      assert_equal [@baz, @bar], @record.fetch_associated_records
+    end
   end
 
   def test_saving_a_child_record_shouldnt_expire_the_parents_blob_if_the_foreign_key_hasnt_changed


### PR DESCRIPTION
@daniellaniyo & @csfrancis for review

## Problem

`fetch_#{association}` on a cache_has_many `embed: :ids` association would use the cached association even if the active record association was already loaded.  This can result in an unnecessary query if the cached association wasn't already loaded.  Also, if the active record association was modified, then the stale cached association would get returned.

Lastly, it the cached association would be used if the active record association was loaded and `IdentityCache.should_use_cache?` returns false, which is definitely not desirable.

## Solution

Fixed the condition so that the cached association is only used when using the cache *and* the association is *not* loaded.

There was a test for this intended behaviour, but it was expecting fetch_multi to not be called on the wrong model.  Using `assert_memcache_operations(0)` will catch regressions in a non-fragile way.