### PR TITLE
Remove support for rails 4.0 and 4.1 since they aren't supported upsteam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ rvm:
   - 2.2.3
 
 gemfile:
-  - Gemfile.rails40
-  - Gemfile.rails41
   - Gemfile.rails42
 
 env:

--- a/Gemfile.rails40
+++ b/Gemfile.rails40
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-gemspec
-
-gem 'activerecord', '~> 4.0.4'
-gem 'activesupport', '~> 4.0.4'
-gem 'mysql2', '~> 0.3.13'

--- a/Gemfile.rails41
+++ b/Gemfile.rails41
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-gemspec
-
-gem 'activerecord', '~> 4.1.0'
-gem 'activesupport', '~> 4.1.0'
-gem 'mysql2', '~> 0.3.13'

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |gem|
   gem.version       = IdentityCache::VERSION
 
   gem.add_dependency('ar_transaction_changes', '~> 1.0')
-  gem.add_dependency('activerecord', '>= 4.0.4')
-  gem.add_development_dependency('memcached', '~> 1.8.0')
+  gem.add_dependency('activerecord', '>= 4.2.0')
 
+  gem.add_development_dependency('memcached', '~> 1.8.0')
   gem.add_development_dependency('memcached_store', '~> 0.12.6')
   gem.add_development_dependency('rake')
   gem.add_development_dependency('mocha', '0.14.0')

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -80,11 +80,7 @@ module IdentityCache
         records = records.to_a
         return if records.empty?
         unless IdentityCache.should_use_cache?
-          if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0
-            ActiveRecord::Associations::Preloader.new(records, associations).run
-          else
-            ActiveRecord::Associations::Preloader.new.preload(records, associations)
-          end
+          ActiveRecord::Associations::Preloader.new.preload(records, associations)
           return
         end
 


### PR DESCRIPTION
@rafaelfranca & @fbogsany for review

It looks like only rails 4.2 and 5.0 are supported (http://guides.rubyonrails.org/maintenance_policy.html) so we should drop support for rails versions that aren't even supported upstream for severe security issues.