### PR TITLE
Fix tests for rails 5.0 with mysql and add it to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,14 @@ rvm:
 
 gemfile:
   - Gemfile.rails42
+  - Gemfile.rails50
+
+matrix:
+  exclude:
+    - rvm: 2.1
+      gemfile: Gemfile.rails50
+    - gemfile: Gemfile.rails50
+      env: DB=postgresql
 
 env:
   - DB=mysql2

--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'activerecord', '~> 5.0.0'
+gem 'activesupport', '~> 5.0.0'
+gem 'mysql2', '>= 0.3.18', '< 0.5'

--- a/test/helpers/database_connection.rb
+++ b/test/helpers/database_connection.rb
@@ -57,7 +57,8 @@ module DatabaseConnection
       'adapter'  => 'postgresql',
       'database' => 'identity_cache_test',
       'host'     => ENV['POSTGRES_HOST'] || '127.0.0.1',
-      'username' => 'postgres'
+      'username' => 'postgres',
+      'prepared_statements' => false,
     }
   }
 end

--- a/test/prefetch_associations_test.rb
+++ b/test/prefetch_associations_test.rb
@@ -18,8 +18,8 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
     Item.send(:cache_belongs_to, :item)
     john = Item.create!(:title => 'john')
     jim = Item.create!(:title => 'jim')
-    @bob.update_column(:item_id, john)
-    @joe.update_column(:item_id, jim)
+    @bob.update_column(:item_id, john.id)
+    @joe.update_column(:item_id, jim.id)
     items = Item.fetch_multi(@bob.id, @joe.id, @fred.id)
 
     spy = Spy.on(Item, :fetch_multi).and_call_through
@@ -127,7 +127,7 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
   def test_fetch_with_includes_option
     Item.send(:cache_belongs_to, :item)
     john = Item.create!(title: 'john')
-    @bob.update_column(:item_id, john)
+    @bob.update_column(:item_id, john.id)
 
     spy = Spy.on(Item, :fetch_multi).and_call_through
 
@@ -140,8 +140,8 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
     Item.send(:cache_belongs_to, :item)
     john = Item.create!(:title => 'john')
     jim = Item.create!(:title => 'jim')
-    @bob.update_column(:item_id, john)
-    @joe.update_column(:item_id, jim)
+    @bob.update_column(:item_id, john.id)
+    @joe.update_column(:item_id, jim.id)
 
     spy = Spy.on(Item, :fetch_multi).and_call_through
 
@@ -309,7 +309,7 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
     Item.send(:cache_belongs_to, :item)
     Item.cache_index :title
     john = Item.create!(title: 'john')
-    @bob.update_column(:item_id, john)
+    @bob.update_column(:item_id, john.id)
 
     spy = Spy.on(Item, :fetch_multi).and_call_through
 
@@ -322,7 +322,7 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
     Item.send(:cache_belongs_to, :item)
     Item.cache_index :title, :unique => true
     john = Item.create!(title: 'john')
-    @bob.update_column(:item_id, john)
+    @bob.update_column(:item_id, john.id)
 
     spy = Spy.on(Item, :fetch_multi).and_call_through
 


### PR DESCRIPTION
@sgrif & @rafaelfranca for review

CI wasn't running tests for Rails 5.0, so there are some failures.  Most of the failures just required some tests to be updated.

There is still a test failure for rails 5.0 with postgresql which I haven't had the time to dig into yet, so decided to exclude it for now so we can get CI coverage for rails 5.0 mysql.  The failure was for the serialization format, which should be independent of rails now, but apparently isn't.  We are using `attributes_before_type_cast` and the same version of the pg gem with rails 5.0, but the type of the "id" values changed from a string to an integer.