### PR TITLE
New version 0.4.0 - Fetch association returns an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # IdentityCache changelog
 
+#### 0.4.0
+
+- Return an array from fetched association to prevent chaining. Up to now, a relation was returned by default. (#287)
+
 #### 0.3.2
 
 - Deprecate returning non read-only records when cache is used. Set IdentityCache.fetch_readonly_records to true to avoid this. (#282)

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -42,11 +42,6 @@ module IdentityCache
 
     version = Gem::Version.new(IdentityCache::VERSION)
 
-    # fetch_#{association} for a cache_has_many association returns a relation
-    # when fetch_returns_relation is set to true and an array when set to false.
-    mattr_accessor :fetch_returns_relation
-    self.fetch_returns_relation = version < Gem::Version.new("0.4")
-
     # Inverse active record associations are set when loading embedded
     # cache_has_many associations from the cache when never_set_inverse_association
     # is false. When set to true, it will only set the inverse cached association.
@@ -148,14 +143,6 @@ module IdentityCache
       end
 
       result
-    end
-
-    def with_fetch_returns_relation(value = true)
-      previous_value = self.fetch_returns_relation
-      self.fetch_returns_relation = value
-      yield
-    ensure
-      self.fetch_returns_relation = previous_value
     end
 
     def with_never_set_inverse_association(value = true)

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -51,13 +51,13 @@ module IdentityCache
     # cache_has_many associations from the cache when never_set_inverse_association
     # is false. When set to true, it will only set the inverse cached association.
     mattr_accessor :never_set_inverse_association
-    self.never_set_inverse_association = version >= Gem::Version.new("0.4")
+    self.never_set_inverse_association = version >= Gem::Version.new("0.5")
 
     # Fetched records are not read-only and this could sometimes prevent IDC from
     # reflecting what's truly in the database when fetch_read_only_records is false.
     # When set to true, it will only return read-only records when cache is used.
     mattr_accessor :fetch_read_only_records
-    self.fetch_read_only_records = version >= Gem::Version.new("0.4")
+    self.fetch_read_only_records = version >= Gem::Version.new("0.5")
 
     def included(base) #:nodoc:
       raise AlreadyIncludedError if base.include?(IdentityCache::ConfigurationDSL)

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -236,11 +236,7 @@ module IdentityCache
             if IdentityCache.should_use_cache? && !#{association}.loaded?
               @#{options[:records_variable_name]} ||= #{options[:association_reflection].klass}.fetch_multi(#{options[:cached_ids_name]})
             else
-              if IdentityCache.fetch_returns_relation
-                #{association}
-              else
-                #{association}.to_a
-              end
+              #{association}.to_a
             end
           end
 

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -435,7 +435,7 @@ module IdentityCache
       else
         send(association_name.to_sym)
       end
-      assoc = assoc.to_ary if assoc.respond_to?(:to_ary) && !IdentityCache.fetch_returns_relation
+      assoc = assoc.to_ary if assoc.respond_to?(:to_ary)
       assoc
     end
 

--- a/lib/identity_cache/version.rb
+++ b/lib/identity_cache/version.rb
@@ -1,4 +1,4 @@
 module IdentityCache
-  VERSION = "0.3.2"
+  VERSION = "0.4.0"
   CACHE_VERSION = 6
 end

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -12,12 +12,9 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     @record.reload
   end
 
-  def test_uncached_record_from_the_db_should_come_back_with_association_array_when_fetch_returns_array
-    IdentityCache.with_fetch_returns_relation(false) do    
-      assert_equal IdentityCache.fetch_returns_relation, false
-      record_from_db = Item.find(@record.id)
-      assert_equal Array, record_from_db.fetch_associated_records.class
-    end
+  def test_uncached_record_from_the_db_should_come_back_with_association_array
+    record_from_db = Item.find(@record.id)
+    assert_equal Array, record_from_db.fetch_associated_records.class
   end
 
   def test_uncached_record_from_the_db_will_use_normal_association
@@ -30,15 +27,12 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     assert_equal expected, record_from_db.fetch_associated_records
   end
 
-  def test_on_cache_hit_record_should_come_back_with_cached_association_array_when_fetch_returns_array
-    IdentityCache.with_fetch_returns_relation(false) do  
-      assert_equal IdentityCache.fetch_returns_relation, false
-      Item.fetch(@record.id) # warm cache
+  def test_on_cache_hit_record_should_come_back_with_cached_association_array
+    Item.fetch(@record.id) # warm cache
 
-      record_from_cache_hit = Item.fetch(@record.id)
-      assert_equal @record, record_from_cache_hit
-      assert_equal Array, record_from_cache_hit.fetch_associated_records.class
-    end
+    record_from_cache_hit = Item.fetch(@record.id)
+    assert_equal @record, record_from_cache_hit
+    assert_equal Array, record_from_cache_hit.fetch_associated_records.class
   end
 
   def test_on_cache_hit_record_should_come_back_with_cached_association
@@ -113,12 +107,10 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     child.save!
   end
 
-  def test_fetch_association_does_not_allow_chaining_when_fetch_returns_array
-    IdentityCache.with_fetch_returns_relation(false) do
-      check = proc { assert_equal false, Item.fetch(@record.id).fetch_associated_records.respond_to?(:where) }
-      2.times { check.call } # for miss and hit
-      Item.transaction { check.call }
-    end
+  def test_fetch_association_does_not_allow_chaining
+    check = proc { assert_equal false, Item.fetch(@record.id).fetch_associated_records.respond_to?(:where) }
+    2.times { check.call } # for miss and hit
+    Item.transaction { check.call }
   end
 
   def test_never_set_inverse_association_on_cache_hit

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -197,12 +197,10 @@ class NormalizedHasManyTest < IdentityCache::TestCase
     @not_cached.save!
   end
 
-  def test_fetch_association_does_not_allow_chaining_when_fetch_returns_array
-    IdentityCache.with_fetch_returns_relation(false) do
-      check = proc { assert_equal false, Item.fetch(@record.id).fetch_associated_records.respond_to?(:where) }
-      2.times { check.call } # for miss and hit
-      Item.transaction { check.call }
-    end
+  def test_fetch_association_does_not_allow_chaining
+    check = proc { assert_equal false, Item.fetch(@record.id).fetch_associated_records.respond_to?(:where) }
+    2.times { check.call } # for miss and hit
+    Item.transaction { check.call }
   end
 
   def test_returned_records_should_be_readonly_on_cache_hit


### PR DESCRIPTION
@fbogsany & @dylanahsmith for review. Cc @camilo 

Bumping the gem version to 0.4.0. Fetch association no longer returns a relation; but rather an array. This will prevent chaining in the future. 

This PR follows https://github.com/Shopify/identity_cache/pull/276 where the `fetch_returns_relation` behavior was made configurable. Also note that this should not cause any break on the shopify side since core is already running with `IdentityCache.fetch_return_relation=false`