### PR TITLE
Consistently store the array for cached has many associations

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -486,7 +486,7 @@ module IdentityCache
     end
 
     def readonly_copy(record_or_records)
-      if record_or_records.respond_to?(:to_ary)
+      if record_or_records.is_a?(Array)
         record_or_records.map { |record| readonly_record_copy(record) }
       elsif record_or_records
         readonly_record_copy(record_or_records)

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -21,7 +21,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     expected = @record.associated_records
     record_from_db = Item.find(@record.id)
 
-    Item.any_instance.expects(:associated_records).returns(expected)
+    Item.any_instance.expects(:association).with(:associated_records).returns(expected)
 
     assert_equal @record, record_from_db
     assert_equal expected, record_from_db.fetch_associated_records
@@ -42,7 +42,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     assert_equal @record, record_from_cache_hit
 
     expected = @record.associated_records
-    Item.any_instance.expects(:associated_records).never
+    Item.any_instance.expects(:association).with(:associated_records).never
     assert_equal expected, record_from_cache_hit.fetch_associated_records
   end
 


### PR DESCRIPTION
@daniellaniyo, @rafaelfranca for review
cc @csfrancis, @camilo

## Problem

This is a second try at solving the inconsistency that #277 attempted to address.  However, that PR was reverted because it was instantiating the collection proxy instances when associations were loaded from the cache rather than lazily when they were accessed, which was causing a significant performance impact.

## Solution

Thanks to @daniellaniyo's work with making `fetch_#{association_name}` cache has many methods return an array instead of a collection proxy, we no longer need to store the cached association as a collection proxy in the instance variable.  Now we can just store an array of records loaded from the cache.

Also, we can get a performance improvement by using `association(association_name).load_target` to load the array using the association without instantiating a collection proxy object.

## CPU Benchmark

### master

```
FindRunner:                             0.850000   0.040000   0.890000 (  1.715479)
FetchEmbedMissRunner:                   2.340000   0.060000   2.400000 (  3.328042)
FetchEmbedHitRunner:                    2.300000   0.060000   2.360000 (  3.280951)
FetchEmbedDeletedRunner:                2.300000   0.060000   2.360000 (  3.287030)
FetchEmbedConflictRunner:               2.520000   0.060000   2.580000 (  3.531867)
FetchEmbedDeletedConflictRunner:        2.520000   0.060000   2.580000 (  3.514359)
FetchNormalizedMissRunner:              3.050000   0.080000   3.130000 (  4.109704)
FetchNormalizedHitRunner:               3.060000   0.080000   3.140000 (  4.106677)
FetchNormalizedDeletedRunner:           2.960000   0.070000   3.030000 (  3.972951)
FetchNormalizedConflictRunner:          2.440000   0.060000   2.500000 (  3.408446)
FetchNormalizedDeletedConflictRunner:   2.430000   0.050000   2.480000 (  3.408808)
```

### this branch

```
FindRunner:                             0.800000   0.040000   0.840000 (  1.639428)
FetchEmbedMissRunner:                   1.540000   0.050000   1.590000 (  2.462227)
FetchEmbedHitRunner:                    1.520000   0.050000   1.570000 (  2.447718)
FetchEmbedDeletedRunner:                1.540000   0.060000   1.600000 (  2.457482)
FetchEmbedConflictRunner:               1.710000   0.050000   1.760000 (  2.644591)
FetchEmbedDeletedConflictRunner:        1.710000   0.060000   1.770000 (  2.628639)
FetchNormalizedMissRunner:              2.790000   0.070000   2.860000 (  3.775260)
FetchNormalizedHitRunner:               2.800000   0.080000   2.880000 (  3.767972)
FetchNormalizedDeletedRunner:           2.810000   0.070000   2.880000 (  3.782054)
FetchNormalizedConflictRunner:          1.710000   0.050000   1.760000 (  2.621399)
FetchNormalizedDeletedConflictRunner:   1.710000   0.050000   1.760000 (  2.628674)
```