### PR TITLE
Move should_use_cache? calls to the model-level

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -8,6 +8,7 @@ require 'identity_cache/belongs_to_caching'
 require 'identity_cache/cache_key_generation'
 require 'identity_cache/configuration_dsl'
 require 'identity_cache/parent_model_expiration'
+require 'identity_cache/should_use_cache'
 require 'identity_cache/query_api'
 require "identity_cache/cache_hash"
 require "identity_cache/cache_invalidation"
@@ -63,6 +64,7 @@ module IdentityCache
       base.send(:include, IdentityCache::ConfigurationDSL)
       base.send(:include, IdentityCache::QueryAPI)
       base.send(:include, IdentityCache::CacheInvalidation)
+      base.send(:include, IdentityCache::ShouldUseCache)
     end
 
     # Sets the cache adaptor IdentityCache will be using

--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -34,14 +34,15 @@ module IdentityCache
         foreign_key = options[:association_reflection].foreign_key
         self.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
           def #{options[:cached_accessor_name]}
-            if IdentityCache.should_use_cache? && #{foreign_key}.present? && !association(:#{association}).loaded?
+            association_klass = association(:#{association}).klass
+            if association_klass.should_use_cache? && #{foreign_key}.present? && !association(:#{association}).loaded?
               if instance_variable_defined?(:@#{options[:records_variable_name]})
                 @#{options[:records_variable_name]}
               else
-                @#{options[:records_variable_name]} = association(:#{association}).klass.fetch_by_id(#{foreign_key})
+                @#{options[:records_variable_name]} = association_klass.fetch_by_id(#{foreign_key})
               end
             else
-              if IdentityCache.fetch_read_only_records && IdentityCache.should_use_cache?
+              if IdentityCache.fetch_read_only_records && association_klass.should_use_cache?
                 load_and_readonlyify(:#{association})
               else
                 #{association}

--- a/lib/identity_cache/should_use_cache.rb
+++ b/lib/identity_cache/should_use_cache.rb
@@ -1,0 +1,11 @@
+module IdentityCache
+  module ShouldUseCache
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def should_use_cache?
+        IdentityCache.should_use_cache?
+      end
+    end
+  end
+end

--- a/test/attribute_cache_test.rb
+++ b/test/attribute_cache_test.rb
@@ -97,4 +97,14 @@ class AttributeCacheTest < IdentityCache::TestCase
       StiRecordTypeA.cache_attribute :name
     end
   end
+
+  def test_cache_attribute_respects_should_use_cache
+    AssociatedRecord.stubs(:should_use_cache?).returns(false)
+
+    assert_queries(1) do
+      assert_memcache_operations(0) do
+        AssociatedRecord.fetch_name_by_id(@record.id)
+      end
+    end
+  end
 end

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -244,4 +244,15 @@ class FetchTest < IdentityCache::TestCase
       end
     end
   end
+
+  def test_respects_should_use_cache_on_record
+    @record.save
+    Item.stubs(:should_use_cache?).returns(false)
+
+    assert_memcache_operations(0) do
+      assert_queries(1) do
+        Item.fetch_by_id(@record.id)
+      end
+    end
+  end
 end

--- a/test/normalized_belongs_to_test.rb
+++ b/test/normalized_belongs_to_test.rb
@@ -84,4 +84,15 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
       end
     end
   end
+
+  def test_respects_should_use_cache_on_parent
+    @record.reload
+    @parent_record.class.stubs(:should_use_cache?).returns(false)
+
+    assert_queries(1) do
+      assert_memcache_operations(0) do
+        @record.fetch_item
+      end
+    end
+  end
 end

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -217,4 +217,15 @@ class NormalizedHasManyTest < IdentityCache::TestCase
       assert record_from_cache_miss.fetch_associated_records.all?(&:readonly?)
     end
   end
+
+  def test_respects_should_use_cache_on_association
+    @record.reload
+    AssociatedRecord.stubs(:should_use_cache?).returns(false)
+
+    assert_queries(1) do
+      assert_memcache_operations(0) do
+        @record.fetch_associated_records
+      end
+    end
+  end
 end


### PR DESCRIPTION
I'd like to be able to override `#should_use_cache?` on specific models to have domain-specific logic to decide whether the cache should be used. This is the minimal change to the code to support such a use-case through method overriding.

The tests are not great, I'm not super familiar with IDC. I can definitely dig more into this.

Please review @dylanahsmith @fbogsany @daniellaniyo

cc @Shopify/pods 

<hr/>

In my case, I have multiple databases in my application. When a particular database connection is to a delayed read-slave, I would like to disable IDC, both reads and writes. While I could continue to perform reads with IDC, my objective is to move off of IDC for the models for this database. Using delayed read-slaves and IDC together is complicated—I'd like to transition to only using the read-slave iteratively. However, before I can disable IDC completely, this is key for me to be able to override as the model may sometimes be used from a readonly context (don't use IDC) and sometimes from a writer context (sure, use IDC).

```ruby
class Shop < ActiveRecord::Base
  include IdentityCache

  def should_use_cache?
     !read_only_connection? && IdentityCache.should_use_cache? 
  end
end

with_read_only_connection do
  Shop.fetch_by_id(12) # will never hit IDC
end

Shop.fetch_by_id(12) # will hit IDC
```

<details>
<summary>**Why did you not do the same for `#should_fill_cache?`.** </summary>
For my use-case for transitioning models off of IDC, it doesn't make sense to continue filling the cache when I am not going to use it eventually. 

Another reason is that if I just disable filling the cache, I will have a situation where after the 4 hour default expiry all the cache entires will expire and my load will be significantly different. Instead of noticing that 4 hours later, I would much rather it be instant while I'm monitoring the rollout.

Even though I don't need it personally, it could make sense to support it, however, the `CacheFetcher` is the only user of this and it doesn't have access to the model. I don't want to start passing down the model or a boolean on every call unnecessarily.
</details>

<details>
  <summary>**Why support this by overriding a public method and not an official API?**</summary>
Instead of providing an interface that allows overriding the method, we could instead expose an API such as:

```ruby
class Shop < ActiveRecord::Base
  include IdentityCache
  self.should_use_cache = -> { !read_only_connection }
end
```

However, this seems like such an obscure use-case to support publicly that I think structuring the code in a way that makes it possible is more important than providing it as a first-class citizen. Especially given the only use-case that has surfaced is for migration purposes.
</details>