### PR TITLE
Clone instead of dup record when readonlyifying fetched records

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -480,7 +480,7 @@ module IdentityCache
     end
 
     def readonly_record_copy(record)
-      record = record.dup
+      record = record.clone
       record.readonly!
       record
     end


### PR DESCRIPTION
Uses clone to copy record for the readonlyifying process.

@dylanahsmith @camilo  for review/thoughts. Cc @fbogsany 

## Problem
In PR #282, we used `dup` to duplicate records before marking them as read-only in order for IDC to return read-only records while not keeping the original AR records writeable. While `dup` allows us to achieve our goal, it is does not return an id, or copy associations. This therefore limits us in several ways.

## Solution
Use `clone` when duplicating the record to be saved. Although both `clone` and `dup` produce shallow copies, `clone` preserves the record id and points to the original hash. In terms of performance, there is no significant observed impact; however using `clone` is slightly better since it does not require copying the attributes hash.

## CPU Benchmark

**On master**
```
FindRunner:                             0.890000   0.050000   0.940000 (  1.946726)
FetchEmbedMissRunner:                   1.710000   0.080000   1.790000 (  2.911759)
FetchEmbedHitRunner:                    1.710000   0.070000   1.780000 (  2.913428)
FetchEmbedDeletedRunner:                1.720000   0.070000   1.790000 (  2.928007)
FetchEmbedConflictRunner:               1.930000   0.080000   2.010000 (  3.150560)
FetchEmbedDeletedConflictRunner:        1.950000   0.080000   2.030000 (  3.179978)
FetchNormalizedMissRunner:              3.150000   0.100000   3.250000 (  4.452420)
FetchNormalizedHitRunner:               3.180000   0.100000   3.280000 (  4.473870)
FetchNormalizedDeletedRunner:           3.220000   0.100000   3.320000 (  4.526194)
FetchNormalizedConflictRunner:          2.000000   0.080000   2.080000 (  3.218922)
FetchNormalizedDeletedConflictRunner:   2.070000   0.070000   2.140000 (  3.294581)
```

**On this branch**
```
FindRunner:                             0.880000   0.060000   0.940000 (  1.952732)
FetchEmbedMissRunner:                   1.710000   0.080000   1.790000 (  2.923782)
FetchEmbedHitRunner:                    1.680000   0.080000   1.760000 (  2.896092)
FetchEmbedDeletedRunner:                1.720000   0.080000   1.800000 (  2.925751)
FetchEmbedConflictRunner:               1.910000   0.080000   1.990000 (  3.133682)
FetchEmbedDeletedConflictRunner:        1.930000   0.080000   2.010000 (  3.147736)
FetchNormalizedMissRunner:              3.180000   0.100000   3.280000 (  4.494991)
FetchNormalizedHitRunner:               3.150000   0.100000   3.250000 (  4.451123)
FetchNormalizedDeletedRunner:           3.200000   0.100000   3.300000 (  4.497655)
FetchNormalizedConflictRunner:          2.010000   0.080000   2.090000 (  3.237587)
FetchNormalizedDeletedConflictRunner:   2.020000   0.080000   2.100000 (  3.258054)
```