### PR TITLE
Support multiple databases and transactional tests in IdentityCache.should_use_cache?

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -105,8 +105,9 @@ module IdentityCache
     end
 
     def should_use_cache? # :nodoc:
-      pool = ActiveRecord::Base.connection_pool
-      !pool.active_connection? || pool.connection.open_transactions == 0
+      ActiveRecord::Base.connection_handler.connection_pool_list.all? do |pool|
+        !pool.active_connection? || pool.connection.open_transactions == 0
+      end
     end
 
     # Cache retrieval and miss resolver primitive; given a key it will try to

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -105,8 +105,26 @@ module IdentityCache
     end
 
     def should_use_cache? # :nodoc:
-      ActiveRecord::Base.connection_handler.connection_pool_list.all? do |pool|
-        !pool.active_connection? || pool.connection.open_transactions == 0
+      ActiveRecord::Base.connection_handler.connection_pool_list.none? do |pool|
+        pool.active_connection? &&
+          # Rails wraps each of your tests in a transaction, so that any changes
+          # made to the database during the test can be rolled back afterwards.
+          # These transactions are flagged as "unjoinable", which tries to make
+          # your application behave as if they weren't there. In particular:
+          #
+          #  - Opening another transaction during the test creates a savepoint,
+          #    which can be rolled back independently of the main transaction.
+          #  - When those nested transactions complete, any `after_commit`
+          #    callbacks for records modified during the transaction will run,
+          #    even though the changes haven't actually been committed yet.
+          #
+          # By ignoring unjoinable transactions, IdentityCache's behaviour
+          # during your test suite will more closely match production.
+          #
+          # When there are no open transactions, `current_transaction` returns a
+          # special `NullTransaction` object that is unjoinable, meaning we will
+          # use the cache.
+          pool.connection.current_transaction.joinable?
       end
     end
 

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -191,24 +191,28 @@ class FetchMultiTest < IdentityCache::TestCase
   end
 
   def test_fetch_multi_with_open_transactions_hits_the_database
-    Item.connection.expects(:open_transactions).at_least_once.returns(1)
-    fetcher.expects(:fetch_multi).never
-    assert_equal([@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id))
+    Item.transaction do
+      fetcher.expects(:fetch_multi).never
+      assert_equal([@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id))
+    end
   end
 
   def test_fetch_multi_with_open_transactions_returns_results_in_the_order_of_the_passed_ids
-    Item.connection.expects(:open_transactions).at_least_once.returns(1)
-    assert_equal([@joe, @bob, @fred], Item.fetch_multi(@joe.id, @bob.id, @fred.id))
+    Item.transaction do
+      assert_equal([@joe, @bob, @fred], Item.fetch_multi(@joe.id, @bob.id, @fred.id))
+    end
   end
 
   def test_fetch_multi_with_open_transactions_should_compacts_returned_array
-    Item.connection.expects(:open_transactions).at_least_once.returns(1)
-    assert_equal([@joe, @fred], Item.fetch_multi(@joe.id, 0, @fred.id))
+    Item.transaction do
+      assert_equal([@joe, @fred], Item.fetch_multi(@joe.id, 0, @fred.id))
+    end
   end
 
   def test_fetch_multi_with_duplicate_ids_in_transaction_returns_results_in_the_order_of_the_passed_ids
-    Item.connection.expects(:open_transactions).at_least_once.returns(1)
-    assert_equal([@joe, @bob, @joe], Item.fetch_multi(@joe.id, @bob.id, @joe.id))
+    Item.transaction do
+      assert_equal([@joe, @bob, @joe], Item.fetch_multi(@joe.id, @bob.id, @joe.id))
+    end
   end
 
   def test_load_multi_from_db_coerces_ids_to_primary_key_type

--- a/test/identity_cache_test.rb
+++ b/test/identity_cache_test.rb
@@ -9,6 +9,10 @@ class IdentityCacheTest < IdentityCache::TestCase
   class BadModel < BadModelBase
   end
 
+  class ModelWithConnection < ActiveRecord::Base
+    establish_connection ActiveRecord::Base.connection_config
+  end
+
   def test_identity_cache_raises_if_loaded_twice
     assert_raises(IdentityCache::AlreadyIncludedError) do
       BadModel.class_eval do
@@ -23,6 +27,12 @@ class IdentityCacheTest < IdentityCache::TestCase
 
   def test_should_use_cache_in_transaction
     ActiveRecord::Base.transaction do
+      assert_equal false, IdentityCache.should_use_cache?
+    end
+  end
+
+  def test_should_use_cache_in_transaction_on_specific_model
+    ModelWithConnection.transaction do
       assert_equal false, IdentityCache.should_use_cache?
     end
   end

--- a/test/identity_cache_test.rb
+++ b/test/identity_cache_test.rb
@@ -9,16 +9,46 @@ class IdentityCacheTest < IdentityCache::TestCase
   class BadModel < BadModelBase
   end
 
-  class ModelWithConnection < ActiveRecord::Base
-    establish_connection ActiveRecord::Base.connection_config
-  end
-
   def test_identity_cache_raises_if_loaded_twice
     assert_raises(IdentityCache::AlreadyIncludedError) do
       BadModel.class_eval do
         include IdentityCache
       end
     end
+  end
+end
+
+class IdentityCacheWithTransactionalFixturesTest < ActiveSupport::TestCase
+  include ActiveRecord::TestFixtures
+  self.use_transactional_tests = true
+
+  class ModelWithConnection < ActiveRecord::Base
+    establish_connection ActiveRecord::Base.connection_config
+  end
+
+  def test_should_use_cache_outside_transaction
+    assert_equal(true, IdentityCache.should_use_cache?)
+  end
+
+  def test_should_use_cache_in_transaction
+    ActiveRecord::Base.transaction do
+      assert_equal false, IdentityCache.should_use_cache?
+    end
+  end
+
+  def test_should_use_cache_in_transaction_on_specific_model
+    ModelWithConnection.transaction do
+      assert_equal false, IdentityCache.should_use_cache?
+    end
+  end
+end
+
+class IdentityCacheWithoutTransactionalFixturesTest < ActiveSupport::TestCase
+  include ActiveRecord::TestFixtures
+  self.use_transactional_tests = false
+
+  class ModelWithConnection < ActiveRecord::Base
+    establish_connection ActiveRecord::Base.connection_config
   end
 
   def test_should_use_cache_outside_transaction


### PR DESCRIPTION
This implements both features described in https://github.com/Shopify/identity_cache/issues/274#issuecomment-227975692:
### Check for open transactions on all connection pools

IdentityCache disables cache reads inside transactions to try to prevent inconsistent cached data from being written back into the database.

When an application uses multiple databases, we need to check for open transactions on all of them; otherwise we could read stale data from a record stored in one database and write it into another database.
### Ignore the top level transaction in transactional tests

An unjoinable transaction forces any transactions nested inside it to behave as if they were at the top level: `after_commit` callbacks for records modified during the nested transaction will be executed when it commits, even though the updated data won't be visible to other connections until the outer transaction has also committed.

Rails creates unjoinable transactions in two places: in the sandbox console, and around transactional tests. In both of these cases, the user expects their code to behave as if the transaction wasn't there; with this change, IdentityCache will conform to that expectation by only disabling cache reads inside joinable transactions.

IdentityCache currently never reads from the cache during transactional tests, since there is always at least one transaction open. With this change transactional tests behave more like production code, which will help catch issues like updating a record that came from the cache.
