### PR TITLE
Fix fetching already loaded belongs_to association

### DIFF
--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -43,7 +43,7 @@ module IdentityCache
               end
             else
               if IdentityCache.fetch_read_only_records && association_klass.should_use_cache?
-                load_and_readonlyify(:#{association})
+                readonly_copy(association(:#{association}).load_target)
               else
                 #{association}
               end

--- a/test/normalized_belongs_to_test.rb
+++ b/test/normalized_belongs_to_test.rb
@@ -76,6 +76,15 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
     end
   end
 
+  def test_db_returned_record_should_never_be_readonly
+    IdentityCache.with_fetch_read_only_records do
+      uncached_record = @record.item
+      refute uncached_record.readonly?
+      @record.fetch_item
+      refute uncached_record.readonly?
+    end
+  end
+
   def test_returned_record_with_open_transactions_should_not_be_readonly
     IdentityCache.with_fetch_read_only_records do
       Item.transaction do


### PR DESCRIPTION
This path was missed when `load_and_readonlyify` was refactored into `readonly_copy` in https://github.com/Shopify/identity_cache/pull/288, and there was no test covering the behaviour.