### PR TITLE
Move delete failure detection to the cache fetcher.

### DIFF
--- a/lib/identity_cache/cache_fetcher.rb
+++ b/lib/identity_cache/cache_fetcher.rb
@@ -11,7 +11,9 @@ module IdentityCache
     end
 
     def delete(key)
-      @cache_backend.write(key, IdentityCache::DELETED, :expires_in => IdentityCache::DELETED_TTL.seconds)
+      result = @cache_backend.write(key, IdentityCache::DELETED, expires_in: IdentityCache::DELETED_TTL.seconds)
+      IdentityCache.logger.debug { "[IdentityCache] delete #{ result ? 'recorded' : 'failed' } for #{key}" }
+      result
     end
 
     def clear

--- a/lib/identity_cache/fallback_fetcher.rb
+++ b/lib/identity_cache/fallback_fetcher.rb
@@ -11,7 +11,9 @@ module IdentityCache
     end
 
     def delete(key)
-      @cache_backend.delete(key)
+      result = @cache_backend.delete(key)
+      IdentityCache.logger.debug { "[IdentityCache] delete for #{key}" }
+      result
     end
 
     def clear

--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -36,9 +36,7 @@ module IdentityCache
 
     def delete(key)
       memoized_key_values.delete(key) if memoizing?
-      result = @cache_fetcher.delete(key)
-      IdentityCache.logger.debug { "[IdentityCache] delete #{ result ? 'recorded'  : 'failed'  } for #{key}" }
-      result
+      @cache_fetcher.delete(key)
     end
 
     def fetch(key)


### PR DESCRIPTION
@daniellaniyo, @Sirupsen please review

Fixes #211

## Problem

IdentityCache::MemoizedCacheProxy#delete was assuming the delete failed if cache_fetcher.delete returned falsey.  However, that falsey value could either mean the memcached request failed or the key wasn't present, and different cache stores aren't consistent about whether `nil` or `false` means as a return value for their delete method as I detailed in https://github.com/Shopify/identity_cache/issues/211#issuecomment-137626605.

This was confusing because we were logging something like `[IdentityCache] delete failed for IDC:5:blob:App:18240036282024875059:41` which sounds like a probably with expiring the cache, but it could just mean that the value wasn't cached yet.

## Solution

If IdentityCache::MemoizedCacheProxy#cache_fetcher is an IdentityCache::CacheFetcher, then it writes a IdentityCache::DELETED value instead of using a delete memcached request.  In that case the return value isn't as ambiguous, it just returns falsey if the request failed.  So, I was able to move the failure detection into IdentityCache::CacheFetcher#delete where we can rely on it and put a generic `[IdentityCache] delete for #{key}` message in IdentityCache::FallbackFetcher#delete.