### PR TITLE
Avoid querying when no ids are passed to fetch_multi

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -299,6 +299,8 @@ module IdentityCache
       end
 
       def find_batch(ids)
+        return [] if ids.empty?
+
         @id_column ||= columns.detect {|c| c.name == primary_key}
         ids = ids.map{ |id| connection.type_cast(id, @id_column) }
         records = where(primary_key => ids).includes(cache_fetch_includes).to_a

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -265,6 +265,16 @@ class FetchMultiTest < IdentityCache::TestCase
     end
   end
 
+  def test_fetch_multi_with_no_keys_does_not_query_when_cache_is_disabled
+    Item.stubs(:should_use_cache?).returns(false)
+
+    assert_queries(0) do
+      assert_memcache_operations(0) do
+        Item.fetch_multi
+      end
+    end
+  end
+
   private
 
   def populate_only_fred


### PR DESCRIPTION
When `should_use_cache?` is false, and no ids are passed to `fetch_multi` on the model, we unnecessarily send an impossible query. ActiveRecord generates something like `SELECT ... WHERE 1=0`. May as well avoid the roundtrip, like `IdentityCache.fetch_multi` does [here](https://github.com/Shopify/identity_cache/blob/e5e0edf653d1295964134a732a854231357be47a/lib/identity_cache.rb#L131).

@dylanahsmith @Sirupsen @fw42 