### PR TITLE
Rescue RangeError and return RecordNotFound instead

### DIFF
--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -53,6 +53,9 @@ module IdentityCache
             def fetch_by_#{field_list}(#{arg_list}, options={})
               id = fetch_id_by_#{field_list}(#{arg_list})
               id && fetch_by_id(id, options)
+
+            rescue RangeError
+              raise ActiveRecord::RecordNotFound
             end
 
             # exception throwing variant

--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -153,6 +153,13 @@ class IndexCacheTest < IdentityCache::TestCase
     assert_equal 123, KeyedRecord.fetch_by_value('a').id
   end
 
+  def test_cache_index_raises_when_range_error
+    Item.cache_index :title, :id, unique: true
+    assert_raises(ActiveRecord::RecordNotFound) do
+      assert_equal @record.id, Item.fetch_by_title_and_id!("title", "1111111111111111111111111111111")
+    end
+  end
+
   private
 
   def cache_key(unique: false)


### PR DESCRIPTION
This rescues the RangeErrors that keep happening all over Shopify (customers, checkout, etc) and instead raises the more appropriate `RecordNotFound` error instead. Example issue: https://github.com/Shopify/shopify/issues/81204

cc @PhilibertDugas @nikixiaoyou @dylanahsmith 