### PR TITLE
refactor: Include modules into IdentityCache instead into models

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -69,6 +69,7 @@ module IdentityCache
       raise AlreadyIncludedError if base.respond_to?(:cached_model)
       base.class_attribute :cached_model
       base.cached_model = base
+      super
     end
 
     # Sets the cache adaptor IdentityCache will be using

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -7,8 +7,8 @@ require 'identity_cache/memoized_cache_proxy'
 require 'identity_cache/belongs_to_caching'
 require 'identity_cache/cache_key_generation'
 require 'identity_cache/configuration_dsl'
-require 'identity_cache/parent_model_expiration'
 require 'identity_cache/should_use_cache'
+require 'identity_cache/parent_model_expiration'
 require 'identity_cache/query_api'
 require "identity_cache/cache_hash"
 require "identity_cache/cache_invalidation"
@@ -16,6 +16,16 @@ require "identity_cache/cache_fetcher"
 require "identity_cache/fallback_fetcher"
 
 module IdentityCache
+  extend ActiveSupport::Concern
+
+  include ArTransactionChanges
+  include IdentityCache::BelongsToCaching
+  include IdentityCache::CacheKeyGeneration
+  include IdentityCache::ConfigurationDSL
+  include IdentityCache::QueryAPI
+  include IdentityCache::CacheInvalidation
+  include IdentityCache::ShouldUseCache
+
   CACHED_NIL = :idc_cached_nil
   BATCH_SIZE = 1000
   DELETED = :idc_cached_deleted
@@ -56,15 +66,9 @@ module IdentityCache
     self.fetch_read_only_records = version >= Gem::Version.new("0.5")
 
     def included(base) #:nodoc:
-      raise AlreadyIncludedError if base.include?(IdentityCache::ConfigurationDSL)
-
-      base.send(:include, ArTransactionChanges) unless base.include?(ArTransactionChanges)
-      base.send(:include, IdentityCache::BelongsToCaching)
-      base.send(:include, IdentityCache::CacheKeyGeneration)
-      base.send(:include, IdentityCache::ConfigurationDSL)
-      base.send(:include, IdentityCache::QueryAPI)
-      base.send(:include, IdentityCache::CacheInvalidation)
-      base.send(:include, IdentityCache::ShouldUseCache)
+      raise AlreadyIncludedError if base.respond_to?(:cached_model)
+      base.class_attribute :cached_model
+      base.cached_model = base
     end
 
     # Sets the cache adaptor IdentityCache will be using

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -3,13 +3,11 @@ module IdentityCache
     extend ActiveSupport::Concern
 
     included do |base|
-      base.class_attribute :cached_model
       base.class_attribute :cache_indexes
       base.class_attribute :cached_has_manys
       base.class_attribute :cached_has_ones
       base.class_attribute :primary_cache_index_enabled
 
-      base.cached_model = base
       base.cached_has_manys = {}
       base.cached_has_ones = {}
       base.cache_indexes = []
@@ -273,10 +271,7 @@ module IdentityCache
       def add_parent_expiry_hook(options)
         child_class = options[:association_reflection].klass
 
-        child_class.send(:include, ArTransactionChanges) unless child_class.include?(ArTransactionChanges)
-        child_class.send(:include, ParentModelExpiration) unless child_class.include?(ParentModelExpiration)
-        child_class.send(:include, ShouldUseCache) unless child_class.respond_to?(:should_use_cache?)
-
+        child_class.send(:include, ParentModelExpiration)
         child_class.parent_expiration_entries[options[:inverse_name]] << [self, options[:only_on_foreign_key_change]]
 
         child_class.after_commit :expire_parent_caches

--- a/lib/identity_cache/parent_model_expiration.rb
+++ b/lib/identity_cache/parent_model_expiration.rb
@@ -2,6 +2,9 @@ module IdentityCache
   module ParentModelExpiration # :nodoc:
     extend ActiveSupport::Concern
 
+    include ArTransactionChanges
+    include IdentityCache::ShouldUseCache
+
     included do |base|
       base.class_attribute :parent_expiration_entries
       base.parent_expiration_entries = Hash.new{ |hash, key| hash[key] = [] }

--- a/test/identity_cache_test.rb
+++ b/test/identity_cache_test.rb
@@ -2,13 +2,16 @@ require "test_helper"
 
 class IdentityCacheTest < IdentityCache::TestCase
 
-  class BadModel < ActiveRecord::Base
+  class BadModelBase < ActiveRecord::Base
+    include IdentityCache
+  end
+
+  class BadModel < BadModelBase
   end
 
   def test_identity_cache_raises_if_loaded_twice
     assert_raises(IdentityCache::AlreadyIncludedError) do
       BadModel.class_eval do
-        include IdentityCache
         include IdentityCache
       end
     end


### PR DESCRIPTION
## Problem

When looking at https://github.com/Shopify/identity_cache/pull/302 I was noticing how much of an unnecessary mess our module includes are in IdentityCache.  We were doing a lot of dynamic module inclusions in included blocks/methods to handle module dependancies when this is something that ActiveSupport::Concern can handle for us.

I would like this refactored to make the code more readable.

## Solution

Just include the module dependancies directly in the IdentityCache module rather than doing it dynamically.  We don't need to check if a module is already included because ruby won't insert a module into the ancestors for a class multiple times and ActiveSupport::Concern will only call the included block for module dependancies once even if the module is included multiple times.

I also tried to make the purpose for the AlreadyIncluded error more clear by modifying the test to use an actual problematic example where IdentityCache is included into the base and derived model.  For the same reason I also co-located the code to setup cached_model along with the AlreadyIncluded check.