### PR TITLE
Deprecated embedded associations on models that don't use IDC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 
 rvm:
-  - '2.2.3'
-  - '2.3.1'
+  - '2.2.6'
+  - '2.3.3'
 
 gemfile:
   - Gemfile.rails42

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ IdentityCache.cache_backend = ActiveSupport::Cache.lookup_store(*Rails.configura
 ### Basic Usage
 
 ``` ruby
+class Image < ActiveRecord::Base
+  include IdentityCache::WithoutPrimaryIndex
+end
+
 class Product < ActiveRecord::Base
   include IdentityCache
 
@@ -44,10 +48,10 @@ class Product < ActiveRecord::Base
   cache_has_many :images, :embed => true
 end
 
-# Fetch the product by its id, the primary index.
+# Fetch the product by its id using the primary primary index as well as the embedded images association.
 @product = Product.fetch(id)
 
-# Fetch the images for the Product. Images are embedded so the product fetch would have already loaded them.
+# Access the loaded images for the Product.
 @images = @product.fetch_images
 ```
 

--- a/dev.yml
+++ b/dev.yml
@@ -3,9 +3,7 @@ name: identity-cache
 up:
   - homebrew:
     - postgresql
-  - ruby:
-      version: 2.2.3p172-shopify
-      package: shopify/shopify/shopify-ruby
+  - ruby: 2.3.3
   - railgun
   - bundler
 

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -14,6 +14,7 @@ require "identity_cache/cache_hash"
 require "identity_cache/cache_invalidation"
 require "identity_cache/cache_fetcher"
 require "identity_cache/fallback_fetcher"
+require 'identity_cache/without_primary_index'
 
 module IdentityCache
   extend ActiveSupport::Concern
@@ -25,6 +26,7 @@ module IdentityCache
   include IdentityCache::QueryAPI
   include IdentityCache::CacheInvalidation
   include IdentityCache::ShouldUseCache
+  include IdentityCache::ParentModelExpiration
 
   CACHED_NIL = :idc_cached_nil
   BATCH_SIZE = 1000

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -173,6 +173,7 @@ module IdentityCache
       end
 
       def disable_primary_cache_index
+        ActiveSupport::Deprecation.warn("disable_primary_cache_index is deprecated, use `include IdentityCache::WithoutPrimaryIndex` instead")
         ensure_base_model
         self.primary_cache_index_enabled = false
       end

--- a/lib/identity_cache/parent_model_expiration.rb
+++ b/lib/identity_cache/parent_model_expiration.rb
@@ -2,9 +2,6 @@ module IdentityCache
   module ParentModelExpiration # :nodoc:
     extend ActiveSupport::Concern
 
-    include ArTransactionChanges
-    include IdentityCache::ShouldUseCache
-
     included do |base|
       base.class_attribute :parent_expiration_entries
       base.parent_expiration_entries = Hash.new{ |hash, key| hash[key] = [] }
@@ -28,7 +25,7 @@ module IdentityCache
       key = record.primary_cache_index_key
       unless parents_to_expire[key]
         parents_to_expire[key] = record
-        record.add_parents_to_cache_expiry_set(parents_to_expire) if record.respond_to?(:add_parents_to_cache_expiry_set, true)
+        record.add_parents_to_cache_expiry_set(parents_to_expire)
       end
     end
 

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -283,10 +283,7 @@ module IdentityCache
         associations_for_identity_cache = recursively_embedded_associations.map do |child_association, options|
           child_class = reflect_on_association(child_association).try(:klass)
 
-          child_includes = nil
-          if child_class.respond_to?(:cache_fetch_includes, true)
-            child_includes = child_class.send(:cache_fetch_includes)
-          end
+          child_includes = child_class.send(:cache_fetch_includes)
 
           if child_includes.blank?
             child_association

--- a/lib/identity_cache/without_primary_index.rb
+++ b/lib/identity_cache/without_primary_index.rb
@@ -1,0 +1,10 @@
+module IdentityCache
+  module WithoutPrimaryIndex
+    extend ActiveSupport::Concern
+
+    included do |base|
+      base.send(:include, IdentityCache)
+      base.primary_cache_index_enabled = false
+    end
+  end
+end

--- a/test/cache_fetch_includes_test.rb
+++ b/test/cache_fetch_includes_test.rb
@@ -33,6 +33,7 @@ class CacheFetchIncludesTest < IdentityCache::TestCase
 
   def test_multiple_cached_associations_and_child_associations_are_included_in_includes
     Item.send(:cache_has_many, :associated_records, :embed => true)
+    PolymorphicRecord.send(:include, IdentityCache::WithoutPrimaryIndex)
     Item.send(:cache_has_many, :polymorphic_records, {:inverse_name => :owner, :embed => true})
     Item.send(:cache_has_one, :associated, :embed => true)
     AssociatedRecord.send(:cache_has_many, :deeply_associated_records, :embed => true)

--- a/test/deeply_nested_associated_record_test.rb
+++ b/test/deeply_nested_associated_record_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class DeeplyNestedAssociatedRecordHasOneTest < IdentityCache::TestCase
   def test_deeply_nested_models_can_cache_has_one_associations
     assert_nothing_raised do
+      PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
       Deeply::Nested::AssociatedRecord.has_one :polymorphic_record, as: 'owner'
       Deeply::Nested::AssociatedRecord.cache_has_one :polymorphic_record, inverse_name: :owner
     end

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class DenormalizedHasManyTest < IdentityCache::TestCase
   def setup
     super
+    PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
     Item.cache_has_many :associated_records, :embed => true
 
     @record = Item.new(:title => 'foo')

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class DenormalizedHasOneTest < IdentityCache::TestCase
   def setup
     super
+    PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
     Item.cache_has_one :associated
     Item.cache_index :title, :unique => true
     @record = Item.new(:title => 'foo')

--- a/test/prefetch_associations_test.rb
+++ b/test/prefetch_associations_test.rb
@@ -188,6 +188,7 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
   end
 
   def test_fetch_multi_batch_fetches_first_level_associations_who_dont_include_identity_cache
+    NotCachedRecord.include(IdentityCache::WithoutPrimaryIndex)
     Item.send(:cache_has_many, :not_cached_records, :embed => true)
 
     @bob_child  = @bob.not_cached_records.create!(:name => "bob child")

--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -75,6 +75,7 @@ class SchemaChangeTest < IdentityCache::TestCase
   def test_schema_changes_on_new_cached_child_association
     record = Item.fetch(@record.id)
 
+    PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
     Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => true
     read_new_schema
 
@@ -92,6 +93,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     teardown_models
     setup_models
 
+    PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
     Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => true
     read_new_schema
 


### PR DESCRIPTION
## Problem

In order to solve issue #300 we need a way to setup the parent expiry hooks without forcing the associated model to be loaded when `cache_has_many` or `cache_has_one` is called.  This means we need to setup the after_commit hook on the associated model independent of the definition of the cached association.

## Solution

In order to solve that issue, this PR deprecates adding a cached association to a model that doesn't include IdentityCache, so we have a way of expiring the association when the associated class changes.

Adding `include IdentityCache` to a bunch of models isn't free, since it installs an after_commit hook to invalidate the primary cache key for the model when one of its records changes.  We can instead avoid this using

```ruby
include IdentityCache
disable_primary_cache_index
```

but I find that unnecessarily verbose. I also dislike how those lines will naturally separate from the style of grouping include statements together. Also, I find it backwards to be calling a method to take away functionality that was just added to the model, since there will be methods that just can't be used and additional checks needed on those methods.

This PR instead deprecates `disable_primary_cache_index` and adds `IdentityCache::WithoutPrimaryIndex` to use instead

```
include IdentityCache::WithoutPrimaryIndex
```

Internally that will `include IdentityCache` and do the same thing as `disable_primary_cache_index` but a future refactor will cleanup that code internally.