### PR TITLE
Allow associated models to be lazily loaded

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -188,16 +188,14 @@ module IdentityCache
 
       def add_cached_associations_to_coder(record, coder)
         klass = record.class
-        if klass.include?(IdentityCache)
-          if (recursively_embedded_associations = klass.send(:recursively_embedded_associations)).present?
-            coder[:associations] = recursively_embedded_associations.each_with_object({}) do |(name, options), hash|
-              hash[name] = IdentityCache.map_cached_nil_for(get_embedded_association(record, name, options))
-            end
+        if (recursively_embedded_associations = klass.send(:recursively_embedded_associations)).present?
+          coder[:associations] = recursively_embedded_associations.each_with_object({}) do |(name, options), hash|
+            hash[name] = IdentityCache.map_cached_nil_for(get_embedded_association(record, name, options))
           end
-          if (cached_has_manys = klass.cached_has_manys).present?
-            coder[:association_ids] = cached_has_manys.each_with_object({}) do |(name, options), hash|
-              hash[name] = record.instance_variable_get(:"@#{options[:ids_variable_name]}") unless options[:embed] == true
-            end
+        end
+        if (cached_has_manys = klass.cached_has_manys).present?
+          coder[:association_ids] = cached_has_manys.each_with_object({}) do |(name, options), hash|
+            hash[name] = record.instance_variable_get(:"@#{options[:ids_variable_name]}") unless options[:embed] == true
           end
         end
       end

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -91,18 +91,21 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
   def test_cache_without_guessable_inverse_name_raises
     assert_raises IdentityCache::InverseAssociationError do
       Item.cache_has_many :polymorphic_records, :embed => true
+      IdentityCache.eager_load!
     end
   end
 
   def test_cache_without_guessable_inverse_name_does_not_raise_when_inverse_name_specified
     assert_nothing_raised do
       Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => true
+      IdentityCache.eager_load!
     end
   end
 
   def test_cache_uses_inverse_of_on_association
     Item.has_many :invertable_association, :inverse_of => :owner, :class_name => 'PolymorphicRecord', :as => "owner"
     Item.cache_has_many :invertable_association, :embed => true
+    IdentityCache.eager_load!
   end
 
   def test_saving_associated_records_should_expire_itself_and_the_parents_cache

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -100,12 +100,14 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
   def test_cache_without_guessable_inverse_name_raises
     assert_raises IdentityCache::InverseAssociationError do
       Item.cache_has_one :polymorphic_record, :embed => true
+      IdentityCache.eager_load!
     end
   end
 
   def test_cache_without_guessable_inverse_name_does_not_raise_when_inverse_name_specified
     assert_nothing_raised do
       Item.cache_has_one :polymorphic_record, :inverse_name => :owner, :embed => true
+      IdentityCache.eager_load!
     end
   end
 

--- a/test/helpers/active_record_objects.rb
+++ b/test/helpers/active_record_objects.rb
@@ -18,72 +18,7 @@ end
 module ActiveRecordObjects
 
   def setup_models(base = ActiveRecord::Base)
-    Object.send :const_set, 'DeeplyAssociatedRecord', Class.new(base) {
-      include IdentityCache
-      belongs_to :item
-      belongs_to :associated_record
-      default_scope { order('name DESC') }
-    }
-
-    Object.send :const_set, 'AssociatedRecord', Class.new(base) {
-      include IdentityCache
-      belongs_to :item, inverse_of: :associated_records
-      belongs_to :item_two, inverse_of: :associated_records
-      has_many :deeply_associated_records
-      default_scope { order('id DESC') }
-    }
-
-    Object.send :const_set, 'NormalizedAssociatedRecord', Class.new(base) {
-      include IdentityCache
-      belongs_to :item
-      default_scope { order('id DESC') }
-    }
-
-    Object.send :const_set, 'NotCachedRecord', Class.new(base) {
-      belongs_to :item, :touch => true
-      default_scope { order('id DESC') }
-    }
-
-    Object.send :const_set, 'PolymorphicRecord', Class.new(base) {
-      belongs_to :owner, :polymorphic => true
-    }
-
-    Object.send :const_set, 'Deeply', Module.new
-    Deeply.send :const_set, 'Nested', Module.new
-    Deeply::Nested.send :const_set, 'AssociatedRecord', Class.new(base) {
-      include IdentityCache
-    }
-
-    Object.send :const_set, 'Item', Class.new(base) {
-      include IdentityCache
-      belongs_to :item
-      has_many :associated_records, inverse_of: :item
-      has_many :deeply_associated_records, inverse_of: :item
-      has_many :normalized_associated_records
-      has_many :not_cached_records
-      has_many :polymorphic_records, :as => 'owner'
-      has_one :polymorphic_record, :as => 'owner'
-      has_one :associated, :class_name => 'AssociatedRecord'
-    }
-
-    Object.send :const_set, 'ItemTwo', Class.new(base) {
-      include IdentityCache
-      has_many :associated_records, inverse_of: :item_two, foreign_key: :item_two_id
-      self.table_name = 'items2'
-    }
-
-    Object.send :const_set, 'KeyedRecord', Class.new(base) {
-      include IdentityCache
-      self.primary_key = "hashed_key"
-    }
-
-    Object.send :const_set, 'StiRecord', Class.new(base) {
-      include IdentityCache
-      has_many :polymorphic_records, :as => 'owner'
-    }
-
-    Object.send :const_set, 'StiRecordTypeA', Class.new(StiRecord) {
-    }
+    Kernel.load(File.expand_path('../../helpers/models.rb', __FILE__))
   end
 
   def teardown_models
@@ -102,5 +37,6 @@ module ActiveRecordObjects
     Deeply::Nested.send :remove_const, 'AssociatedRecord'
     Deeply.send :remove_const, 'Nested'
     Object.send :remove_const, 'Deeply'
+    IdentityCache.const_get(:ParentModelExpiration).send(:lazy_hooks).clear
   end
 end

--- a/test/helpers/models.rb
+++ b/test/helpers/models.rb
@@ -1,0 +1,68 @@
+class DeeplyAssociatedRecord < ActiveRecord::Base
+  include IdentityCache
+  belongs_to :item
+  belongs_to :associated_record
+  default_scope { order('name DESC') }
+end
+
+class AssociatedRecord < ActiveRecord::Base
+  include IdentityCache
+  belongs_to :item, inverse_of: :associated_records
+  belongs_to :item_two, inverse_of: :associated_records
+  has_many :deeply_associated_records
+  default_scope { order('id DESC') }
+end
+
+class NormalizedAssociatedRecord < ActiveRecord::Base
+  include IdentityCache
+  belongs_to :item
+  default_scope { order('id DESC') }
+end
+
+class NotCachedRecord < ActiveRecord::Base
+  belongs_to :item, :touch => true
+  default_scope { order('id DESC') }
+end
+
+class PolymorphicRecord < ActiveRecord::Base
+  belongs_to :owner, :polymorphic => true
+end
+
+module Deeply
+  module Nested
+    class AssociatedRecord < ActiveRecord::Base
+      include IdentityCache
+    end
+  end
+end
+
+class Item < ActiveRecord::Base
+  include IdentityCache
+  belongs_to :item
+  has_many :associated_records, inverse_of: :item
+  has_many :deeply_associated_records, inverse_of: :item
+  has_many :normalized_associated_records
+  has_many :not_cached_records
+  has_many :polymorphic_records, :as => 'owner'
+  has_one :polymorphic_record, :as => 'owner'
+  has_one :associated, :class_name => 'AssociatedRecord'
+end
+
+class ItemTwo < ActiveRecord::Base
+  include IdentityCache
+  has_many :associated_records, inverse_of: :item_two, foreign_key: :item_two_id
+  self.table_name = 'items2'
+end
+
+class KeyedRecord < ActiveRecord::Base
+  include IdentityCache
+  self.primary_key = "hashed_key"
+end
+
+class StiRecord < ActiveRecord::Base
+  include IdentityCache
+  has_many :polymorphic_records, :as => 'owner'
+end
+
+class StiRecordTypeA < StiRecord
+end

--- a/test/lazy_load_associated_classes_test.rb
+++ b/test/lazy_load_associated_classes_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class LazyLoadAssociatedClassesTest < IdentityCache::TestCase
+  def setup
+    @old_lazy_load_associated_classes = IdentityCache.lazy_load_associated_classes
+    IdentityCache.lazy_load_associated_classes = true
+    super
+  end
+
+  def teardown
+    super
+    IdentityCache.lazy_load_associated_classes = @old_lazy_load_associated_classes
+  end
+
+  def test_cache_has_many_does_not_load_associated_class
+    Item.has_many :missing_model
+    Item.cache_has_many :missing_model
+  end
+
+  def test_cache_has_many_embed_does_not_load_associated_class
+    Item.has_many :missing_model
+    Item.cache_has_many :missing_model, embed: true
+  end
+
+  def test_cache_has_one_does_not_load_associated_class
+    Item.has_one :missing_model
+    Item.cache_has_one :missing_model
+  end
+
+  def test_cache_invalidation
+    Item.cache_has_many :associated_records, embed: true
+    associated_record = AssociatedRecord.new(name: 'baz')
+    item = Item.new(title: 'foo')
+    item.associated_records << associated_record
+    item.save!
+    Item.fetch(item.id)
+
+    assert_queries(0) do
+      assert_equal 'baz', Item.fetch(item.id).fetch_associated_records.first.name
+    end
+    associated_record.update_attributes!(name: 'buzz')
+    assert_queries(2) do
+      assert_equal 'buzz', Item.fetch(item.id).fetch_associated_records.first.name
+    end
+  end
+
+  def test_avoid_caching_embed_association_missing_include_identity_cache
+    Item.cache_has_many :not_cached_records, embed: true
+
+    assert_memcache_operations(0) do
+      err1 = assert_raises(IdentityCache::UnsupportedAssociationError) do
+        Item.fetch(1)
+      end
+      assert_equal 'cached association Item#not_cached_records requires associated class NotCachedRecord to include IdentityCache or IdentityCache::WithoutPrimaryIndex', err1.message
+      err2 = assert_raises(IdentityCache::UnsupportedAssociationError) do
+        Item.fetch_multi([1])
+      end
+      assert_equal err1.message, err2.message
+    end
+  end
+
+  def test_avoid_caching_id_embed_association_missing_include_identity_cache
+    Item.cache_has_many :not_cached_records, embed: :ids
+
+    assert_memcache_operations(0) do
+      err1 = assert_raises(IdentityCache::UnsupportedAssociationError) do
+        Item.fetch(1)
+      end
+      assert_equal 'cached association Item#not_cached_records requires associated class NotCachedRecord to include IdentityCache', err1.message
+      err2 = assert_raises(IdentityCache::UnsupportedAssociationError) do
+        Item.fetch_multi([1])
+      end
+      assert_equal err1.message, err2.message
+    end
+  end
+end
+


### PR DESCRIPTION
Fixes #300

This adds a configuration option `IdentityCache. lazy_load_associated_classes` that will lazily add parent expiry hooks by using the after_commit hook installed by `include IdentityCache` or `include IdentityCache::WithoutPrimaryIndex` that will check for hooks that are registered when cached associations are defined.

Associations are checked when the lazy hooks are installed or when the cache key is created for a model.  We were already doing this lazy association checking to raise for scopes with a join, which was moved to the cache key generation to make sure it was always done before the cached association is used.

The IdentityCache module can now also be used as an rails eager_load_namespace to install the lazy hooks during eager loading.