### PR TITLE
Remove a respond_to? check that hides mistakes in includes hash

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -93,8 +93,8 @@ module IdentityCache
           associations.each do |association, sub_associations|
             next_level_records = prefetch_one_association(association, records)
 
-            associated_class = reflect_on_association(association).klass
-            if associated_class.respond_to?(:prefetch_associations)
+            if sub_associations.present?
+              associated_class = reflect_on_association(association).klass
               associated_class.prefetch_associations(sub_associations, next_level_records)
             end
           end


### PR DESCRIPTION
## Problem

I started adding `include IdentityCache::WithoutPrimaryIndex` to a bunch of models in Shopify for PR #305 and noticed some `ArgumentError: Unknown cached association #{association} listed for prefetching` exceptions when running the tests.  I found out that an includes hash given to fetch_multi was referencing associations on a model that didn't `include IdentityCache` so had no cached associations.

The reason why it was ignoring these uncached associations in the includes hash before was that there was a `.respond_to?(:prefetch_associations)` condition which ignores sub-associations of a model that doesn't include IdentityCache, so adding `include IdentityCache::WithoutPrimaryIndex` surfaced the issue.

## Solution

Replace the `.respond_to?(:prefetch_associations)` condition with a `sub_associations.present?` condition.