### PR TITLE
Remove Postgres from Homebrew.

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,8 +1,6 @@
 name: identity-cache
 
 up:
-  - homebrew:
-    - postgresql
   - ruby: 2.3.3
   - railgun
   - bundler
@@ -52,4 +50,3 @@ railgun:
 
 packages:
   - git@github.com:Shopify/dev-shopify.git
-


### PR DESCRIPTION
It is no longer necessary when using dev since we now have it in Railgun.