### PR TITLE
Prepare for release 0.5.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # IdentityCache changelog
 
-#### Unreleased
+#### 0.5.0
 
+- `never_set_inverse_association` and `fetch_read_only_records` are now `true` by default (#315)
 - Store the class name instead of the class itself (#311)
 
 #### 0.4.1

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -53,19 +53,17 @@ module IdentityCache
     mattr_accessor :cache_namespace
     self.cache_namespace = "IDC:#{CACHE_VERSION}:".freeze
 
-    version = Gem::Version.new(IdentityCache::VERSION)
-
     # Inverse active record associations are set when loading embedded
     # cache_has_many associations from the cache when never_set_inverse_association
     # is false. When set to true, it will only set the inverse cached association.
     mattr_accessor :never_set_inverse_association
-    self.never_set_inverse_association = version >= Gem::Version.new("0.5")
+    self.never_set_inverse_association = true
 
     # Fetched records are not read-only and this could sometimes prevent IDC from
     # reflecting what's truly in the database when fetch_read_only_records is false.
     # When set to true, it will only return read-only records when cache is used.
     mattr_accessor :fetch_read_only_records
-    self.fetch_read_only_records = version >= Gem::Version.new("0.5")
+    self.fetch_read_only_records = true
 
     def included(base) #:nodoc:
       raise AlreadyIncludedError if base.respond_to?(:cached_model)

--- a/lib/identity_cache/version.rb
+++ b/lib/identity_cache/version.rb
@@ -1,4 +1,4 @@
 module IdentityCache
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
   CACHE_VERSION = 7
 end

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -130,12 +130,15 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
   end
 
   def test_deprecated_set_inverse_association_on_cache_hit
+    IdentityCache.never_set_inverse_association = false
     Item.fetch(@record.id) # warm cache
 
     item = Item.fetch(@record.id)
 
     associated_record = item.fetch_associated_records.to_a.first
     assert_equal item.object_id, associated_record.item.object_id
+  ensure
+    IdentityCache.never_set_inverse_association = true
   end
 
   def test_returned_records_should_be_readonly_on_cache_hit

--- a/test/memoized_attributes_test.rb
+++ b/test/memoized_attributes_test.rb
@@ -1,6 +1,16 @@
 require "test_helper"
 
 class MemoizedAttributesTest < IdentityCache::TestCase
+  def setup
+    IdentityCache.fetch_read_only_records = false
+    super
+  end
+
+  def teardown
+    super
+    IdentityCache.fetch_read_only_records = true
+  end
+
   def test_memoization_should_not_break_dirty_tracking_with_empty_cache
     item = Item.create!
 


### PR DESCRIPTION
This implies flipping the default values of `never_set_inverse_association` and `fetch_read_only_records` from `false` to `true`.