### PR TITLE
Add missing compact for prefetch_associations for cache_has_one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # IdentityCache changelog
 
+#### 0.5.1
+
+- Fix bug in prefetch_associations for cache_has_one associations that may be nil
+
 #### 0.5.0
 
 - `never_set_inverse_association` and `fetch_read_only_records` are now `true` by default (#315)

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -401,7 +401,7 @@ module IdentityCache
         when details = cached_has_ones[association]
           if details[:embed] == true
             prefetch_embedded_association(records, association, details)
-            parent_records = records.map(&details[:cached_accessor_name].to_sym)
+            parent_records = records.map(&details[:cached_accessor_name].to_sym).compact
           else
             raise ArgumentError.new("Non-embedded has_one associations do not support prefetching yet.")
           end

--- a/lib/identity_cache/version.rb
+++ b/lib/identity_cache/version.rb
@@ -1,4 +1,4 @@
 module IdentityCache
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
   CACHE_VERSION = 7
 end


### PR DESCRIPTION
## Problem

We got a NoMethodError in production because we had a hash in the includes option being passed into `fetch_multi` where there was a key referencing a cache_has_one association which could return `nil` values and that array of records wasn't compacted before trying to fetch the sub-associations.

## Solution

Compact the array before using it as an array of records for the sub-association.

The added test fails without the code change.

This seems like a bug fix worth making a patch release for, so I bumped the version in this PR to prepare for the release.