### PR TITLE
Fix infinite caching in the case of self associated models

### DIFF
--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('mocha', '0.14.0')
   gem.add_development_dependency('spy')
   gem.add_development_dependency('minitest', '>= 2.11.0')
-  gem.add_development_dependency('pry-byebug')
 
   if RUBY_PLATFORM == 'java'
     raise NotImplementedError

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('mocha', '0.14.0')
   gem.add_development_dependency('spy')
   gem.add_development_dependency('minitest', '>= 2.11.0')
+  gem.add_development_dependency('pry-byebug')
 
   if RUBY_PLATFORM == 'java'
     raise NotImplementedError

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -7,7 +7,7 @@ module IdentityCache
       columns.sort_by(&:name).map{|c| "#{c.name}:#{c.type}"}.join(',')
     end
 
-    def self.denormalized_schema_hash(klass, seen_assocs)
+    def self.denormalized_schema_hash(klass, seen_assocs = Set.new)
       schema_string = schema_to_string(klass.columns)
       klass.send(:all_cached_associations).sort.each do |name, options|
         klass.send(:check_association_scope, name)
@@ -31,7 +31,7 @@ module IdentityCache
       end
 
       def rails_cache_key_prefix
-        @rails_cache_key_prefix ||= IdentityCache::CacheKeyGeneration.denormalized_schema_hash(self, Set.new)
+        @rails_cache_key_prefix ||= IdentityCache::CacheKeyGeneration.denormalized_schema_hash(self)
       end
 
       def prefixed_rails_cache_key

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -277,11 +277,12 @@ module IdentityCache
         end
       end
 
-      def cache_fetch_includes
+      def cache_fetch_includes(seen_assocs = Set.new)
         associations_for_identity_cache = recursively_embedded_associations.map do |child_association, options|
           child_class = reflect_on_association(child_association).try(:klass)
-
-          child_includes = child_class.send(:cache_fetch_includes)
+          if seen_assocs.add?(child_association)
+            child_includes = child_class.send(:cache_fetch_includes, seen_assocs)
+          end
 
           if child_includes.blank?
             child_association

--- a/test/helpers/active_record_objects.rb
+++ b/test/helpers/active_record_objects.rb
@@ -31,6 +31,8 @@ module ActiveRecordObjects
     Object.send :remove_const, 'NotCachedRecord'
     Object.send :remove_const, 'Item'
     Object.send :remove_const, 'ItemTwo'
+    Object.send :remove_const, 'SelfItem'
+    Object.send :remove_const, 'SelfItemTwo'
     Object.send :remove_const, 'KeyedRecord'
     Object.send :remove_const, 'StiRecord'
     Object.send :remove_const, 'StiRecordTypeA'

--- a/test/helpers/database_connection.rb
+++ b/test/helpers/database_connection.rb
@@ -43,17 +43,17 @@ module DatabaseConnection
   end
 
   TABLES = {
-    :polymorphic_records           => [[:string, :owner_type], [:integer, :owner_id], [:timestamps, null: true]],
-    :deeply_associated_records     => [[:string, :name], [:integer, :associated_record_id], [:integer, :item_id], [:timestamps, null: true]],
-    :associated_records            => [[:string, :name], [:integer, :item_id], [:integer, :item_two_id]],
-    :normalized_associated_records => [[:string, :name], [:integer, :item_id], [:timestamps, null: true]],
-    :not_cached_records            => [[:string, :name], [:integer, :item_id], [:timestamps, null: true]],
-    :items                         => [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
-    :items2                        => [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
+    polymorphic_records:              [[:string, :owner_type], [:integer, :owner_id], [:timestamps, null: true]],
+    deeply_associated_records:        [[:string, :name], [:integer, :associated_record_id], [:integer, :item_id], [:timestamps, null: true]],
+    associated_records:               [[:string, :name], [:integer, :item_id], [:integer, :item_two_id]],
+    normalized_associated_records:    [[:string, :name], [:integer, :item_id], [:timestamps, null: true]],
+    not_cached_records:               [[:string, :name], [:integer, :item_id], [:timestamps, null: true]],
+    items:                            [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
+    items2:                           [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
     self_items:                       [[:string, :title], [:integer, :parent_item_id], [:integer, :self_item_two_id], [:timestamps, null: true]],
     self_item_twos:                   [[:string, :title], [:integer, :self_item_id], [:timestamps, null: true]],
-    :keyed_records                 => [[:string, :value], :primary_key => "hashed_key"],
-    :sti_records                   => [[:string, :type], [:string, :name]],
+    keyed_records:                    [[:string, :value], :primary_key => "hashed_key"],
+    sti_records:                      [[:string, :type], [:string, :name]],
   }
 
   DEFAULT_CONFIG = {

--- a/test/helpers/database_connection.rb
+++ b/test/helpers/database_connection.rb
@@ -50,6 +50,8 @@ module DatabaseConnection
     :not_cached_records            => [[:string, :name], [:integer, :item_id], [:timestamps, null: true]],
     :items                         => [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
     :items2                        => [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
+    self_items:                       [[:string, :title], [:integer, :parent_item_id], [:integer, :self_item_two_id], [:timestamps, null: true]],
+    self_item_twos:                   [[:string, :title], [:integer, :self_item_id], [:timestamps, null: true]],
     :keyed_records                 => [[:string, :value], :primary_key => "hashed_key"],
     :sti_records                   => [[:string, :type], [:string, :name]],
   }

--- a/test/helpers/models.rb
+++ b/test/helpers/models.rb
@@ -54,6 +54,20 @@ class ItemTwo < ActiveRecord::Base
   self.table_name = 'items2'
 end
 
+class SelfItem < ActiveRecord::Base
+  include IdentityCache
+  belongs_to :parent_item, class_name: 'SelfItem'
+  belongs_to :self_item_two
+  has_many :self_item_twos
+  has_many :associated_items, class_name: 'SelfItem', foreign_key: 'parent_item_id'
+end
+
+class SelfItemTwo < ActiveRecord::Base
+  include IdentityCache
+  belongs_to :self_item
+  has_many :self_items
+end
+
 class KeyedRecord < ActiveRecord::Base
   include IdentityCache
   self.primary_key = "hashed_key"

--- a/test/self_association_test.rb
+++ b/test/self_association_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+class SelfAssociationTest < IdentityCache::TestCase
+  def setup
+    super
+    SelfItem.cache_has_many :associated_items, embed: true, inverse_name: :parent_item
+    SelfItem.cache_belongs_to :parent_item
+    @item = SelfItem.new(title: 'foo')
+    @item.save
+
+    @associated_item = SelfItem.new(title: 'bar')
+    @associated_item.save
+
+    @deeply_associated_item = SelfItem.new(title: 'baz')
+    @deeply_associated_item.save
+
+    SelfItemTwo.cache_has_many :self_items, embed: true
+    SelfItemTwo.cache_belongs_to :self_item
+    @other_item = SelfItemTwo.new(title: 'qux')
+    @other_item.save
+    @other_item_two = SelfItemTwo.new(title: 'quux')
+    @other_item_two.save
+  end
+
+  def test_associating_record_with_itself_should_not_raise_exceptions
+    assert_nothing_raised do
+      @item.associated_items << SelfItem.new(title: 'bar')
+      @item.save
+    end
+  end
+
+  def test_self_associated_record_should_be_returned_on_cache_hit
+    @item.associated_items << @associated_item
+    @item.save
+
+    SelfItem.fetch(@item.id)
+
+    cached_item = SelfItem.fetch(@item.id)
+    assert_equal @item, cached_item
+    assert_equal [@associated_item], cached_item.associated_items
+  end
+
+  def test_multiple_self_assoc_levels_should_be_returned
+    @associated_item.associated_items << @deeply_associated_item
+    @item.associated_items << @associated_item
+
+    @item.save
+    @associated_item.save
+
+    SelfItem.fetch(@item.id)
+
+    cached_item = SelfItem.fetch(@item.id)
+    assert_equal [@associated_item], cached_item.associated_items
+    cached_assoc_item = cached_item.associated_items.first
+    assert_equal [@deeply_associated_item], cached_assoc_item.associated_items
+  end
+
+  def test_self_assoc_should_include_other_associations
+    @item.associated_items << @associated_item
+
+    @item.self_item_twos << @other_item
+    @associated_item.self_item_twos << @other_item_two
+
+    @item.save
+    @associated_item.save
+
+    SelfItem.fetch(@item.id)
+
+    cached_item = SelfItem.fetch(@item.id)
+    assert_equal [@other_item], cached_item.self_item_twos
+    assert_equal [@other_item_two], cached_item.associated_items.first.self_item_twos
+  end
+
+  def test_should_detect_cyclical_associations
+    @item.self_item_twos << @other_item
+    @other_item.self_items << @associated_item
+
+    @item.save
+    @other_item.save
+
+    SelfItem.fetch(@item.id)
+
+    cached_item = SelfItem.fetch(@item.id)
+    assert_equal [@other_item], cached_item.self_item_twos
+    assert_equal [@associated_item], cached_item.self_item_twos.first.self_items
+  end
+end


### PR DESCRIPTION
When we tried to cache a model with itself and had `embed: true`, identity cache would attempt to cache the objects in an infinite loop and caused a stack overflow. This PR aims to fix that by adding checks for that case.