### PR TITLE
Alternate cache namespace for smooth rollouts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # IdentityCache changelog
 
+#### Unreleased
+
+- Support alternate cache key for smoother upgrades
+
 #### 0.5.1
 
 - Fix bug in prefetch_associations for cache_has_one associations that may be nil

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -49,6 +49,11 @@ module IdentityCache
     mattr_accessor :cache_namespace
     self.cache_namespace = "IDC:#{CACHE_VERSION}:".freeze
 
+    # If non-nil, IDC will expire entries on that namespace as well. Use this to
+    # progressively roll out a new cache format.
+    mattr_accessor :alternate_cache_namespace
+    self.alternate_cache_namespace = nil
+
     # Inverse active record associations are set when loading embedded
     # cache_has_many associations from the cache when never_set_inverse_association
     # is false. When set to true, it will only set the inverse cached association.

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -3,23 +3,53 @@ module IdentityCache
     extend ActiveSupport::Concern
     DEFAULT_NAMESPACE = "IDC:#{CACHE_VERSION}:".freeze
 
-    def self.schema_to_string(columns)
-      columns.sort_by(&:name).map{|c| "#{c.name}:#{c.type}"}.join(',')
-    end
+    class << self
+      def schema_to_string(columns)
+        columns.sort_by(&:name).map { |c| "#{c.name}:#{c.type}" }.join(',')
+      end
 
-    def self.denormalized_schema_hash(klass)
-      schema_string = schema_to_string(klass.columns)
-      klass.send(:all_cached_associations).sort.each do |name, options|
-        klass.send(:check_association_scope, name)
-        ParentModelExpiration.check_association(options) if options[:embed]
-        case options[:embed]
-        when true
-          schema_string << ",#{name}:(#{denormalized_schema_hash(options[:association_reflection].klass)})"
-        when :ids
-          schema_string << ",#{name}:ids"
+      def denormalized_schema_hash(klass)
+        schema_string = schema_to_string(klass.columns)
+        klass.send(:all_cached_associations).sort.each do |name, options|
+          klass.send(:check_association_scope, name)
+          ParentModelExpiration.check_association(options) if options[:embed]
+          case options[:embed]
+          when true
+            schema_string << ",#{name}:(#{denormalized_schema_hash(options[:association_reflection].klass)})"
+          when :ids
+            schema_string << ",#{name}:ids"
+          end
+        end
+        IdentityCache.memcache_hash(schema_string)
+      end
+
+      def evaluate_namespace(model, namespace)
+        case namespace
+        when Proc
+          namespace.call(model)
+        else
+          namespace
         end
       end
-      IdentityCache.memcache_hash(schema_string)
+
+      def prefixed_rails_cache_key(model_class, namespace)
+        "#{namespace}blob:#{model_class.base_class.name}:#{model_class.rails_cache_key_prefix}:"
+      end
+
+      def rails_cache_key_for_attribute_and_fields_and_values(model, namespace, attribute, fields, values, unique)
+        unique_indicator = unique ? '' : 's'
+        "#{namespace}" \
+          "attr#{unique_indicator}" \
+          ":#{model.base_class.name}" \
+          ":#{attribute}" \
+          ":#{rails_cache_string_for_fields_and_values(fields, values)}"
+      end
+
+      private
+
+      def rails_cache_string_for_fields_and_values(fields, values)
+        "#{fields.join('/')}:#{IdentityCache.memcache_hash(values.join('/'))}"
+      end
     end
 
     module ClassMethods
@@ -27,31 +57,64 @@ module IdentityCache
         "#{prefixed_rails_cache_key}#{id}"
       end
 
+      def rails_cache_keys(id)
+        prefixed_rails_cache_keys.map do |prefix|
+          "#{prefix}#{id}"
+        end
+      end
+
       def rails_cache_key_prefix
         @rails_cache_key_prefix ||= IdentityCache::CacheKeyGeneration.denormalized_schema_hash(self)
       end
 
       def prefixed_rails_cache_key
-        "#{rails_cache_key_namespace}blob:#{base_class.name}:#{rails_cache_key_prefix}:"
+        CacheKeyGeneration.prefixed_rails_cache_key(self, rails_cache_key_namespace)
+      end
+
+      def prefixed_rails_cache_keys
+        rails_cache_key_namespaces.map do |namespace|
+          CacheKeyGeneration.prefixed_rails_cache_key(self, namespace)
+        end
       end
 
       def rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, values, unique)
-        unique_indicator = unique ? '' : 's' 
-        "#{rails_cache_key_namespace}" \
-          "attr#{unique_indicator}" \
-          ":#{base_class.name}" \
-          ":#{attribute}" \
-          ":#{rails_cache_string_for_fields_and_values(fields, values)}"
+        CacheKeyGeneration.rails_cache_key_for_attribute_and_fields_and_values(
+          self,
+          rails_cache_key_namespace,
+          attribute,
+          fields,
+          values,
+          unique,
+        )
+      end
+
+      def rails_cache_keys_for_attribute_and_fields_and_values(attribute, fields, values, unique)
+        rails_cache_key_namespaces.map do |namespace|
+          CacheKeyGeneration.rails_cache_key_for_attribute_and_fields_and_values(
+            self,
+            namespace,
+            attribute,
+            fields,
+            values,
+            unique,
+          )
+        end
       end
 
       def rails_cache_key_namespace
-        ns = IdentityCache.cache_namespace
-        ns.is_a?(Proc) ? ns.call(self) : ns
+        CacheKeyGeneration.evaluate_namespace(self, IdentityCache.cache_namespace)
       end
 
-      private
-      def rails_cache_string_for_fields_and_values(fields, values)
-        "#{fields.join('/')}:#{IdentityCache.memcache_hash(values.join('/'))}"
+      def rails_cache_key_namespaces
+        alternate_cache_namespace = IdentityCache.alternate_cache_namespace
+        if alternate_cache_namespace
+          [
+            rails_cache_key_namespace,
+            CacheKeyGeneration.evaluate_namespace(self, alternate_cache_namespace),
+          ]
+        else
+          [rails_cache_key_namespace]
+        end
       end
     end
 
@@ -59,12 +122,32 @@ module IdentityCache
       self.class.rails_cache_key(id)
     end
 
+    def primary_cache_index_keys # :nodoc:
+      self.class.rails_cache_keys(id)
+    end
+
     def attribute_cache_key_for_attribute_and_current_values(attribute, fields, unique) # :nodoc:
-      self.class.rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, current_values_for_fields(fields), unique)
+      self.class.rails_cache_key_for_attribute_and_fields_and_values(
+        attribute, fields, current_values_for_fields(fields), unique,
+      )
+    end
+
+    def attribute_cache_keys_for_attribute_and_current_values(attribute, fields, unique) # :nodoc:
+      self.class.rails_cache_keys_for_attribute_and_fields_and_values(
+        attribute, fields, current_values_for_fields(fields), unique,
+      )
     end
 
     def attribute_cache_key_for_attribute_and_previous_values(attribute, fields, unique) # :nodoc:
-      self.class.rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, old_values_for_fields(fields), unique)
+      self.class.rails_cache_key_for_attribute_and_fields_and_values(
+        attribute, fields, old_values_for_fields(fields), unique,
+      )
+    end
+
+    def attribute_cache_keys_for_attribute_and_previous_values(attribute, fields, unique) # :nodoc:
+      self.class.rails_cache_keys_for_attribute_and_fields_and_values(
+        attribute, fields, old_values_for_fields(fields), unique,
+      )
     end
 
     def current_values_for_fields(fields) # :nodoc:

--- a/test/save_test.rb
+++ b/test/save_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SaveTest < IdentityCache::TestCase
@@ -9,74 +11,166 @@ class SaveTest < IdentityCache::TestCase
     Item.cache_index :id, :title, :unique => true
 
     @record = Item.create(:title => 'bob')
-    @blob_key = "#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:1"
+    @blob_cache_hash = cache_hash(
+      "created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime",
+    )
   end
 
   def test_create
     @record = Item.new
     @record.title = 'bob'
 
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('2/bob')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
-    expect_cache_delete("#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:2").once
+    expect_cache_delete("blob:Item:#{@blob_cache_hash}:2")
+    expect_cache_delete("attr:Item:id:id/title:#{cache_hash('2/bob')}")
+    expect_cache_delete("attr:Item:id:title:#{cache_hash('bob')}")
     @record.save
+  end
+
+  def test_create_with_alternate_key
+    with_alternate_key do
+      @record = Item.new
+      @record.title = 'bob'
+
+      expect_cache_delete("blob:Item:#{@blob_cache_hash}:2", alt: true).once
+      expect_cache_delete("attr:Item:id:id/title:#{cache_hash('2/bob')}", alt: true)
+      expect_cache_delete("attr:Item:id:title:#{cache_hash('bob')}", alt: true)
+      @record.save
+    end
   end
 
   def test_update
     # Regular flow, write index id, write index id/tile, delete data blob since Record has changed
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/fred')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('fred')}")
-    expect_cache_delete(@blob_key)
+    expect_cache_delete("attr:Item:id:id/title:#{cache_hash('1/fred')}")
+    expect_cache_delete("attr:Item:id:title:#{cache_hash('fred')}")
+    expect_cache_delete("blob:Item:#{@blob_cache_hash}:1")
 
     # Delete index id, delete index id/title
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
+    expect_cache_delete("attr:Item:id:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("attr:Item:id:title:#{cache_hash('bob')}")
 
     @record.title = 'fred'
     @record.save
   end
 
+  def test_update_with_alternate_key
+    with_alternate_key do
+      # Regular flow, write index id, write index id/tile, delete data blob since Record has changed
+      expect_cache_delete("attr:Item:id:id/title:#{cache_hash('1/fred')}", alt: true)
+      expect_cache_delete("attr:Item:id:title:#{cache_hash('fred')}", alt: true)
+      expect_cache_delete("blob:Item:#{@blob_cache_hash}:1", alt: true)
+
+      # Delete index id, delete index id/title
+      expect_cache_delete("attr:Item:id:id/title:#{cache_hash('1/bob')}", alt: true)
+      expect_cache_delete("attr:Item:id:title:#{cache_hash('bob')}", alt: true)
+
+      @record.title = 'fred'
+      @record.save
+    end
+  end
+
   def test_destroy
     # Regular flow: delete data blob, delete index id, delete index id/tile
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
-    expect_cache_delete(@blob_key)
+    expect_cache_delete("attr:Item:id:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("attr:Item:id:title:#{cache_hash('bob')}")
+    expect_cache_delete("blob:Item:#{@blob_cache_hash}:1")
 
     @record.destroy
   end
 
+  def test_destroy_with_alternate_key
+    with_alternate_key do
+      # Regular flow: delete data blob, delete index id, delete index id/tile
+      expect_cache_delete("attr:Item:id:id/title:#{cache_hash('1/bob')}", alt: true)
+      expect_cache_delete("attr:Item:id:title:#{cache_hash('bob')}", alt: true)
+      expect_cache_delete("blob:Item:#{@blob_cache_hash}:1", alt: true)
+
+      @record.destroy
+    end
+  end
+
   def test_destroy_with_changed_attributes
     # Make sure to delete the old cache index key, since the new title never ended up in an index
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
-    expect_cache_delete(@blob_key)
+    expect_cache_delete("attr:Item:id:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("attr:Item:id:title:#{cache_hash('bob')}")
+    expect_cache_delete("blob:Item:#{@blob_cache_hash}:1")
 
     @record.title = 'fred'
     @record.destroy
   end
 
+  def test_destroy_with_changed_attributes_and_alternate_key
+    with_alternate_key do
+      # Make sure to delete the old cache index key, since the new title never ended up in an index
+      expect_cache_delete("attr:Item:id:id/title:#{cache_hash('1/bob')}", alt: true)
+      expect_cache_delete("attr:Item:id:title:#{cache_hash('bob')}", alt: true)
+      expect_cache_delete("blob:Item:#{@blob_cache_hash}:1", alt: true)
+
+      @record.title = 'fred'
+      @record.destroy
+    end
+  end
+
   def test_touch_will_expire_the_caches
     # Regular flow: delete data blob, delete index id, delete index id/tile
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
-    expect_cache_delete(@blob_key)
+    expect_cache_delete("attr:Item:id:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("attr:Item:id:title:#{cache_hash('bob')}")
+    expect_cache_delete("blob:Item:#{@blob_cache_hash}:1")
 
     @record.touch
   end
 
+  def test_touch_will_expire_the_caches_with_alternate_key
+    with_alternate_key do
+      # Regular flow: delete data blob, delete index id, delete index id/tile
+      expect_cache_delete("attr:Item:id:id/title:#{cache_hash('1/bob')}", alt: true)
+      expect_cache_delete("attr:Item:id:title:#{cache_hash('bob')}", alt: true)
+      expect_cache_delete("blob:Item:#{@blob_cache_hash}:1", alt: true)
+
+      @record.touch
+    end
+  end
+
   def test_expire_cache_works_in_a_transaction
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
-    expect_cache_delete(@blob_key)
+    expect_cache_delete("attr:Item:id:id/title:#{cache_hash('1/bob')}")
+    expect_cache_delete("attr:Item:id:title:#{cache_hash('bob')}")
+    expect_cache_delete("blob:Item:#{@blob_cache_hash}:1")
 
     ActiveRecord::Base.transaction do
       @record.send(:expire_cache)
     end
   end
 
+  def test_expire_cache_works_in_a_transaction_with_alternate_key
+    with_alternate_key do
+      expect_cache_delete("attr:Item:id:id/title:#{cache_hash('1/bob')}", alt: true)
+      expect_cache_delete("attr:Item:id:title:#{cache_hash('bob')}", alt: true)
+      expect_cache_delete("blob:Item:#{@blob_cache_hash}:1", alt: true)
+
+      ActiveRecord::Base.transaction do
+        @record.send(:expire_cache)
+      end
+    end
+  end
+
   private
 
-  def expect_cache_delete(key)
-    @backend.expects(:write).with(key, IdentityCache::DELETED, anything)
+  def with_alternate_key
+    IdentityCache.alternate_cache_namespace = "#{IdentityCache.cache_namespace}alt:"
+    yield
+  ensure
+    IdentityCache.alternate_cache_namespace = nil
+  end
+
+  def expect_cache_delete(key, alt: false)
+    @backend
+      .expects(:write)
+      .with("#{NAMESPACE}#{key}", IdentityCache::DELETED, anything)
+      .once
+    if alt
+      @backend
+        .expects(:write)
+        .with("#{NAMESPACE}alt:#{key}", IdentityCache::DELETED, anything)
+        .once
+    end
   end
 end


### PR DESCRIPTION
Every time we roll out a breaking change to IDC we have to monkey patch it to delete both versions when a value is expired. No more... well yes, but it's now much easier. You have to set `IdentityCache. alternate_cache_namespace` and you are set!