### PR TITLE
Remote deprecated never_set_inverse_association option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # IdentityCache changelog
 
+#### 0.6.0 Unreleased
+
+- Remove deprecated `never_set_inverse_association` option (#319)
+
 #### 0.5.1
 
 - Fix bug in prefetch_associations for cache_has_one associations that may be nil

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -49,12 +49,6 @@ module IdentityCache
     mattr_accessor :cache_namespace
     self.cache_namespace = "IDC:#{CACHE_VERSION}:".freeze
 
-    # Inverse active record associations are set when loading embedded
-    # cache_has_many associations from the cache when never_set_inverse_association
-    # is false. When set to true, it will only set the inverse cached association.
-    mattr_accessor :never_set_inverse_association
-    self.never_set_inverse_association = true
-
     # Fetched records are not read-only and this could sometimes prevent IDC from
     # reflecting what's truly in the database when fetch_read_only_records is false.
     # When set to true, it will only return read-only records when cache is used.
@@ -150,15 +144,6 @@ module IdentityCache
 
       result
     end
-
-    def with_never_set_inverse_association(value = true)
-      old_value = self.never_set_inverse_association
-      self.never_set_inverse_association = value
-      yield
-    ensure
-      self.never_set_inverse_association = old_value
-    end
-
 
     def with_fetch_read_only_records(value = true)
       old_value = self.fetch_read_only_records

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -149,15 +149,7 @@ module IdentityCache
           nil
         elsif (reflection = record.class.reflect_on_association(association_name)).collection?
           associated_records = coder_or_array.map {|e| record_from_coder(e) }
-
           set_inverse_of_cached_has_many(record, reflection, associated_records)
-
-          unless IdentityCache.never_set_inverse_association
-            association = reflection.association_class.new(record, reflection)
-            association.target = associated_records
-            association.target.each {|e| association.set_inverse_instance(e) }
-          end
-
           associated_records
         else
           record_from_coder(coder_or_array)

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -124,24 +124,10 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
   def test_never_set_inverse_association_on_cache_hit
     Item.fetch(@record.id) # warm cache
 
-    item = IdentityCache.with_never_set_inverse_association do
-      Item.fetch(@record.id)
-    end
-
-    associated_record = item.fetch_associated_records.to_a.first
-    assert item.object_id != associated_record.item.object_id
-  end
-
-  def test_deprecated_set_inverse_association_on_cache_hit
-    IdentityCache.never_set_inverse_association = false
-    Item.fetch(@record.id) # warm cache
-
     item = Item.fetch(@record.id)
 
     associated_record = item.fetch_associated_records.to_a.first
-    assert_equal item.object_id, associated_record.item.object_id
-  ensure
-    IdentityCache.never_set_inverse_association = true
+    refute_equal item.object_id, associated_record.item.object_id
   end
 
   def test_returned_records_should_be_readonly_on_cache_hit


### PR DESCRIPTION
I removed the deprecated option from Shopify, so I figured I could clean it up.