### PR TITLE
Make cache setup consistent to fix dev profile and dev benchmark-cpu

### DIFF
--- a/performance/cache_runner.rb
+++ b/performance/cache_runner.rb
@@ -6,14 +6,12 @@ require 'identity_cache'
 require 'memcached_store'
 require 'active_support/cache/memcached_store'
 
-$memcached_port = 11211
-$mysql_port = 3306
-
 require File.dirname(__FILE__) + '/../test/helpers/active_record_objects'
 require File.dirname(__FILE__) + '/../test/helpers/database_connection'
+require File.dirname(__FILE__) + '/../test/helpers/cache_connection'
 
 IdentityCache.logger = Logger.new(nil)
-IdentityCache.cache_backend = ActiveSupport::Cache::MemcachedStore.new("localhost:#{$memcached_port}", :support_cas => true)
+CacheConnection.setup
 
 if ActiveRecord.gem_version < Gem::Version.new('5') && ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks=)
   ActiveRecord::Base.raise_in_transactional_callbacks = true

--- a/test/helpers/cache_connection.rb
+++ b/test/helpers/cache_connection.rb
@@ -1,0 +1,15 @@
+module CacheConnection
+  extend self
+
+  def host
+    ENV['MEMCACHED_HOST'] || "127.0.0.1"
+  end
+
+  def backend
+    @backend ||= ActiveSupport::Cache::MemcachedStore.new("#{host}:11211", support_cas: true)
+  end
+
+  def setup
+    IdentityCache.cache_backend = backend
+  end
+end

--- a/test/helpers/update_serialization_format.rb
+++ b/test/helpers/update_serialization_format.rb
@@ -6,6 +6,7 @@ require 'memcached_store'
 require 'active_support/cache/memcached_store'
 require_relative 'serialization_format'
 require_relative 'database_connection'
+require_relative 'cache_connection'
 require_relative 'active_record_objects'
 require 'identity_cache'
 
@@ -16,10 +17,7 @@ DatabaseConnection.setup
 DatabaseConnection.drop_tables
 DatabaseConnection.create_tables
 IdentityCache.logger = Logger.new(nil)
-IdentityCache.cache_backend = ActiveSupport::Cache::MemcachedStore.new(
-  "#{ENV["MEMCACHED_HOST"] || "localhost"}:11211",
-  :support_cas => true,
-)
+CacheConnection.setup
 setup_models
 File.open(serialized_record_file, 'w') {|file| serialize(serialized_record, file) }
 puts "Serialized record to #{serialized_record_file}"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'minitest/autorun'
 require 'mocha/setup'
 require 'active_record'
 require 'helpers/database_connection'
+require 'helpers/cache_connection'
 require 'helpers/active_record_objects'
 require 'spy/integration'
 require 'memcached_store'
@@ -11,6 +12,7 @@ require 'active_support/cache/memcached_store'
 require File.dirname(__FILE__) + '/../lib/identity_cache'
 
 DatabaseConnection.setup
+CacheConnection.setup
 ActiveSupport::Cache::Store.instrument = true if ActiveSupport.version < Gem::Version.new("4.2.0")
 
 # This patches AR::MemcacheStore to notify AS::Notifications upon read_multis like the rest of rails does
@@ -39,8 +41,8 @@ class IdentityCache::TestCase < Minitest::Test
 
     IdentityCache.logger = Logger.new(nil)
 
-    memcached_host = ENV['MEMCACHED_HOST'] || "127.0.0.1"
-    IdentityCache.cache_backend = @backend = ActiveSupport::Cache::MemcachedStore.new("#{memcached_host}:11211", :support_cas => true)
+    @backend = CacheConnection.backend
+    IdentityCache.cache_backend = @backend
 
     setup_models
   end


### PR DESCRIPTION
## Problem

I ran `dev benchmark-cpu` on master and got surprising results, since it looked like hits and misses were taking approximately the same time.  It turns out we setup the cache connection inconsistently, so `dev test` was using identity-cache.railgun as the memcached host and `dev benchmark-cpu` was using localhost. 

## Solution

Move the cache setup into its own file like the database setup, so it will stay consistent across dev/rake tasks.