### PR TITLE
Raise when trying to cache a belong_to association with a scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 0.6.0 Unreleased
 
+- Raise when trying to cache a belong_to association with a scope. Previously the scope was ignored on a cache hit (#323)
 - Remove deprecated `never_set_inverse_association` option (#319)
 
 #### 0.5.1

--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -15,6 +15,9 @@ module IdentityCache
         unless association_reflection = reflect_on_association(association)
           raise AssociationError, "Association named '#{association}' was not found on #{self.class}"
         end
+        if association_reflection.scope
+          raise UnsupportedAssociationError, "caching association #{self}.#{association} is scoped which isn't supported"
+        end
 
         options = {}
         self.cached_belongs_tos[association] = options

--- a/test/normalized_belongs_to_test.rb
+++ b/test/normalized_belongs_to_test.rb
@@ -104,4 +104,12 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
       end
     end
   end
+
+  def test_cache_belongs_to_with_scope
+    AssociatedRecord.belongs_to :item_with_scope, -> { where.not(timestamp: nil) },
+      class_name: 'Item', foreign_key: 'item_id'
+    assert_raises(IdentityCache::UnsupportedAssociationError) do
+      AssociatedRecord.cache_belongs_to :item_with_scope
+    end
+  end
 end


### PR DESCRIPTION
Fixes #304

## Problem

Identity cache implements cache_belongs_to by using `fetch_by_id` on the associated model using the foreign key, so the scope on the association would get ignored on a cache hit.  This is inconsistent with cases where it falls back to the association (e.g. in a transaction or if the belongs_to association is already loaded).

## Solution

Caching a belongs_to association without a scope was never something we intended to support, and not something we rely on in Shopify.  This PR simply raises if `cache_belongs_to` is called on an association with a scope to avoid confusion from this not being properly supported.