### PR TITLE
Raise on id mismatch from the cache

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -55,6 +55,11 @@ module IdentityCache
     mattr_accessor :fetch_read_only_records
     self.fetch_read_only_records = true
 
+    # Raise an exception if the record returned from the cache don't match the id
+    # the user expected
+    mattr_accessor :raise_on_id_mismatch
+    self.raise_on_id_mismatch = false
+
     mattr_accessor :lazy_load_associated_classes
     self.lazy_load_associated_classes = Gem::Version.new(IdentityCache::VERSION) >= Gem::Version.new("0.6")
 

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -20,6 +20,15 @@ class FetchTest < IdentityCache::TestCase
     assert_nil Item.fetch_by_id('garbage')
   end
 
+  def test_fetch_with_corrupted_cache
+    attributes = @record.attributes_before_type_cast
+    attributes["id"] += 1
+    IdentityCache.cache.expects(:fetch).with(@blob_key).returns(class: @record.class.name, attributes: attributes)
+
+    IdentityCache.raise_on_id_mismatch = true
+    assert_raises(IdentityCache::CorruptedCache) { Item.fetch(1) }
+  end
+
   def test_fetch_cache_hit
     IdentityCache.cache.expects(:fetch).with(@blob_key).returns(@cached_value)
 


### PR DESCRIPTION
Hello,

I recently found an issue on an application of mine that was leading to cache corruption. When that happened I was able to see very helpful lines like:

```
[IDC id mismatch] fetch_by_id_requested=248053 fetch_by_id_got=390397 for #<User id: 390397, email: ...
```

For my use case when this happen it actually make more sense to raise an exception to prevent the transaction from finishing with the wrong user. Would you consider adding a configuration option to enable this behavior ?

Thank you