### PR TITLE
Warn when a cache backend is used that doesn't support CAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Add this line to your application's Gemfile:
 ```ruby
 gem 'identity_cache'
 gem 'cityhash'        # optional, for faster hashing (C-Ruby only)
+gem 'memcached_store' # for CAS support, needed for cache consistency
 ```
 
 And then execute:
@@ -22,7 +23,12 @@ And then execute:
 Add the following to all your environment/*.rb files (production/development/test):
 
 ```ruby
-config.identity_cache_store = :mem_cache_store, Memcached::Rails.new(:servers => ["mem1.server.com"])
+config.identity_cache_store = :memcached_store,
+  Memcached::Rails.new(servers: ["mem1.server.com"],
+    support_cas: true,
+    auto_eject_hosts: false,  # avoids more cache consistency issues
+    expires_in: 6.hours.to_i, # in case of network errors when sending a delete
+  )
 ```
 
 Add an initializer with this code:

--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -13,6 +13,13 @@ module IdentityCache
       if cache_adaptor.respond_to?(:cas) && cache_adaptor.respond_to?(:cas_multi)
         @cache_fetcher = CacheFetcher.new(cache_adaptor)
       else
+        case cache_adaptor
+        when ActiveSupport::Cache::MemoryStore, ActiveSupport::Cache::NullStore
+          # no need for CAS support
+        else
+          warn "[IdentityCache] Missing CAS support in cache backend #{cache_adaptor.class} "\
+               "which is needed for cache consistency"
+        end
         @cache_fetcher = FallbackFetcher.new(cache_adaptor)
       end
     end


### PR DESCRIPTION
## Problem

We were recommending ActiveSupport::Cache::MemCacheStore in the README, which doesn't have CAS support so would result in cache consistency issues.  There was also no warning in the code when falling back to a cache adapter that will have cache consistency issues. 

## Solution

I updated the README to recommend using memcached_store with a few important configuration options.

If a cache backend is used that doesn't support CAS, then we will warn to let the developer know about these cache consistency errors.  I don't think the warning is needed for NullStore or MemoryStore, since those aren't expected to have distributed cache consistency and are mostly used for tests and development.