### PR TITLE
Check if cache should be used before expiry

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -461,6 +461,7 @@ module IdentityCache
     end
 
     def expire_cache # :nodoc:
+      return unless should_use_cache?
       expire_primary_index
       expire_attribute_indexes
       true


### PR DESCRIPTION
I noticed that it was possible to `expire_cache` on models that have `should_use_cache?` set to `false`. Since this causes a write, it can cause undesirable behaviour. 

cc @Shopify/pods 

TODO:

- [ ] Add tests

I'm not 100% certain this is the correct place to do this in IDC so I'd like  to check before I implement tests.