### PR TITLE
Allow case insensitive attribute values for secondary indexes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ _[:unique]_ Allows you to say that an index is unique (only one object stored at
 Example:
 `cache_index :handle`
 
+_[:case_insensitive]_ Allows you to specify attributes used in the secondary index for which the values should be downcased at cache key generation. This is helpful when indexing with nonbinary strings in MySQL.
+
+Example:
+`cache_index :vendor, :product_type, case_insensitive: [:product_type]`
+
 #### cache_has_many
 
 Options:

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -36,7 +36,7 @@ module IdentityCache
       end
 
       def rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, values, unique)
-        unique_indicator = unique ? '' : 's' 
+        unique_indicator = unique ? '' : 's'
         "#{rails_cache_key_namespace}" \
           "attr#{unique_indicator}" \
           ":#{base_class.name}" \


### PR DESCRIPTION
This PR fixes a simple bug caused my MySQL case insensitivity for nonbinary strings.

#### Disclaimer

It's not really about case sensitivity but about the actual database collation, I'll try to find a better solution than just the `downcase` hack that works in my use case

### The problem

Let's say we have a simple `DiscountCode` model with a secondary index on code `VARCHAR(255)`

```ruby
class DiscountCode < ActiveRecord::Base
   ...
   cache_index :code, unique: true
end
```

This is what happens when fetching with different cases, although bypassing IDC and using `find_by` would work because of MySQL collation.

```ruby
[0] DiscountCode.fetch_by_code("FOO")
=> # cache miss, secondary index created with "FOO"
[1] DiscountCode.create!(code: "foo")
=> # no secondary index "foo" to invalidate
[2] PriceRule::DiscountCode.fetch_by_code("FOO")
=> # cache hit, we can't retrieve the code
```

### The fix

When creating a secondary cache index, we can specify attributes that should be treated as case insensitive

```ruby
class DiscountCode < ActiveRecord::Base
   ...
   cache_index :code, unique: true, case_insensitive: [:code]
end
```

and then...

```ruby
[0] DiscountCode.fetch_by_code("FOO")
=> # cache miss, secondary index created with "foo" because it was downcased
[1] DiscountCode.create!(code: "foo")
=> # secondary index with "foo" invalidated
[2] PriceRule::DiscountCode.fetch_by_code("FOO")
=> # cache miss with "foo", we can retrieve the code! success
```

cc @gmalette 