### PR TITLE
Remove deprecated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 0.6.0 Unreleased
 
 - Remove disable_primary_cache_index
+- Remove deprecated `embed: false` cache_has_many option
 - Raise when trying to cache a belong_to association with a scope. Previously the scope was ignored on a cache hit (#323)
 - Remove deprecated `never_set_inverse_association` option (#319)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # IdentityCache changelog
 
-#### 0.6.0 Unreleased
+#### 1.0.0 Unreleased
 
 - Remove disable_primary_cache_index
 - Remove deprecated `embed: false` cache_has_many option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 0.6.0 Unreleased
 
+- Remove disable_primary_cache_index
 - Raise when trying to cache a belong_to association with a scope. Previously the scope was ignored on a cache hit (#323)
 - Remove deprecated `never_set_inverse_association` option (#319)
 

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -102,7 +102,6 @@ module IdentityCache
         ensure_base_model
         options = options.slice(:embed, :inverse_name)
         options[:embed] = :ids unless options.has_key?(:embed)
-        deprecate_embed_option(options, false, :ids)
         check_association_for_caching(association, options)
         self.cached_has_manys[association] = options
 
@@ -261,13 +260,6 @@ module IdentityCache
         query = query.limit(1) if unique_index
         results = query.pluck(attribute)
         unique_index ? results.first : results
-      end
-
-      def deprecate_embed_option(options, old_value, new_value)
-        if options[:embed] == old_value
-          options[:embed] = new_value
-          ActiveSupport::Deprecation.warn("`embed: #{old_value.inspect}` was renamed to `embed: #{new_value.inspect}` for clarity", caller(2))
-        end
       end
 
       def ensure_base_model

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -172,12 +172,6 @@ module IdentityCache
         cache_attribute_by_alias(attribute.inspect, attribute, options)
       end
 
-      def disable_primary_cache_index
-        ActiveSupport::Deprecation.warn("disable_primary_cache_index is deprecated, use `include IdentityCache::WithoutPrimaryIndex` instead")
-        ensure_base_model
-        self.primary_cache_index_enabled = false
-      end
-
       private
 
       def cache_attribute_by_alias(attribute, alias_name, options)

--- a/test/recursive_denormalized_has_many_test.rb
+++ b/test/recursive_denormalized_has_many_test.rb
@@ -126,6 +126,6 @@ end
 class DisabledPrimaryIndexTest < RecursiveDenormalizedHasManyTest
   def setup
     super
-    AssociatedRecord.disable_primary_cache_index
+    AssociatedRecord.primary_cache_index_enabled = false
   end
 end


### PR DESCRIPTION
Since the next release will have breaking changes, I thought we should any deprecated code.

This PR removes the disable_primary_cache_index method and the `embed: false` cache_has_many option.