### PR TITLE
Fix the column name in association query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove deprecated `embed: false` cache_has_many option
 - Raise when trying to cache a belong_to association with a scope. Previously the scope was ignored on a cache hit (#323)
 - Remove deprecated `never_set_inverse_association` option (#319)
+- Fix column name in the preload association query when using custom primary keys (#338)
 
 #### 0.5.1
 

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -228,7 +228,7 @@ module IdentityCache
           scope = child_model.all
           scope = scope.instance_exec(nil, &reflection.scope) if reflection.scope
 
-          pairs = scope.where(reflection.foreign_key => records.map(&:id)).pluck(reflection.foreign_key, reflection.active_record_primary_key)
+          pairs = scope.where(reflection.foreign_key => records.map(&:id)).pluck(reflection.foreign_key, reflection.association_primary_key)
           ids_by_parent = Hash.new{ |hash, key| hash[key] = [] }
           pairs.each do |parent_id, child_id|
             ids_by_parent[parent_id] << child_id

--- a/test/custom_primary_keys_test.rb
+++ b/test/custom_primary_keys_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class CustomPrimaryKeysTest < IdentityCache::TestCase
+  def setup
+    super
+    CustomMasterRecord.cache_has_many :custom_child_record
+    CustomChildRecord.cache_belongs_to :custom_master_record
+    @master_record = CustomMasterRecord.create!(master_primary_key: 1)
+    @child_record_1 = CustomChildRecord.create!(custom_master_record: @master_record, child_primary_key: 1)
+    @child_record_2 = CustomChildRecord.create!(custom_master_record: @master_record, child_primary_key: 2)
+  end
+
+  def test_fetch_master
+    assert_nothing_raised do
+      CustomMasterRecord.fetch @master_record.master_primary_key
+    end
+  end
+end

--- a/test/helpers/active_record_objects.rb
+++ b/test/helpers/active_record_objects.rb
@@ -37,6 +37,8 @@ module ActiveRecordObjects
     Deeply::Nested.send :remove_const, 'AssociatedRecord'
     Deeply.send :remove_const, 'Nested'
     Object.send :remove_const, 'Deeply'
+    Object.send :remove_const, 'CustomMasterRecord'
+    Object.send :remove_const, 'CustomChildRecord'
     IdentityCache.const_get(:ParentModelExpiration).send(:lazy_hooks).clear
   end
 end

--- a/test/helpers/database_connection.rb
+++ b/test/helpers/database_connection.rb
@@ -52,6 +52,8 @@ module DatabaseConnection
     :items2                        => [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
     :keyed_records                 => [[:string, :value], :primary_key => "hashed_key"],
     :sti_records                   => [[:string, :type], [:string, :name]],
+    :custom_master_records         => [[:integer, :master_primary_key], :id => false, :primary_key => 'master_primary_key'],
+    :custom_child_records          => [[:integer, :child_primary_key], [:integer, :master_id], :id => false, :primary_key => 'child_primary_key' ]
   }
 
   DEFAULT_CONFIG = {

--- a/test/helpers/models.rb
+++ b/test/helpers/models.rb
@@ -66,3 +66,15 @@ end
 
 class StiRecordTypeA < StiRecord
 end
+
+class CustomMasterRecord < ActiveRecord::Base
+  include IdentityCache
+  has_many :custom_child_record, foreign_key: :master_id
+  self.primary_key = 'master_primary_key'
+end
+
+class CustomChildRecord < ActiveRecord::Base
+  include IdentityCache
+  belongs_to :custom_master_record, foreign_key: :master_id
+  self.primary_key = 'child_primary_key'
+end


### PR DESCRIPTION
This didn't work correctly for the models using custom primary key.

Fixes https://github.com/Shopify/identity_cache/issues/338