### PR TITLE
Use keyword arguments to raise when an invalid options is passed in

### DIFF
--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -8,9 +8,8 @@ module IdentityCache
     end
 
     module ClassMethods
-      def cache_belongs_to(association, options = {})
+      def cache_belongs_to(association)
         ensure_base_model
-        raise NotImplementedError if options[:embed]
 
         unless association_reflection = reflect_on_association(association)
           raise AssociationError, "Association named '#{association}' was not found on #{self.class}"

--- a/test/helpers/serialization_format.rb
+++ b/test/helpers/serialization_format.rb
@@ -1,7 +1,7 @@
 module SerializationFormat
   def serialized_record
     AssociatedRecord.cache_has_many :deeply_associated_records, :embed => true
-    AssociatedRecord.cache_belongs_to :item, :embed => false
+    AssociatedRecord.cache_belongs_to :item
     Item.cache_has_many :associated_records, :embed => true
     Item.cache_has_one :associated
     time = Time.parse('1970-01-01T00:00:00 UTC')

--- a/test/normalized_belongs_to_test.rb
+++ b/test/normalized_belongs_to_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class NormalizedBelongsToTest < IdentityCache::TestCase
   def setup
     super
-    AssociatedRecord.cache_belongs_to :item, :embed => false
+    AssociatedRecord.cache_belongs_to :item
 
     @parent_record = Item.new(:title => 'foo')
     @parent_record.associated_records << AssociatedRecord.new(:name => 'bar')
@@ -49,7 +49,7 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
 
   def test_cache_belongs_to_on_derived_model_raises
     assert_raises(IdentityCache::DerivedModelError) do
-      StiRecordTypeA.cache_belongs_to :item, :embed => false
+      StiRecordTypeA.cache_belongs_to :item
     end
   end
 

--- a/test/prefetch_associations_test.rb
+++ b/test/prefetch_associations_test.rb
@@ -186,7 +186,7 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
   end
 
   def test_fetch_multi_batch_fetches_first_level_belongs_to_associations
-    AssociatedRecord.send(:cache_belongs_to, :item, :embed => false)
+    AssociatedRecord.send(:cache_belongs_to, :item)
 
     @bob_child  = @bob.associated_records.create!(:name => "bob child")
     @fred_child = @fred.associated_records.create!(:name => "fred child")
@@ -238,8 +238,8 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
   end
 
   def test_fetch_multi_batch_fetches_non_embedded_second_level_belongs_to_associations
-    Item.send(:cache_belongs_to, :item, :embed => false)
-    AssociatedRecord.send(:cache_belongs_to, :item, :embed => false)
+    Item.send(:cache_belongs_to, :item)
+    AssociatedRecord.send(:cache_belongs_to, :item)
 
     @bob_child  = @bob.associated_records.create!(:name => "bob child")
     @fred_child = @fred.associated_records.create!(:name => "fred child")
@@ -261,7 +261,7 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
   end
 
   def test_fetch_multi_doesnt_batch_fetches_belongs_to_associations_if_the_foreign_key_isnt_present
-    AssociatedRecord.send(:cache_belongs_to, :item, :embed => false)
+    AssociatedRecord.send(:cache_belongs_to, :item)
     @child = AssociatedRecord.create!(:name => "bob child")
     # populate the cache entry
     AssociatedRecord.fetch_multi(@child.id)


### PR DESCRIPTION
## Problem

It can be hard to keep track of what options are accepted some IDC methods that take an options hash, since the IDC documentation isn't complete.

I also noticed some code in Shopify was passing in `class_name:` which was just getting ignored.  Reading code like this can add more confusion which I would prefer to stop by having these methods raise if an unknown argument is passed in.

## Solution

Use keyword arguments, which will raise if options aren't provided.  This also means information about the available options and their defaults can be seen from the method signature itself.  It will also make it easier to see what options still need to be documented if documentation is missed for an option.