### PR TITLE
Stop making readonly copy of loaded belongs_to association.

### DIFF
--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -45,11 +45,7 @@ module IdentityCache
                 @#{options[:records_variable_name]} = association_klass.fetch_by_id(#{foreign_key})
               end
             else
-              if IdentityCache.fetch_read_only_records && association_klass.should_use_cache?
-                readonly_copy(association(:#{association}).load_target)
-              else
-                #{association}
-              end
+              #{association}
             end
           end
 


### PR DESCRIPTION
## Problem

Calling the `fetch_`* method for a cache_belongs_to association when the Active Record association is already loaded will make a read-only copy of the record on each call to the method.  This is inconsistent with the `cache_has_`* associations (see [build_id_embedded_has_many_cache](https://github.com/Shopify/identity_cache/blob/cd76435dbdb3b53a0cc754c557244d050d61e7eb/lib/identity_cache/configuration_dsl.rb#L232) and [fetch_recursively_cached_association](https://github.com/Shopify/identity_cache/blob/cd76435dbdb3b53a0cc754c557244d050d61e7eb/lib/identity_cache/query_api.rb#L440)), which don't mark the records read-only, since there isn't an attempt to fetch them from the cache in this situation.

## Solution

Remove the conditional `readonly_copy` from the fetch method for cache_belongs_to