### PR TITLE
Always lazy load associatied classes rather than making it configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 1.0.0 Unreleased
 
+- Lazy load associated classes (#306)
 - Remove disable_primary_cache_index
 - Remove deprecated `embed: false` cache_has_many option
 - Raise when trying to cache a belong_to association with a scope. Previously the scope was ignored on a cache hit (#323)

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -55,9 +55,6 @@ module IdentityCache
     mattr_accessor :fetch_read_only_records
     self.fetch_read_only_records = true
 
-    mattr_accessor :lazy_load_associated_classes
-    self.lazy_load_associated_classes = Gem::Version.new(IdentityCache::VERSION) >= Gem::Version.new("0.6")
-
     def included(base) #:nodoc:
       raise AlreadyIncludedError if base.respond_to?(:cached_model)
       base.class_attribute :cached_model

--- a/lib/identity_cache/parent_model_expiration.rb
+++ b/lib/identity_cache/parent_model_expiration.rb
@@ -6,19 +6,8 @@ module IdentityCache
       def add_parent_expiry_hook(cached_association_hash)
         association_reflection = cached_association_hash[:association_reflection]
         name = model_basename(association_reflection.class_name)
-        if IdentityCache.lazy_load_associated_classes
-          lazy_hooks[name] ||= []
-          lazy_hooks[name] << cached_association_hash
-        else
-          child_model = association_reflection.klass
-          unless child_model < IdentityCache
-            message = "associated class #{child_model} will need to include IdentityCache or " \
-              "IdentityCache::WithoutPrimaryIndex for embedded associations"
-            ActiveSupport::Deprecation.warn(message, caller(3))
-            child_model.send(:include, IdentityCache::WithoutPrimaryIndex)
-          end
-          install_hook(cached_association_hash)
-        end
+        lazy_hooks[name] ||= []
+        lazy_hooks[name] << cached_association_hash
       end
 
       def install_all_pending_parent_expiry_hooks

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -141,8 +141,6 @@ module IdentityCache
 
       def set_inverse_of_cached_has_many(record, association_reflection, child_records)
         associated_class = association_reflection.klass
-        return unless associated_class < IdentityCache
-
         inverse_name = record.class.cached_has_manys.fetch(association_reflection.name).fetch(:inverse_name)
         inverse_cached_association = associated_class.cached_belongs_tos[inverse_name]
         return unless inverse_cached_association
@@ -254,10 +252,8 @@ module IdentityCache
         end
         recursively_embedded_associations.each_value do |options|
           child_model = options.fetch(:association_reflection).klass
-          if child_model.include?(IdentityCache)
-            child_records = records.flat_map(&options.fetch(:cached_accessor_name).to_sym).compact
-            child_model.send(:preload_id_embedded_associations, child_records)
-          end
+          child_records = records.flat_map(&options.fetch(:cached_accessor_name).to_sym).compact
+          child_model.send(:preload_id_embedded_associations, child_records)
         end
       end
 

--- a/test/lazy_load_associated_classes_test.rb
+++ b/test/lazy_load_associated_classes_test.rb
@@ -1,17 +1,6 @@
 require "test_helper"
 
 class LazyLoadAssociatedClassesTest < IdentityCache::TestCase
-  def setup
-    @old_lazy_load_associated_classes = IdentityCache.lazy_load_associated_classes
-    IdentityCache.lazy_load_associated_classes = true
-    super
-  end
-
-  def teardown
-    super
-    IdentityCache.lazy_load_associated_classes = @old_lazy_load_associated_classes
-  end
-
   def test_cache_has_many_does_not_load_associated_class
     Item.has_many :missing_model
     Item.cache_has_many :missing_model


### PR DESCRIPTION
The next release already has breaking changes in it, so we may as well remove the IdentityCache.lazy_load_associated_classes configuration to cleanup the code, since we are already unconditionally setting it to `true` in Shopify.