### PR TITLE
Set inverse cached association for cache_has_one on cache hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 1.0.0 Unreleased
 
+- Set inverse cached association for cache_has_one on cache hit (#345)
 - Lazy load associated classes (#306)
 - Remove disable_primary_cache_index
 - Remove deprecated `embed: false` cache_has_many option

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -191,10 +191,15 @@ module IdentityCache
         options[:association_reflection] = reflect_on_association(association)
         options[:cached_accessor_name]   = "fetch_#{association}"
         options[:records_variable_name]  = "cached_#{association}"
+        options[:prepopulate_method_name] = "prepopulate_fetched_#{association}"
 
         self.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
           def #{options[:cached_accessor_name]}
             fetch_recursively_cached_association('#{options[:records_variable_name]}', :#{association})
+          end
+
+          def #{options[:prepopulate_method_name]}(records)
+            @#{options[:records_variable_name]} = records
           end
         CODE
 

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -150,6 +150,17 @@ module IdentityCache
         end
       end
 
+      def set_embedded_association(record, association_name, association_target) #:nodoc:
+        model = record.class
+        association_options = model.send(:cached_association_options, association_name)
+
+        reflection = model.reflect_on_association(association_name)
+        set_inverse_of_cached_association(record, association_options, association_target)
+
+        prepopulate_method_name = association_options.fetch(:prepopulate_method_name)
+        record.send(prepopulate_method_name, association_target)
+      end
+
       def set_inverse_of_cached_association(record, association_options, association_target)
         return if association_target.nil?
         associated_class = association_options.fetch(:association_reflection).klass
@@ -163,17 +174,6 @@ module IdentityCache
         else
           association_target.send(prepopulate_method_name, record)
         end
-      end
-
-      def set_embedded_association(record, association_name, association_target) #:nodoc:
-        model = record.class
-        association_options = model.send(:cached_association_options, association_name)
-
-        reflection = model.reflect_on_association(association_name)
-        set_inverse_of_cached_association(record, association_options, association_target)
-
-        prepopulate_method_name = association_options.fetch(:prepopulate_method_name)
-        record.send(prepopulate_method_name, association_target)
       end
 
       def get_embedded_association(record, association, options) #:nodoc:

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -97,6 +97,18 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     assert_nothing_raised { ar.expire_parent_caches }
   end
 
+  def test_set_inverse_cached_association
+    AssociatedRecord.cache_belongs_to :item
+    Item.fetch(@record.id) # warm cache
+    item = Item.fetch(@record.id)
+
+    assert_no_queries do
+      assert_memcache_operations(0) do
+        item.fetch_associated.fetch_item
+      end
+    end
+  end
+
   def test_cache_without_guessable_inverse_name_raises
     assert_raises IdentityCache::InverseAssociationError do
       Item.cache_has_one :polymorphic_record, :embed => true


### PR DESCRIPTION
## Problem

For a `cache_has_many` we were setting the inverse cached association for associated records, but we weren't doing the same thing for `cache_has_one`.

## Solution

I generalized `set_inverse_of_cached_has_many` into `set_inverse_of_cached_association` which no longer assumes that the cached association options are in `cached_has_manys` or that the association target is an array.

To make it easier to get the cached association options across associations types, I've added `cached_association_options` which is used in `set_embedded_association`.  I've also added a `:prepopulate_method_name` cached association option key and associated method for recursively embedded associations to avoid yet another inconsistency.

I have also separated out the step to turn the coder objects into their corresponding active record objects to keep `set_embedded_association` more focused.

The added regression test fails without the other changes in this PR.