### PR TITLE
Add support for blob replication.

### DIFF
--- a/lib/identity_cache/replicated_cache_proxy.rb
+++ b/lib/identity_cache/replicated_cache_proxy.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module IdentityCache
+  class ReplicatedCacheProxy
+    def initialize(cache_backend, blob_replication_factor:)
+      @cache_backend = cache_backend
+      @blob_replication_factor = blob_replication_factor
+    end
+
+    def write(key, value)
+      keys(key).each do |key|
+        cache_backend.write(key, value)
+      end
+    end
+
+    def delete(key)
+      keys(key).each do |key|
+        cache_backend.delete(key)
+      end
+    end
+
+    def fetch(key)
+      cache_backend.fetch(keys(key).sample)
+    end
+
+    def fetch_multi(*keys)
+      result = {}
+      cache_backend.fetch_multi(*keys.map { |key| keys(key).sample }).each do |k, v|
+        result[k[0...-2]] = v
+      end
+      result
+    end
+
+    def clear
+      cache_backend.clear
+    end
+
+    private
+
+    attr_reader(:cache_backend, :blob_replication_factor)
+
+    def keys(key)
+      blob_replication_factor.times.map { |i| "#{key}:#{i}" }
+    end
+  end
+end

--- a/test/replicated_cache_proxy_test.rb
+++ b/test/replicated_cache_proxy_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class ReplicatedCacheProxyTest < IdentityCache::TestCase
+  def setup
+    super
+    @backend = ActiveSupport::Cache::MemoryStore.new
+    @proxy = IdentityCache::ReplicatedCacheProxy.new(@backend, blob_replication_factor: 2)
+  end
+
+  def test_write_writes_both_keys
+    @proxy.write("k", "tacocat")
+    assert_equal("tacocat", @backend.fetch("k:0"))
+    assert_equal("tacocat", @backend.fetch("k:1"))
+  end
+
+  def test_deletes_both_keys
+    @backend.write("k:0", "tacocat")
+    @backend.write("k:1", "tacocat")
+    @proxy.delete("k")
+    assert_nil(@backend.fetch("k:0"))
+    assert_nil(@backend.fetch("k:1"))
+  end
+
+  def test_fetch_will_return_value_from_one_of_the_keys
+    @backend.write("k:0", "tacocat")
+    @backend.write("k:1", "tacocat")
+    assert_equal("tacocat", @proxy.fetch("k"))
+  end
+
+  def test_fetch_multi_will_return_a_mix_of_values
+    @backend.write("k:0", "tacocat")
+    @backend.write("k:1", "tacocat")
+    @backend.write("l:0", "tacodog")
+    @backend.write("l:1", "tacodog")
+    assert_equal({ "k" => "tacocat", "l" => "tacodog" }, @proxy.fetch_multi("k", "l"))
+  end
+
+  def test_clear_clears_the_backend
+    @backend.write("k:0", "tacocat")
+    @proxy.clear
+    assert_nil(@backend.fetch("k:0"))
+  end
+end


### PR DESCRIPTION
An access pattern we see is when a sigle row becomes really hot. Because of the way memcached works, all the load goes to a single memcached server, which we have seen become slow.

This PR does not fix the issue, but mitigates it by replicating blobs under multiple keys. For 2 replicas, there is a (_n_ - 1) / _n_ chance they fall on different servers and the load is split, given a memcached ring of _n_ servers.

An alternative would be to do the replication right in the memcached client, as the distribution is computed so we could pick instead the _n_ + _k_ (mod _n_) th server instead of a random one to make sure they land on different machines.

@csfrancis, @sirupsen is that what you had in mind?