### PR TITLE
Update readme config to reflect Memcached::Rails deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ Add the following to all your environment/*.rb files (production/development/tes
 
 ```ruby
 config.identity_cache_store = :memcached_store,
-  Memcached::Rails.new(servers: ["mem1.server.com"],
+  Memcached.new(["mem1.server.com"],
     support_cas: true,
     auto_eject_hosts: false,  # avoids more cache consistency issues
-    expires_in: 6.hours.to_i, # in case of network errors when sending a delete
-  )
+  ), { expires_in: 6.hours.to_i } # in case of network errors when sending a delete
 ```
 
 Add an initializer with this code:


### PR DESCRIPTION
- Memcached::Rails form the memcached_store gem is no longer supported
- Universal options like `expires_in` should be passed after instance creation
- The servers list is the first argument to `Memcached#initialize`, not an option
  or kwarg