### PR TITLE
Type cast values using attribute types before using in cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 1.0.0 Unreleased
 
+- Type cast values using attribute types before using in cache key (#354)
 - Remove support for rails 4.2 (#355)
 - Set inverse cached association for cache_has_one on cache hit (#345)
 - Lazy load associated classes (#306)

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -51,7 +51,7 @@ module IdentityCache
 
       private
       def rails_cache_string_for_fields_and_values(fields, values)
-        "#{fields.join('/')}:#{IdentityCache.memcache_hash(values.join('/'))}"
+        "#{fields.join('/')}:#{IdentityCache.memcache_hash(values.map(&:to_json).join('/'))}"
       end
     end
 

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -51,7 +51,7 @@ module IdentityCache
 
       private
       def rails_cache_string_for_fields_and_values(fields, values)
-        "#{fields.join('/')}:#{IdentityCache.memcache_hash(values.map(&:to_json).join('/'))}"
+        "#{fields.join('/')}:#{IdentityCache.memcache_hash(values.map { |v| v.try!(:to_s).inspect }.join('/'))}"
       end
     end
 

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -245,6 +245,10 @@ module IdentityCache
       def attribute_dynamic_fetcher(attribute, fields, values, unique_index) #:nodoc:
         raise_if_scoped
 
+        fields.each_with_index do |field, i|
+          values[i] = type_for_attribute(field.to_s).cast(values[i])
+        end
+
         if should_use_cache?
           cache_key = rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, values, unique_index)
           IdentityCache.fetch(cache_key) do

--- a/test/attribute_cache_test.rb
+++ b/test/attribute_cache_test.rb
@@ -9,7 +9,7 @@ class AttributeCacheTest < IdentityCache::TestCase
 
     @parent = Item.create!(:title => 'bob')
     @record = @parent.associated_records.create!(:name => 'foo')
-    @name_attribute_key = "#{NAMESPACE}attr:AssociatedRecord:name:id:#{cache_hash(@record.id.to_s)}"
+    @name_attribute_key = "#{NAMESPACE}attr:AssociatedRecord:name:id:#{cache_hash(@record.id.to_s.inspect)}"
     IdentityCache.cache.clear
   end
 

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -267,6 +267,13 @@ class FetchMultiTest < IdentityCache::TestCase
     assert_equal cache_response_for(Item.find(@bob.id)), backend.read(@bob.primary_cache_index_key)
   end
 
+  def test_fetch_multi_id_coercion
+    assert_equal @joe.title, Item.fetch_multi(@joe.id.to_f).first.title
+    @joe.update_attributes!(title: "#{@joe.title} changed")
+
+    assert_equal @joe.title, Item.fetch_multi(@joe.id.to_f).first.title
+  end
+
   def test_fetch_multi_raises_when_called_on_a_scope
     assert_raises(IdentityCache::UnsupportedScopeError) do
       Item.where(updated_at: nil).fetch_multi(@bob.id, @joe.id, @fred.id)

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -13,7 +13,7 @@ class FetchTest < IdentityCache::TestCase
     @record.title = 'bob'
     @cached_value = { class: @record.class.name, attributes: @record.attributes_before_type_cast }
     @blob_key = "#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:1"
-    @index_key = "#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}"
+    @index_key = "#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}"
   end
 
   def test_fetch_with_garbage_input
@@ -206,6 +206,13 @@ class FetchTest < IdentityCache::TestCase
 
     @record.save!
     assert_equal IdentityCache::DELETED, backend.read(key)
+  end
+
+  def test_fetch_id_coercion
+    assert_nil Item.fetch_by_id(@record.id.to_f)
+    @record.save!
+
+    assert_equal @record, Item.fetch_by_id(@record.id.to_f)
   end
 
   def test_fetch_by_title_hit

--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -156,6 +156,6 @@ class IndexCacheTest < IdentityCache::TestCase
   private
 
   def cache_key(unique: false)
-    "#{NAMESPACE}attr#{unique ? '' : 's'}:Item:id:title:#{cache_hash(@record.title)}"
+    "#{NAMESPACE}attr#{unique ? '' : 's'}:Item:id:title:#{cache_hash(@record.title.to_json)}"
   end
 end

--- a/test/save_test.rb
+++ b/test/save_test.rb
@@ -9,28 +9,29 @@ class SaveTest < IdentityCache::TestCase
     Item.cache_index :id, :title, :unique => true
 
     @record = Item.create(:title => 'bob')
-    @blob_key = "#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:1"
+    @blob_key_prefix = "#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:"
+    @blob_key = "#{@blob_key_prefix}1"
   end
 
   def test_create
     @record = Item.new
     @record.title = 'bob'
 
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('2/bob')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
-    expect_cache_delete("#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:2").once
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('2/"bob"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}")
+    expect_cache_delete("#{@blob_key_prefix}2").once
     @record.save
   end
 
   def test_update
     # Regular flow, write index id, write index id/tile, delete data blob since Record has changed
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/fred')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('fred')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/"fred"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"fred"')}")
     expect_cache_delete(@blob_key)
 
     # Delete index id, delete index id/title
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/"bob"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}")
 
     @record.title = 'fred'
     @record.save
@@ -38,8 +39,8 @@ class SaveTest < IdentityCache::TestCase
 
   def test_destroy
     # Regular flow: delete data blob, delete index id, delete index id/tile
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/"bob"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}")
     expect_cache_delete(@blob_key)
 
     @record.destroy
@@ -47,8 +48,8 @@ class SaveTest < IdentityCache::TestCase
 
   def test_destroy_with_changed_attributes
     # Make sure to delete the old cache index key, since the new title never ended up in an index
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/"bob"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}")
     expect_cache_delete(@blob_key)
 
     @record.title = 'fred'
@@ -57,16 +58,16 @@ class SaveTest < IdentityCache::TestCase
 
   def test_touch_will_expire_the_caches
     # Regular flow: delete data blob, delete index id, delete index id/tile
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/"bob"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}")
     expect_cache_delete(@blob_key)
 
     @record.touch
   end
 
   def test_expire_cache_works_in_a_transaction
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/bob')}")
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('bob')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/"bob"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}")
     expect_cache_delete(@blob_key)
 
     ActiveRecord::Base.transaction do

--- a/test/save_test.rb
+++ b/test/save_test.rb
@@ -17,7 +17,7 @@ class SaveTest < IdentityCache::TestCase
     @record = Item.new
     @record.title = 'bob'
 
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('2/"bob"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('"2"/"bob"')}")
     expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}")
     expect_cache_delete("#{@blob_key_prefix}2").once
     @record.save
@@ -25,12 +25,12 @@ class SaveTest < IdentityCache::TestCase
 
   def test_update
     # Regular flow, write index id, write index id/tile, delete data blob since Record has changed
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/"fred"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('"1"/"fred"')}")
     expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"fred"')}")
     expect_cache_delete(@blob_key)
 
     # Delete index id, delete index id/title
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/"bob"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('"1"/"bob"')}")
     expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}")
 
     @record.title = 'fred'
@@ -39,7 +39,7 @@ class SaveTest < IdentityCache::TestCase
 
   def test_destroy
     # Regular flow: delete data blob, delete index id, delete index id/tile
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/"bob"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('"1"/"bob"')}")
     expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}")
     expect_cache_delete(@blob_key)
 
@@ -48,7 +48,7 @@ class SaveTest < IdentityCache::TestCase
 
   def test_destroy_with_changed_attributes
     # Make sure to delete the old cache index key, since the new title never ended up in an index
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/"bob"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('"1"/"bob"')}")
     expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}")
     expect_cache_delete(@blob_key)
 
@@ -58,7 +58,7 @@ class SaveTest < IdentityCache::TestCase
 
   def test_touch_will_expire_the_caches
     # Regular flow: delete data blob, delete index id, delete index id/tile
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/"bob"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('"1"/"bob"')}")
     expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}")
     expect_cache_delete(@blob_key)
 
@@ -66,7 +66,7 @@ class SaveTest < IdentityCache::TestCase
   end
 
   def test_expire_cache_works_in_a_transaction
-    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('1/"bob"')}")
+    expect_cache_delete("#{NAMESPACE}attr:Item:id:id/title:#{cache_hash('"1"/"bob"')}")
     expect_cache_delete("#{NAMESPACE}attr:Item:id:title:#{cache_hash('"bob"')}")
     expect_cache_delete(@blob_key)
 


### PR DESCRIPTION
Fixes #352 
~~Depends on #355~~

## Problem

If we don't coerce values before using them as part of cache keys, then we can end up caching the data in a key that won't get expired when the data changes.

We also need to make sure we don't encode the values in a way that can result in conflicts between sets of values.  For example, when we just use `to_s` to encode a value in a cache key, then there can be conflicts between `nil` and `""`.

## Solution

Use `type_for_attribute(field_name).cast(value)` on the model to use active record's attribute casting logic to normalize values before using them in the cache key.

I also changed the way values are encoded in cache keys for `cache_attribute` from implicitly using `.to_s` to instead use `to_json` so that `nil` and `""` get encoded differently.