### PR TITLE
Use the Active Support Notification convention for instrumentation name

### DIFF
--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -39,7 +39,7 @@ module IdentityCache
 
     def write(key, value)
       memoizing = memoizing?
-      ActiveSupport::Notifications.instrument('identity_cache.cache.write', memoizing: memoizing) do
+      ActiveSupport::Notifications.instrument('cache_write.identity_cache', memoizing: memoizing) do
         memoized_key_values[key] = value if memoizing
         @cache_fetcher.write(key, value)
       end
@@ -47,7 +47,7 @@ module IdentityCache
 
     def delete(key)
       memoizing = memoizing?
-      ActiveSupport::Notifications.instrument('identity_cache.cache.delete', memoizing: memoizing) do
+      ActiveSupport::Notifications.instrument('cache_delete.identity_cache', memoizing: memoizing) do
         memoized_key_values.delete(key) if memoizing
         result = @cache_fetcher.delete(key)
         IdentityCache.logger.debug {"[IdentityCache] delete #{ result ? 'recorded' : 'failed'  } for #{key}"}
@@ -59,7 +59,7 @@ module IdentityCache
       memo_misses = 0
       cache_misses = 0
 
-      value = ActiveSupport::Notifications.instrument('identity_cache.cache.fetch') do |payload|
+      value = ActiveSupport::Notifications.instrument('cache_fetch.identity_cache') do |payload|
         payload[:resolve_miss_time] = 0.0
 
         value = fetch_memoized(key) do
@@ -88,7 +88,7 @@ module IdentityCache
       memo_miss_keys = EMPTY_ARRAY
       cache_miss_keys = EMPTY_ARRAY
 
-      result = ActiveSupport::Notifications.instrument('identity_cache.cache.fetch_multi') do |payload|
+      result = ActiveSupport::Notifications.instrument('cache_fetch_multi.identity_cache') do |payload|
         payload[:resolve_miss_time] = 0.0
 
         result = fetch_multi_memoized(keys) do |non_memoized_keys|
@@ -112,7 +112,7 @@ module IdentityCache
     end
 
     def clear
-      ActiveSupport::Notifications.instrument('identity_cache.cache.clear') do
+      ActiveSupport::Notifications.instrument('cache_clear.identity_cache') do
         clear_memoization
         @cache_fetcher.clear
       end

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -125,7 +125,7 @@ module IdentityCache
 
       def instrumented_record_from_coder(coder) #:nodoc:
         return unless coder
-        ActiveSupport::Notifications.instrument('identity_cache.hydration', class: coder[:class]) do
+        ActiveSupport::Notifications.instrument('hydration.identity_cache', class: coder[:class]) do
           record_from_coder(coder)
         end
       end
@@ -190,7 +190,7 @@ module IdentityCache
 
       def instrumented_coder_from_record(record) #:nodoc:
         return unless record
-        ActiveSupport::Notifications.instrument('identity_cache.dehydration', class: record.class.name) do
+        ActiveSupport::Notifications.instrument('dehydration.identity_cache', class: record.class.name) do
           coder_from_record(record)
         end
       end

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -46,7 +46,7 @@ class FetchMultiTest < IdentityCache::TestCase
     IdentityCache.cache.expects(:fetch_multi).with(@bob_blob_key, @joe_blob_key, @fred_blob_key).returns(cache_response)
 
     events = 0
-    subscriber = ActiveSupport::Notifications.subscribe('identity_cache.hydration') do |_, _, _, _, payload|
+    subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
       events += 1
       assert_equal "Item", payload[:class]
     end
@@ -74,7 +74,7 @@ class FetchMultiTest < IdentityCache::TestCase
     fetch_multi_stub(cache_response)
 
     events = 0
-    subscriber = ActiveSupport::Notifications.subscribe('identity_cache.dehydration') do |_, _, _, _, payload|
+    subscriber = ActiveSupport::Notifications.subscribe('dehydration.identity_cache') do |_, _, _, _, payload|
       events += 1
       assert_equal "Item", payload[:class]
     end
@@ -102,7 +102,7 @@ class FetchMultiTest < IdentityCache::TestCase
       Item.fetch(@fred.id)
       expected = { memoizing: true, memo_hits: 1, cache_hits: 1, cache_misses: 1 }
       events = 0
-      subscriber = ActiveSupport::Notifications.subscribe('identity_cache.cache.fetch_multi') do |_, _, _, _, payload|
+      subscriber = ActiveSupport::Notifications.subscribe('cache_fetch_multi.identity_cache') do |_, _, _, _, payload|
         events += 1
         assert payload.delete(:resolve_miss_time) > 0
         assert_equal expected, payload

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -30,7 +30,7 @@ class FetchTest < IdentityCache::TestCase
     IdentityCache.cache.expects(:fetch).with(@blob_key).returns(@cached_value)
 
     events = 0
-    subscriber = ActiveSupport::Notifications.subscribe('identity_cache.hydration') do |_, _, _, _, payload|
+    subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
       events += 1
       assert_equal "Item", payload[:class]
     end
@@ -45,7 +45,7 @@ class FetchTest < IdentityCache::TestCase
     expected = { memoizing: false, resolve_miss_time: 0, memo_hits: 0, cache_hits: 1, cache_misses: 0 }
 
     events = 0
-    subscriber = ActiveSupport::Notifications.subscribe('identity_cache.cache.fetch') do |_, _, _, _, payload|
+    subscriber = ActiveSupport::Notifications.subscribe('cache_fetch.identity_cache') do |_, _, _, _, payload|
       events += 1
       assert_equal expected, payload
     end
@@ -63,7 +63,7 @@ class FetchTest < IdentityCache::TestCase
     IdentityCache.cache.with_memoization do
       Item.fetch(1)
       events = 0
-      subscriber = ActiveSupport::Notifications.subscribe('identity_cache.cache.fetch') do |_, _, _, _, payload|
+      subscriber = ActiveSupport::Notifications.subscribe('cache_fetch.identity_cache') do |_, _, _, _, payload|
         events += 1
         assert_equal expected, payload
       end
@@ -112,7 +112,7 @@ class FetchTest < IdentityCache::TestCase
     Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
 
     events = 0
-    subscriber = ActiveSupport::Notifications.subscribe('identity_cache.dehydration') do |_, _, _, _, payload|
+    subscriber = ActiveSupport::Notifications.subscribe('dehydration.identity_cache') do |_, _, _, _, payload|
       events += 1
       assert_equal "Item", payload[:class]
     end
@@ -127,7 +127,7 @@ class FetchTest < IdentityCache::TestCase
     expected = { memoizing: false, memo_hits: 0, cache_hits: 0, cache_misses: 1 }
 
     events = 0
-    subscriber = ActiveSupport::Notifications.subscribe('identity_cache.cache.fetch') do |_, _, _, _, payload|
+    subscriber = ActiveSupport::Notifications.subscribe('cache_fetch.identity_cache') do |_, _, _, _, payload|
       events += 1
       assert payload.delete(:resolve_miss_time) > 0
       assert_equal expected, payload

--- a/test/memoized_cache_proxy_test.rb
+++ b/test/memoized_cache_proxy_test.rb
@@ -108,7 +108,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
   def test_write_notifies
     events = 0
     expected = { memoizing: false }
-    subscriber = ActiveSupport::Notifications.subscribe('identity_cache.cache.write') do |_, _, _, _, payload|
+    subscriber = ActiveSupport::Notifications.subscribe('cache_write.identity_cache') do |_, _, _, _, payload|
       events += 1
       assert_equal expected, payload
     end
@@ -121,7 +121,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
   def test_delete_notifies
     events = 0
     expected = { memoizing: false }
-    subscriber = ActiveSupport::Notifications.subscribe('identity_cache.cache.delete') do |_, _, _, _, payload|
+    subscriber = ActiveSupport::Notifications.subscribe('cache_delete.identity_cache') do |_, _, _, _, payload|
       events += 1
       assert_equal expected, payload
     end
@@ -133,7 +133,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
 
   def test_clear_notifies
     events = 0
-    subscriber = ActiveSupport::Notifications.subscribe('identity_cache.cache.clear') do |_, _, _, _, payload|
+    subscriber = ActiveSupport::Notifications.subscribe('cache_clear.identity_cache') do |_, _, _, _, payload|
       events += 1
       assert payload.empty?
     end

--- a/test/recursive_denormalized_has_many_test.rb
+++ b/test/recursive_denormalized_has_many_test.rb
@@ -56,7 +56,7 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
 
   def test_on_cache_hit_record_should_publish_one_dehydration_notification
     events = 0
-    subscriber = ActiveSupport::Notifications.subscribe('identity_cache.dehydration') do |_, _, _, _, payload|
+    subscriber = ActiveSupport::Notifications.subscribe('dehydration.identity_cache') do |_, _, _, _, payload|
       events += 1
       assert_equal "Item", payload[:class]
     end
@@ -73,7 +73,7 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
     AssociatedRecord.any_instance.expects(:deeply_associated_records).never
 
     events = 0
-    subscriber = ActiveSupport::Notifications.subscribe('identity_cache.hydration') do |_, _, _, _, payload|
+    subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
       events += 1
       assert_equal "Item", payload[:class]
     end


### PR DESCRIPTION
The convention is `event.library` and using this convention make possible to use ActiveSupport::Subscriber.attach_to method to attach to all events of the gem.

Also the `.` should be only used to separate the event from the library and not as namespace in the event.

Closes #358.