### PR TITLE
Fix exceptions from renaming classes by not using a cached name

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -109,17 +109,19 @@ module IdentityCache
       protected
 
       def record_from_coder(coder) #:nodoc:
-        if coder
-          record = instantiate(coder[:attributes].dup)
+        return nil unless coder
 
+        record = instantiate(coder[:attributes].dup)
+
+        if coder.has_key?(:associations)
           coder[:associations].each do |name, value|
             associated_class = reflect_on_association(name).klass
             set_embedded_association(record, name, hydrate_association_target(associated_class, value))
-          end if coder.has_key?(:associations)
-          coder[:association_ids].each {|name, ids| record.instance_variable_set(:"@#{record.class.cached_has_manys[name][:ids_variable_name]}", ids) } if coder.has_key?(:association_ids)
-          record.readonly! if IdentityCache.fetch_read_only_records
-          record
+          end
         end
+        coder[:association_ids].each {|name, ids| record.instance_variable_set(:"@#{record.class.cached_has_manys[name][:ids_variable_name]}", ids) } if coder.has_key?(:association_ids)
+        record.readonly! if IdentityCache.fetch_read_only_records
+        record
       end
 
       private


### PR DESCRIPTION
Closes #365

## Problem

We were storing the cache name for records in the cache, so renaming a class would result in a NameError when using cache entries from before the rename.

## Solution

We don't actually need the class name, since `fetch_by_id` and `fetch_multi` are called on the class and associated classes we can get from the association.

The class name is still stored in the class for now, so this can be rolled out without causing problems during deploys or if a rollback is needed.