### PR TITLE
Log delete failed on error level

### DIFF
--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -49,8 +49,11 @@ module IdentityCache
       memoizing = memoizing?
       ActiveSupport::Notifications.instrument('cache_delete.identity_cache', memoizing: memoizing) do
         memoized_key_values.delete(key) if memoizing
-        result = @cache_fetcher.delete(key)
-        IdentityCache.logger.debug {"[IdentityCache] delete #{ result ? 'recorded' : 'failed'  } for #{key}"}
+        if result = @cache_fetcher.delete(key)
+          IdentityCache.logger.debug {"[IdentityCache] delete recorded for #{key}"}
+        else
+          IdentityCache.logger.error {"[IdentityCache] delete failed for #{key}"}
+        end
         result
       end
     end


### PR DESCRIPTION
Would you mind if I changed the log severity to `error` when invalidating a record failed?

When `expire_cache` fails because of a network blip on the production system and Memcached becomes unreachable for a moment seems to be a bigger issue to log it on debug level. Production systems use info level as default and if invalidating the cache fails then the system can go to an inconsistent state easily when Memcached comes back, that's why I think this message should be on error level instead.