### PR TITLE
Store full variable names in cached options so it can be used directly

### DIFF
--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -23,7 +23,7 @@ module IdentityCache
 
         options[:embed]                   = false
         options[:cached_accessor_name]    = "fetch_#{association}"
-        options[:records_variable_name]   = "cached_#{association}"
+        options[:records_variable_name]   = :"@cached_#{association}"
         options[:association_reflection]  = association_reflection
         options[:prepopulate_method_name] = "prepopulate_fetched_#{association}"
 
@@ -38,10 +38,10 @@ module IdentityCache
           def #{options[:cached_accessor_name]}
             association_klass = association(:#{association}).klass
             if association_klass.should_use_cache? && #{foreign_key}.present? && !association(:#{association}).loaded?
-              if instance_variable_defined?(:@#{options[:records_variable_name]})
-                @#{options[:records_variable_name]}
+              if instance_variable_defined?(:#{options[:records_variable_name]})
+                #{options[:records_variable_name]}
               else
-                @#{options[:records_variable_name]} = association_klass.fetch_by_id(#{foreign_key})
+                #{options[:records_variable_name]} = association_klass.fetch_by_id(#{foreign_key})
               end
             else
               #{association}
@@ -49,7 +49,7 @@ module IdentityCache
           end
 
           def #{options[:prepopulate_method_name]}(record)
-            @#{options[:records_variable_name]} = record
+            #{options[:records_variable_name]} = record
           end
         CODE
       end

--- a/lib/identity_cache/cache_invalidation.rb
+++ b/lib/identity_cache/cache_invalidation.rb
@@ -14,7 +14,7 @@ module IdentityCache
       self.class.send(:all_cached_associations).each do |_, data|
         CACHE_KEY_NAMES.each do |key|
           if data[key]
-            instance_variable_name = "@#{data[key]}"
+            instance_variable_name = data[key]
             if instance_variable_defined?(instance_variable_name)
               remove_instance_variable(instance_variable_name)
             end

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -16,7 +16,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
   def test_reload_invalidate_cached_ids
     Item.cache_has_many :associated_records, :embed => :ids
 
-    variable_name = "@#{@record.class.send(:embedded_associations)[:associated_records][:ids_variable_name]}"
+    variable_name = @record.class.send(:embedded_associations)[:associated_records][:ids_variable_name]
 
     @record.fetch_associated_record_ids
     assert_equal [@baz.id, @bar.id], @record.instance_variable_get(variable_name)
@@ -31,7 +31,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
   def test_reload_invalidate_cached_objects
     Item.cache_has_many :associated_records, :embed => :ids
 
-    variable_name = "@#{@record.class.send(:embedded_associations)[:associated_records][:records_variable_name]}"
+    variable_name = @record.class.send(:embedded_associations)[:associated_records][:records_variable_name]
 
     @record.fetch_associated_records
     assert_equal [@baz, @bar], @record.instance_variable_get(variable_name)


### PR DESCRIPTION
## Problem

This is mostly a refactor to simplify a follow-up lazy hydration PR.

The problem is that we store the variable names in the cached association options (`:records_variable_name` & `:ids_variable_name`) without the `@` prefix, even though we almost always need to prefix the variable names with that prefix to use them.  This also results in creating unnecessary string objects.

## Solution

Store the variable names as a symbol, prefixed with `@`.  The only place where this couldn't be used directly was for an `attr_reader` line in the same method that sets the variable name, so I just used a local variable to capture the unprefixed name.