### PR TITLE
Delay hydration of cache embedded associations until accessed

### DIFF
--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -191,11 +191,16 @@ module IdentityCache
         options[:association_reflection] = reflect_on_association(association)
         options[:cached_accessor_name]   = "fetch_#{association}"
         options[:records_variable_name]  = :"@cached_#{association}"
+        options[:dehydrated_variable_name]  = :"@dehydrated_#{association}"
         options[:prepopulate_method_name] = "prepopulate_fetched_#{association}"
 
         self.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
           def #{options[:cached_accessor_name]}
-            fetch_recursively_cached_association(:#{options[:records_variable_name]}, :#{association})
+            fetch_recursively_cached_association(
+              :#{options[:records_variable_name]},
+              :#{options[:dehydrated_variable_name]},
+              :#{association}
+            )
           end
 
           def #{options[:prepopulate_method_name]}(records)

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -45,7 +45,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     expected = @record.associated_records
 
     assoc = mock()
-    assoc.expects(:klass).returns(Item)
+    assoc.expects(:klass).at_least_once.returns(AssociatedRecord)
     Item.any_instance.expects(:association).with(:associated_records).returns(assoc).once
 
     assert_equal expected, record_from_cache_hit.fetch_associated_records

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -38,24 +38,6 @@ class FetchMultiTest < IdentityCache::TestCase
     assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id)
   end
 
-  def test_fetch_multi_with_all_hits_publishes_notifications
-    cache_response = {}
-    cache_response[@bob_blob_key] = cache_response_for(@bob)
-    cache_response[@joe_blob_key] = cache_response_for(@joe)
-    cache_response[@fred_blob_key] = cache_response_for(@fred)
-    IdentityCache.cache.expects(:fetch_multi).with(@bob_blob_key, @joe_blob_key, @fred_blob_key).returns(cache_response)
-
-    events = 0
-    subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
-      events += 1
-      assert_equal "Item", payload[:class]
-    end
-    Item.fetch_multi(@bob.id, @joe.id, @fred.id)
-    assert_equal 3, events
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
-  end
-
   def test_fetch_multi_with_all_misses
     cache_response = {}
     cache_response[@bob_blob_key] = nil

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -26,20 +26,6 @@ class FetchTest < IdentityCache::TestCase
     assert_equal @record, Item.fetch(1)
   end
 
-  def test_fetch_cache_hit_publishes_hydration_notification
-    IdentityCache.cache.expects(:fetch).with(@blob_key).returns(@cached_value)
-
-    events = 0
-    subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
-      events += 1
-      assert_equal "Item", payload[:class]
-    end
-    Item.fetch(1)
-    assert_equal 1, events
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
-  end
-
   def test_fetch_cache_hit_publishes_cache_notification
     IdentityCache.cache.cache_fetcher.expects(:fetch).with(@blob_key).returns(@cached_value)
     expected = { memoizing: false, resolve_miss_time: 0, memo_hits: 0, cache_hits: 1, cache_misses: 0 }

--- a/test/recursive_denormalized_has_many_test.rb
+++ b/test/recursive_denormalized_has_many_test.rb
@@ -66,23 +66,6 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
 
-  def test_on_cache_hit_record_should_publish_one_hydration_notification
-    Item.fetch(@record.id) # warm cache
-
-    Item.any_instance.expects(:associated_records).never
-    AssociatedRecord.any_instance.expects(:deeply_associated_records).never
-
-    events = 0
-    subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
-      events += 1
-      assert_equal "Item", payload[:class]
-    end
-    Item.fetch(@record.id)
-    assert_equal 1, events
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
-  end
-
   def test_on_cache_miss_child_record_fetch_should_include_nested_associations_to_avoid_n_plus_ones
     assert_queries(5) do
       # one for the top level record


### PR DESCRIPTION
Depends on #371

## Problem

The hydration instrumentation added in #340 showed that we spend a significant amount of time for the hydration of cache blobs with a lot of embedded associations.  We should try to improve performance around hydration since we use identity cache and embedded association so heavily.

## Solution

I don't think we even need the embedded associations in many cases, so I think we can just lazily hydrate embedded associations.

Unfortunately, doing this with the current instrumentation would cause a lot more instrumentation overhead, since we wouldn't be able to group all the hydration together to instrument it once for all embedded associations.  Even if we kept the instrumentation, it would be hard to compare with the previous instrumentation data.  As a result, I decided to remove the hydration instrumentation as part of this PR.