### PR TITLE
Add support for fill lock with lock wait to avoid thundering herd problem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,6 @@ inherit_from:
 
 AllCops:
   TargetRubyVersion: 2.4
+
+Layout/BeginEndAlignment:
+  EnforcedStyleAlignWith: start_of_line

--- a/dev.yml
+++ b/dev.yml
@@ -6,7 +6,7 @@ up:
     - mysql-client@5.7:
         or:        [mysql@5.7]
         conflicts: [mysql-connector-c, mysql, mysql-client]
-  - ruby: 2.6.5
+  - ruby: 2.7.2
   - railgun
   - bundler
 

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -65,6 +65,8 @@ module IdentityCache
 
   class DerivedModelError < StandardError; end
 
+  class LockWaitTimeout < StandardError; end
+
   mattr_accessor :cache_namespace
   self.cache_namespace = "IDC:#{CACHE_VERSION}:"
 
@@ -141,10 +143,13 @@ module IdentityCache
     #
     # == Parameters
     # +key+ A cache key string
+    # +cache_fetcher_options+ A hash of options to pass to the cache backend
     #
-    def fetch(key)
+    def fetch(key, cache_fetcher_options = {})
       if should_use_cache?
-        unmap_cached_nil_for(cache.fetch(key) { map_cached_nil_for(yield) })
+        unmap_cached_nil_for(cache.fetch(key, cache_fetcher_options) do
+          map_cached_nil_for(yield)
+        end)
       else
         yield
       end

--- a/lib/identity_cache/cache_fetcher.rb
+++ b/lib/identity_cache/cache_fetcher.rb
@@ -192,6 +192,11 @@ module IdentityCache
           if old_lock == fetched_lock
             # preserve data version since there hasn't been any cache invalidations
             new_lock = FillLock.new(client_id: client_id, data_version: old_lock.data_version)
+          elsif old_lock && fetched_lock.data_version != old_lock.data_version
+            # Cache was invalidated, then another lock was taken during a lock wait.
+            # Treat it as any other cache invalidation, where the caller will switch
+            # to the fallback key.
+            return IdentityCache::DELETED
           else
             return fetched_lock
           end

--- a/lib/identity_cache/cache_fetcher.rb
+++ b/lib/identity_cache/cache_fetcher.rb
@@ -136,7 +136,9 @@ module IdentityCache
             # loop around to retry fetch_or_take_lock
           end
         when IdentityCache::DELETED # interrupted by cache invalidation
-          if lock && !using_fallback_key
+          if using_fallback_key
+            raise "unexpected cache invalidation of versioned fallback key"
+          elsif lock
             # cache invalidated during lock wait, try fallback key
             using_fallback_key = true
             key = lock_fill_fallback_key(key, lock)

--- a/lib/identity_cache/cache_fetcher.rb
+++ b/lib/identity_cache/cache_fetcher.rb
@@ -117,7 +117,7 @@ module IdentityCache
             if !fill_with_lock(key, data, lock, expiration_options) && !using_fallback_key
               # fallback to storing data in the fallback key so it is available to clients waiting on the lock
               expiration_options = fallback_key_expiration_options(fill_lock_duration)
-              @cache_backend.write(lock_fill_fallback_key(key, lock), data, **expiration_options)
+              @cache_backend.write(lock_fill_fallback_key(key, lock), data, expiration_options)
             end
             return data
           else
@@ -296,7 +296,7 @@ module IdentityCache
       result.each { |k, v| add(k, v) }
     end
 
-    def add(key, value, **expiration_options)
+    def add(key, value, expiration_options = EMPTY_HASH)
       return false unless IdentityCache.should_fill_cache?
       @cache_backend.write(key, value, { unless_exist: true, **expiration_options })
     end

--- a/lib/identity_cache/cache_fetcher.rb
+++ b/lib/identity_cache/cache_fetcher.rb
@@ -1,7 +1,51 @@
 # frozen_string_literal: true
+
+require 'securerandom'
+
 module IdentityCache
   class CacheFetcher
     attr_accessor :cache_backend
+
+    EMPTY_HASH = {}.freeze
+
+    class FillLock
+      FILL_LOCKED = :fill_locked
+      FAILED_CLIENT_ID = 'fill_failed'
+
+      class << self
+        def from_cache(marker, client_id, data_version)
+          raise ArgumentError unless marker == FILL_LOCKED
+          new(client_id: client_id, data_version: data_version)
+        end
+
+        def cache_value?(cache_value)
+          cache_value.is_a?(Array) && cache_value.length == 3 && cache_value.first == FILL_LOCKED
+        end
+      end
+
+      attr_reader :client_id, :data_version
+
+      def initialize(client_id:, data_version:)
+        @client_id = client_id
+        @data_version = data_version
+      end
+
+      def cache_value
+        [FILL_LOCKED, client_id, data_version]
+      end
+
+      def mark_failed
+        @client_id = FAILED_CLIENT_ID
+      end
+
+      def fill_failed?
+        @client_id == FAILED_CLIENT_ID
+      end
+
+      def ==(other)
+        self.class == other.class && client_id == other.client_id && data_version == other.data_version
+      end
+    end
 
     def initialize(cache_backend)
       @cache_backend = cache_backend
@@ -25,27 +69,184 @@ module IdentityCache
       results
     end
 
-    def fetch(key)
-      result = nil
-      yielded = false
-      @cache_backend.cas(key) do |value|
-        yielded = true
-        unless IdentityCache::DELETED == value
-          result = value
-          break
+    def fetch(key, fill_lock_duration: nil, lock_wait_limit: 2)
+      if fill_lock_duration && IdentityCache.should_fill_cache?
+        fetch_with_fill_lock(key, fill_lock_duration, lock_wait_limit) do
+          yield
         end
-        result = yield
-        break unless IdentityCache.should_fill_cache?
-        result
+      else
+        fetch_without_fill_lock(key) { yield }
       end
-      unless yielded
-        result = yield
-        add(key, result)
-      end
-      result
     end
 
     private
+
+    def fetch_without_fill_lock(key)
+      data = nil
+      upsert(key) do |value|
+        value = nil if value == IdentityCache::DELETED || FillLock.cache_value?(value)
+        unless value.nil?
+          return value
+        end
+        data = yield
+        break unless IdentityCache.should_fill_cache?
+        data
+      end
+      data
+    end
+
+    def fetch_with_fill_lock(key, fill_lock_duration, lock_wait_limit)
+      raise ArgumentError, 'fill_lock_duration must be greater than 0.0' unless fill_lock_duration > 0.0
+      raise ArgumentError, 'lock_wait_limit must be greater than 0' unless lock_wait_limit > 0
+      lock = nil
+      using_fallback_key = false
+      expiration_options = EMPTY_HASH
+      (lock_wait_limit + 2).times do # +2 is for first attempt and retry with fallback key
+        result = fetch_or_take_lock(key, old_lock: lock, **expiration_options)
+        case result
+        when FillLock
+          lock = result
+          if lock.client_id == client_id # have lock
+            data = begin
+              yield
+            rescue
+              mark_fill_failure_on_lock(key, expiration_options)
+              raise
+            end
+
+            if !fill_with_lock(key, data, lock, expiration_options) && !using_fallback_key
+              # fallback to storing data in the fallback key so it is available to clients waiting on the lock
+              expiration_options = fallback_key_expiration_options(fill_lock_duration)
+              @cache_backend.write(lock_fill_fallback_key(key, lock), data, **expiration_options)
+            end
+            return data
+          else
+            raise LockWaitTimeout if lock_wait_limit <= 0
+            lock_wait_limit -= 1
+
+            # If fill failed in the other client, then it might be failing fast
+            # so avoid waiting the typical amount of time for a lock wait. The
+            # semian gem can be used to handle failing fast when the database is slow.
+            if lock.fill_failed?
+              return fetch_without_fill_lock(key) { yield }
+            end
+
+            # lock wait
+            sleep(fill_lock_duration)
+            # loop around to retry fetch_or_take_lock
+          end
+        when IdentityCache::DELETED # interrupted by cache invalidation
+          if lock && !using_fallback_key
+            # cache invalidated during lock wait, try fallback key
+            using_fallback_key = true
+            key = lock_fill_fallback_key(key, lock)
+            expiration_options = fallback_key_expiration_options(fill_lock_duration)
+            # loop around to retry with fallback key
+          else
+            # cache invalidation prevented lock from being taken
+            return yield
+          end
+        when nil # Errors talking to memcached
+          return yield
+        else # hit
+          return result
+        end
+      end
+      raise "unexpected number of loop iterations"
+    end
+
+    def mark_fill_failure_on_lock(key, expiration_options)
+      @cache_backend.cas(key, expiration_options) do |value|
+        break unless FillLock.cache_value?(value)
+        lock = FillLock.from_cache(*value)
+        break if lock.client_id != client_id
+        lock.mark_failed
+        lock.cache_value
+      end
+    end
+
+    def upsert(key, expiration_options = EMPTY_HASH)
+      yielded = false
+      upserted = @cache_backend.cas(key, expiration_options) do |value|
+        yielded = true
+        yield value
+      end
+      unless yielded
+        data = yield nil
+        upserted = add(key, data, expiration_options)
+      end
+      upserted
+    end
+
+    def fetch_or_take_lock(key, old_lock:, **expiration_options)
+      new_lock = nil
+      upserted = upsert(key, expiration_options) do |value|
+        if value.nil? || value == IdentityCache::DELETED
+          if old_lock # cache invalidated
+            return value
+          else
+            new_lock = FillLock.new(client_id: client_id, data_version: SecureRandom.uuid)
+          end
+        elsif FillLock.cache_value?(value)
+          fetched_lock = FillLock.from_cache(*value)
+          if old_lock == fetched_lock
+            # preserve data version since there hasn't been any cache invalidations
+            new_lock = FillLock.new(client_id: client_id, data_version: old_lock.data_version)
+          else
+            return fetched_lock
+          end
+        else # hit
+          return value
+        end
+        new_lock.cache_value # take lock
+      end
+
+      return new_lock if upserted
+
+      value = @cache_backend.read(key)
+      if FillLock.cache_value?(value)
+        FillLock.from_cache(*value)
+      else
+        value
+      end
+    end
+
+    def fill_with_lock(key, data, my_lock, expiration_options)
+      upserted = upsert(key, expiration_options) do |value|
+        return false if value.nil? || value == IdentityCache::DELETED
+        return true unless FillLock.cache_value?(value) # already filled
+        current_lock = FillLock.from_cache(*value)
+        if current_lock.data_version != my_lock.data_version
+          return false # invalidated then relocked
+        end
+        data
+      end
+
+      upserted
+    end
+
+    def lock_fill_fallback_key(key, lock)
+      "lock_fill:#{lock.data_version}:#{key}"
+    end
+
+    def fallback_key_expiration_options(fill_lock_duration)
+      # Override the default TTL for the fallback key lock since it won't be used for very long.
+      expires_in = fill_lock_duration * 2
+
+      # memcached uses integer number of seconds for TTL so round up to avoid having
+      # the cache store round down with `to_i`
+      expires_in = expires_in.ceil
+
+      # memcached TTL only gets part of the first second (https://github.com/memcached/memcached/issues/307),
+      # so increase TTL by 1 to compensate
+      expires_in += 1
+
+      { expires_in: expires_in }
+    end
+
+    def client_id
+      @client_id ||= SecureRandom.uuid
+    end
 
     def cas_multi(keys)
       result = nil
@@ -81,8 +282,9 @@ module IdentityCache
       result.each { |k, v| add(k, v) }
     end
 
-    def add(key, value)
-      @cache_backend.write(key, value, unless_exist: true) if IdentityCache.should_fill_cache?
+    def add(key, value, **expiration_options)
+      return false unless IdentityCache.should_fill_cache?
+      @cache_backend.write(key, value, { unless_exist: true, **expiration_options })
     end
   end
 end

--- a/lib/identity_cache/cache_key_loader.rb
+++ b/lib/identity_cache/cache_key_loader.rb
@@ -25,12 +25,12 @@ module IdentityCache
       # @param cache_fetcher [_CacheFetcher]
       # @param db_key Reference to what to load from the database.
       # @return The database value corresponding to the database key.
-      def load(cache_fetcher, db_key)
+      def load(cache_fetcher, db_key, cache_fetcher_options = {})
         cache_key = cache_fetcher.cache_key(db_key)
 
         db_value = nil
 
-        cache_value = IdentityCache.fetch(cache_key) do
+        cache_value = IdentityCache.fetch(cache_key, cache_fetcher_options) do
           db_value = cache_fetcher.load_one_from_db(db_key)
           cache_fetcher.cache_encode(db_value)
         end

--- a/lib/identity_cache/cached/primary_index.rb
+++ b/lib/identity_cache/cached/primary_index.rb
@@ -9,11 +9,11 @@ module IdentityCache
         @model = model
       end
 
-      def fetch(id)
+      def fetch(id, cache_fetcher_options)
         id = cast_id(id)
         return unless id
         record = if model.should_use_cache?
-          object = CacheKeyLoader.load(self, id)
+          object = CacheKeyLoader.load(self, id, cache_fetcher_options)
           if object && object.id != id
             IdentityCache.logger.error(
               <<~MSG.squish

--- a/lib/identity_cache/fallback_fetcher.rb
+++ b/lib/identity_cache/fallback_fetcher.rb
@@ -32,7 +32,10 @@ module IdentityCache
       results
     end
 
-    def fetch(key)
+    def fetch(key, **cache_fetcher_options)
+      unless cache_fetcher_options.empty?
+        raise ArgumentError, "unsupported cache_fetcher options: #{cache_fetcher_options.keys.join(', ')}"
+      end
       result = @cache_backend.read(key)
       if result.nil?
         result = yield

--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -78,7 +78,7 @@ module IdentityCache
 
         value = fetch_memoized(key) do
           memo_misses = 1
-          @cache_fetcher.fetch(key, cache_fetcher_options) do
+          @cache_fetcher.fetch(key, **cache_fetcher_options) do
             cache_misses = 1
             instrument_duration(payload, :resolve_miss_time) do
               yield

--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -69,7 +69,7 @@ module IdentityCache
       end
     end
 
-    def fetch(key)
+    def fetch(key, cache_fetcher_options = {})
       memo_misses = 0
       cache_misses = 0
 
@@ -78,7 +78,7 @@ module IdentityCache
 
         value = fetch_memoized(key) do
           memo_misses = 1
-          @cache_fetcher.fetch(key) do
+          @cache_fetcher.fetch(key, cache_fetcher_options) do
             cache_misses = 1
             instrument_duration(payload, :resolve_miss_time) do
               yield

--- a/lib/identity_cache/with_primary_index.rb
+++ b/lib/identity_cache/with_primary_index.rb
@@ -109,15 +109,15 @@ module IdentityCache
       #   by another client. Defaults to not setting the fill lock and trying to fill the
       #   cache from the database regardless of the presence of another client's fill lock.
       #   Set this to just above the typical amount of time it takes to do a cache fill.
-      # @param lock_wait_limit [Integer] Only applicable if fill_lock_duration is provided,
+      # @param lock_wait_tries [Integer] Only applicable if fill_lock_duration is provided,
       #   in which case it specifies the number of times to do a lock wait. After the first
       #   lock wait it will try to take the lock, so will only do following lock waits due
       #   to another client taking the lock first. If another lock wait would be needed after
       #   reaching the limit, then a `LockWaitTimeout` exception is raised. Default is 2. Use
       #   this to control the maximum total lock wait duration
-      #   (`lock_wait_limit * fill_lock_duration`).
-      # @raise [LockWaitTimeout] Timeout after waiting `lock_wait_limit * fill_lock_duration`
-      #   seconds for `lock_wait_limit` other clients to fill the cache.
+      #   (`lock_wait_tries * fill_lock_duration`).
+      # @raise [LockWaitTimeout] Timeout after waiting `lock_wait_tries * fill_lock_duration`
+      #   seconds for `lock_wait_tries` other clients to fill the cache.
       # @return [self|nil] An instance of this model for the record with the specified id or
       #   `nil` if no record with this `id` exists in the database
       def fetch_by_id(id, includes: nil, **cache_fetcher_options)

--- a/lib/identity_cache/with_primary_index.rb
+++ b/lib/identity_cache/with_primary_index.rb
@@ -97,21 +97,47 @@ module IdentityCache
         !!fetch_by_id(id)
       end
 
-      # Default fetcher added to the model on inclusion, it behaves like
-      # ActiveRecord::Base.where(id: id).first
-      def fetch_by_id(id, includes: nil)
+      # Fetch the record by its primary key from the cache or read from
+      # the database and fill the cache on a cache miss. This behaves like
+      # `where(id: id).readonly.first` being called on the model.
+      #
+      # @param id Primary key value for the record to fetch.
+      # @param includes [Hash|Array|Symbol] Cached associations to prefetch from
+      #   the cache on the returned record
+      # @param fill_lock_duration [Float] If provided, take a fill lock around cache fills
+      #   and wait for this duration for cache to be filled when reading a lock provided
+      #   by another client. Defaults to not setting the fill lock and trying to fill the
+      #   cache from the database regardless of the presence of another client's fill lock.
+      #   Set this to just above the typical amount of time it takes to do a cache fill.
+      # @param lock_wait_limit [Integer] Only applicable if fill_lock_duration is provided,
+      #   in which case it specifies the number of times to do a lock wait. After the first
+      #   lock wait it will try to take the lock, so will only do following lock waits due
+      #   to another client taking the lock first. If another lock wait would be needed after
+      #   reaching the limit, then a `LockWaitTimeout` exception is raised. Default is 2. Use
+      #   this to control the maximum total lock wait duration
+      #   (`lock_wait_limit * fill_lock_duration`).
+      # @raise [LockWaitTimeout] Timeout after waiting `lock_wait_limit * fill_lock_duration`
+      #   seconds for `lock_wait_limit` other clients to fill the cache.
+      # @return [self|nil] An instance of this model for the record with the specified id or
+      #   `nil` if no record with this `id` exists in the database
+      def fetch_by_id(id, includes: nil, **cache_fetcher_options)
         ensure_base_model
         raise_if_scoped
-        record = cached_primary_index.fetch(id)
+        record = cached_primary_index.fetch(id, cache_fetcher_options)
         prefetch_associations(includes, [record]) if record && includes
         record
       end
 
-      # Default fetcher added to the model on inclusion, it behaves like
-      # ActiveRecord::Base.find, but will raise IdentityCache::RecordNotFound
-      # if the id is not in the cache.
-      def fetch(id, includes: nil)
-        fetch_by_id(id, includes: includes) || raise(
+      # Fetch the record by its primary key from the cache or read from
+      # the database and fill the cache on a cache miss. This behaves like
+      # `readonly.find(id)` being called on the model.
+      #
+      # @param (see #fetch_by_id)
+      # @raise (see #fetch_by_id)
+      # @raise [ActiveRecord::RecordNotFound] if the record isn't found
+      # @return [self] An instance of this model for the record with the specified id
+      def fetch(id, **options)
+        fetch_by_id(id, **options) || raise(
           IdentityCache::RecordNotFound, "Couldn't find #{name} with ID=#{id}"
         )
       end

--- a/test/attribute_cache_test.rb
+++ b/test/attribute_cache_test.rb
@@ -20,7 +20,7 @@ class AttributeCacheTest < IdentityCache::TestCase
     assert_queries(1) do
       assert_equal('foo', AssociatedRecord.fetch_name_by_id(1))
     end
-    assert(fetch.has_been_called_with?(@name_attribute_key))
+    assert(fetch.has_been_called_with?(@name_attribute_key, {}))
   end
 
   def test_attribute_values_are_returned_on_cache_hits

--- a/test/cache_fetcher_test.rb
+++ b/test/cache_fetcher_test.rb
@@ -108,7 +108,7 @@ class CacheFetcherTest < IdentityCache::TestCase
     assert_equal([:fill_locked, third_client.send(:client_id)], key_value.first(2))
   end
 
-  def test_fetch_lock_wait_limit_reached
+  def test_fetch_lock_wait_tries_reached
     data_version = SecureRandom.uuid
     lock = write_lock(data_version: data_version)
     other_client_operations = 3
@@ -118,7 +118,7 @@ class CacheFetcherTest < IdentityCache::TestCase
     end
     assert_memcache_operations(4 + other_client_operations) do # get (miss) * 4
       assert_raises(IdentityCache::LockWaitTimeout) do
-        cache_fetcher.fetch(key, fill_lock_duration: 0.9, lock_wait_limit: 3)
+        cache_fetcher.fetch(key, fill_lock_duration: 0.9, lock_wait_tries: 3)
       end
     end
     assert_equal(lock, backend.read(key))

--- a/test/cache_fetcher_test.rb
+++ b/test/cache_fetcher_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "socket"
+
+class CacheFetcherTest < IdentityCache::TestCase
+  attr_reader :key, :cache_fetcher
+
+  def setup
+    super
+    @cache_fetcher = IdentityCache::CacheFetcher.new(backend)
+    @key = "key"
+  end
+
+  def test_fetch_without_lock_miss
+    assert_memcache_operations(2) do # get, add
+      assert_equal(:fill_data, cache_fetcher.fetch(key) { :fill_data })
+    end
+    assert_equal(:fill_data, backend.read(key))
+  end
+
+  def test_fetch_miss
+    assert_memcache_operations(3) do # get (miss), add (lock), get+cas (fill)
+      assert_equal(:fill_data, cache_fetcher.fetch(key, fill_lock_duration: 0.9) { :fill_data })
+    end
+    assert_equal(:fill_data, backend.read(key))
+  end
+
+  def test_fetch_hit
+    cache_fetcher.fetch(key) { :hit_data }
+    assert_memcache_operations(1) do # get
+      assert_equal(:hit_data, cache_fetcher.fetch(key, fill_lock_duration: 0.9) { flunk("unexpected yield") })
+    end
+  end
+
+  def test_fetch_lock_wait
+    other_client_takes_lock
+
+    # fill during lock wait
+    other_client_operations = 1
+    cache_fetcher.expects(:sleep).with do |duration|
+      assert_memcache_operations(other_client_operations) do # get+cas
+        other_cache_fetcher.fetch(key) { :fill_data }
+      end
+      duration == 0.9
+    end
+
+    assert_memcache_operations(2 + other_client_operations) do # get (miss), get (hit)
+      assert_equal(:fill_data, cache_fetcher.fetch(key, fill_lock_duration: 0.9) { flunk("unexpected yield") })
+    end
+  end
+
+  def test_fetch_lock_wait_timeout
+    other_client_takes_lock
+
+    cache_fetcher.expects(:sleep).with(0.9)
+    assert_memcache_operations(3) do # get (miss), get+cas (miss, take lock), get+cas (fill)
+      assert_equal(:fill_data, cache_fetcher.fetch(key, fill_lock_duration: 0.9) { :fill_data })
+    end
+    assert_equal(:fill_data, backend.read(key))
+  end
+
+  def test_fetch_lock_wait_with_cache_invalidation
+    other_client_takes_lock
+
+    # invalidate during lock wait
+    other_client_operations = 1
+    cache_fetcher.expects(:sleep).with do |duration|
+      assert_memcache_operations(other_client_operations) do # get+cas
+        other_cache_fetcher.delete(key)
+      end
+      duration == 0.9
+    end
+
+    assert_memcache_operations(3 + other_client_operations) do # get (miss), get (invalidated), get (fallback key)
+      assert_equal(:fill_data, cache_fetcher.fetch(key, fill_lock_duration: 0.9) { :fill_data })
+    end
+    assert_equal(IdentityCache::DELETED, backend.read(key))
+  end
+
+  def test_fetch_lock_wait_limit_reached
+    data_version = SecureRandom.uuid
+    lock = write_lock(data_version: data_version)
+    other_client_operations = 3
+    cache_fetcher.expects(:sleep).times(3).with do |duration|
+      lock = write_lock(data_version: data_version)
+      duration == 0.9
+    end
+    assert_memcache_operations(4 + other_client_operations) do # get (miss) * 4
+      assert_raises(IdentityCache::LockWaitTimeout) do
+        cache_fetcher.fetch(key, fill_lock_duration: 0.9, lock_wait_limit: 3)
+      end
+    end
+    assert_equal(lock, backend.read(key))
+  end
+
+  def test_fetch_lock_attempt_interrupted_with_cache_invalidation
+    cache_fetcher.expects(:sleep).never
+    backend.expects(:cas).returns(false).with do |got_key|
+      other_cache_fetcher.delete(key)
+      key == got_key
+    end
+    other_client_operations = 1
+    assert_memcache_operations(2 + other_client_operations) do # add (lock), get (lock), excludes mocked cas
+      assert_equal(:fill_data, cache_fetcher.fetch(key, fill_lock_duration: 0.9) { :fill_data })
+    end
+    assert_equal(IdentityCache::DELETED, backend.read(key))
+  end
+
+  def test_fetch_with_memcached_down
+    cache_fetcher = IdentityCache::CacheFetcher.new(unconnected_cache_backend)
+    cache_fetcher.expects(:sleep).never
+    # 3 operations because the underlying cache store doesn't distinguish between
+    # request failures and error responses (e.g. NOT_FOUND or NOT_STORED)
+    assert_memcache_operations(3) do # get (miss), add (lock), get (read lock)
+      assert_equal(:miss_data, cache_fetcher.fetch(key, fill_lock_duration: 0.9) { :miss_data })
+    end
+  end
+
+  def test_fetch_with_database_down
+    IdentityCache::CacheFetcher.any_instance.expects(:sleep).never
+    exc = assert_raises(RuntimeError) do
+      other_cache_fetcher.fetch(key, fill_lock_duration: 0.9) { raise 'database down' }
+    end
+    assert_equal('database down', exc.message)
+    exc = assert_raises(RuntimeError) do
+      cache_fetcher.fetch(key, fill_lock_duration: 0.9) { raise 'database still down' }
+    end
+    assert_equal('database still down', exc.message)
+  end
+
+  private
+
+  def write_lock(client_id: SecureRandom.uuid, data_version:)
+    lock = IdentityCache::CacheFetcher::FillLock.new(client_id: client_id, data_version: data_version)
+    other_cache_fetcher.write(key, lock)
+    lock
+  end
+
+  def other_client_takes_lock
+    other_cache_fetcher.fetch(key, fill_lock_duration: 0.9) do
+      break # skip filling
+    end
+  end
+
+  def other_cache_fetcher
+    @other_cache_fetcher ||= IdentityCache::CacheFetcher.new(backend)
+  end
+
+  def unconnected_cache_backend
+    CacheConnection.build_backend(address: "127.0.0.1:#{open_port}").tap do |backend|
+      backend.extend(IdentityCache::MemCacheStoreCAS) if backend.is_a?(ActiveSupport::Cache::MemCacheStore)
+    end
+  end
+
+  def open_port
+    socket = Socket.new(:INET, :STREAM)
+    socket.bind(Addrinfo.tcp('127.0.0.1', 0))
+    socket.local_address.ip_port
+  ensure
+    socket&.close
+  end
+end

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -23,16 +23,8 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     assert_equal(@record, record_from_cache_miss)
     assert_not_nil(@record.fetch_associated)
     assert_equal(@record.associated, record_from_cache_miss.fetch_associated)
-    assert(
-      fetch.has_been_called_with?(
-        @cached_attribute.cache_key('foo')
-      )
-    )
-    assert(
-      fetch.has_been_called_with?(
-        @record.primary_cache_index_key
-      )
-    )
+    assert(fetch.has_been_called_with?(@cached_attribute.cache_key('foo'), {}))
+    assert(fetch.has_been_called_with?(@record.primary_cache_index_key, {}))
   end
 
   def test_on_cache_miss_record_should_embed_nil_object
@@ -50,16 +42,8 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     5.times do
       assert_nil(record_from_cache_miss.fetch_associated)
     end
-    assert(
-      fetch.has_been_called_with?(
-        @cached_attribute.cache_key('foo')
-      )
-    )
-    assert(
-      fetch.has_been_called_with?(
-        @record.primary_cache_index_key
-      )
-    )
+    assert(fetch.has_been_called_with?(@cached_attribute.cache_key('foo'), {}))
+    assert(fetch.has_been_called_with?(@record.primary_cache_index_key, {}))
   end
 
   def test_on_record_from_the_db_will_use_normal_association

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -355,7 +355,7 @@ class FetchTest < IdentityCache::TestCase
         assert_queries(1) { Item.fetch(@record.id) }
         duration == 0.1
       end
-      Item.fetch(@record.id, fill_lock_duration: 0.1, lock_wait_limit: 1)
+      Item.fetch(@record.id, fill_lock_duration: 0.1, lock_wait_tries: 1)
 
       assert_equal(@record, Item.fetch(@record.id))
     end

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -23,13 +23,13 @@ class FetchTest < IdentityCache::TestCase
   end
 
   def test_fetch_cache_hit
-    IdentityCache.cache.expects(:fetch).with(@blob_key).returns(@cached_value)
+    IdentityCache.cache.expects(:fetch).with(@blob_key, {}).returns(@cached_value)
 
     assert_equal(@record, Item.fetch(1))
   end
 
   def test_fetch_cache_hit_publishes_hydration_notification
-    IdentityCache.cache.expects(:fetch).with(@blob_key).returns(@cached_value)
+    IdentityCache.cache.expects(:fetch).with(@blob_key, {}).returns(@cached_value)
 
     events = 0
     subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
@@ -43,7 +43,7 @@ class FetchTest < IdentityCache::TestCase
   end
 
   def test_fetch_cache_hit_publishes_cache_notification
-    IdentityCache.cache.cache_fetcher.expects(:fetch).with(@blob_key).returns(@cached_value)
+    IdentityCache.cache.cache_fetcher.expects(:fetch).with(@blob_key, {}).returns(@cached_value)
     expected = { memoizing: false, resolve_miss_time: 0, memo_hits: 0, cache_hits: 1, cache_misses: 0 }
 
     events = 0
@@ -59,7 +59,7 @@ class FetchTest < IdentityCache::TestCase
 
   def test_fetch_memoized_hit_publishes_cache_notification
     subscriber = nil
-    IdentityCache.cache.cache_fetcher.expects(:fetch).with(@blob_key).returns(@cached_value)
+    IdentityCache.cache.cache_fetcher.expects(:fetch).with(@blob_key, {}).returns(@cached_value)
     expected = { memoizing: true, resolve_miss_time: 0, memo_hits: 1, cache_hits: 0, cache_misses: 0 }
 
     IdentityCache.cache.with_memoization do
@@ -81,7 +81,7 @@ class FetchTest < IdentityCache::TestCase
     IdentityCache.cache_namespace = proc { |model| "#{model.table_name}:#{old_ns}" }
 
     new_blob_key = "items:#{@blob_key}"
-    IdentityCache.cache.expects(:fetch).with(new_blob_key).returns(@cached_value)
+    IdentityCache.cache.expects(:fetch).with(new_blob_key, {}).returns(@cached_value)
 
     assert_equal(@record, Item.fetch(1))
   ensure
@@ -89,7 +89,7 @@ class FetchTest < IdentityCache::TestCase
   end
 
   def test_exists_with_identity_cache_when_cache_hit
-    IdentityCache.cache.expects(:fetch).with(@blob_key).returns(@cached_value)
+    IdentityCache.cache.expects(:fetch).with(@blob_key, {}).returns(@cached_value)
 
     assert(Item.exists_with_identity_cache?(1))
   end
@@ -99,7 +99,7 @@ class FetchTest < IdentityCache::TestCase
     Item.cached_primary_index.expects(:load_one_from_db).with(1).once.returns(@record)
 
     assert(Item.exists_with_identity_cache?(1))
-    assert(fetch.has_been_called_with?(@blob_key))
+    assert(fetch.has_been_called_with?(@blob_key, {}))
   end
 
   def test_exists_with_identity_cache_when_cache_miss_and_not_in_db
@@ -107,7 +107,7 @@ class FetchTest < IdentityCache::TestCase
     Item.cached_primary_index.expects(:load_one_from_db).with(1).once.returns(nil)
 
     assert(!Item.exists_with_identity_cache?(1))
-    assert(fetch.has_been_called_with?(@blob_key))
+    assert(fetch.has_been_called_with?(@blob_key, {}))
   end
 
   def test_fetch_miss_published_dehydration_notification
@@ -147,7 +147,7 @@ class FetchTest < IdentityCache::TestCase
     fetch = Spy.on(IdentityCache.cache, :fetch).and_return { |_, &block| block.call.tap { |result| results << result } }
 
     assert_equal(@record, Item.fetch(1))
-    assert(fetch.has_been_called_with?(@blob_key))
+    assert(fetch.has_been_called_with?(@blob_key, {}))
     assert_equal([@cached_value], results)
   end
 
@@ -162,11 +162,11 @@ class FetchTest < IdentityCache::TestCase
       @record.expire_cache
       @record
     end
-    add = Spy.on(fetcher, :add).and_call_through
+    write = Spy.on(backend, :write).and_call_through
 
     assert_equal(@record, Item.fetch(1))
     assert(load_one_from_db.has_been_called_with?(1))
-    assert(add.has_been_called_with?(@blob_key, @cached_value))
+    assert(write.has_been_called_with?(@blob_key, @cached_value, unless_exist: true))
     assert_equal(IdentityCache::DELETED, backend.read(@record.primary_cache_index_key))
   end
 
@@ -178,24 +178,24 @@ class FetchTest < IdentityCache::TestCase
       @record.expire_cache
       @record
     end
-    add = Spy.on(IdentityCache.cache.cache_fetcher, :add).and_call_through
+    write = Spy.on(backend, :write).and_call_through
 
     assert_equal(@record, Item.fetch(1))
     assert(load_one_from_db.has_been_called_with?(1))
-    refute(add.has_been_called?)
+    refute(write.calls.any? { |call| call.args.last.key?(unless_exist: true) })
     assert_equal(IdentityCache::DELETED, backend.read(@record.primary_cache_index_key))
   end
 
   def test_fetch_by_id_not_found_should_return_nil
     nonexistent_record_id = 10
-    fetcher.expects(:add).with(@blob_key + '0', IdentityCache::CACHED_NIL)
+    fetcher.expects(:add).with(@blob_key + '0', IdentityCache::CACHED_NIL, {})
 
     assert_nil(Item.fetch_by_id(nonexistent_record_id))
   end
 
   def test_fetch_not_found_should_raise
     nonexistent_record_id = 10
-    fetcher.expects(:add).with(@blob_key + '0', IdentityCache::CACHED_NIL)
+    fetcher.expects(:add).with(@blob_key + '0', IdentityCache::CACHED_NIL, {})
 
     assert_raises(IdentityCache::RecordNotFound) { Item.fetch(nonexistent_record_id) }
   end
@@ -219,7 +219,7 @@ class FetchTest < IdentityCache::TestCase
 
   def test_fetch_by_title_hit
     values = []
-    fetch = Spy.on(IdentityCache.cache, :fetch).and_return do |key, &block|
+    fetch = Spy.on(IdentityCache.cache, :fetch, {}).and_return do |key, &block|
       case key
       # Read record with title bob
       when @index_key then block.call.tap { |val| values << val }
@@ -233,35 +233,28 @@ class FetchTest < IdentityCache::TestCase
 
     assert_equal(@record, Item.fetch_by_title('bob'))
     assert_equal([1], values)
-    assert(fetch.has_been_called_with?(@index_key))
-    assert(fetch.has_been_called_with?(@blob_key))
+    assert(fetch.has_been_called_with?(@index_key, {}))
+    assert(fetch.has_been_called_with?(@blob_key, {}))
   end
 
   def test_fetch_by_title_cache_namespace
     Item.send(:include, SwitchNamespace)
-    IdentityCache.cache.expects(:fetch).with("ns:#{@index_key}").returns(1)
-    IdentityCache.cache.expects(:fetch).with("ns:#{@blob_key}").returns(@cached_value)
+    IdentityCache.cache.expects(:fetch).with("ns:#{@index_key}", {}).returns(1)
+    IdentityCache.cache.expects(:fetch).with("ns:#{@blob_key}", {}).returns(@cached_value)
 
     assert_equal(@record, Item.fetch_by_title('bob'))
   end
 
-  def test_fetch_by_title_stores_idcnil
-    Item.connection.expects(:exec_query).once.returns(ActiveRecord::Result.new([], []))
-    add = Spy.on(fetcher, :add).and_call_through
-    fetch = Spy.on(fetcher, :fetch).and_call_through
-    assert_nil(Item.fetch_by_title('bob')) # exec_query => nil
-
-    assert_nil(Item.fetch_by_title('bob')) # returns cached nil
-    assert_nil(Item.fetch_by_title('bob')) # returns cached nil
-
-    assert(add.has_been_called_with?(@index_key, IdentityCache::CACHED_NIL))
-    assert_equal(3, fetch.calls.length)
+  def test_fetch_by_title_caches_nil
+    assert_nil(Item.fetch_by_title('missing'))
+    assert_no_queries do
+      assert_nil(Item.fetch_by_title('missing'))
+    end
   end
 
   def test_fetch_by_bang_method
-    Item.connection.expects(:exec_query).returns(ActiveRecord::Result.new([], []))
     assert_raises(IdentityCache::RecordNotFound) do
-      Item.fetch_by_title!('bob')
+      Item.fetch_by_title!('missing')
     end
   end
 
@@ -306,7 +299,7 @@ class FetchTest < IdentityCache::TestCase
 
   def test_returned_records_are_readonly_on_cache_hit
     IdentityCache.with_fetch_read_only_records do
-      IdentityCache.cache.expects(:fetch).with(@blob_key).returns(@cached_value)
+      IdentityCache.cache.expects(:fetch).with(@blob_key, {}).returns(@cached_value)
       assert(Item.fetch(1).readonly?)
     end
   end
@@ -317,7 +310,7 @@ class FetchTest < IdentityCache::TestCase
       Item.cached_primary_index.expects(:load_one_from_db).with(1).once.returns(@record)
 
       assert(Item.exists_with_identity_cache?(1))
-      assert(fetch.has_been_called_with?(@blob_key))
+      assert(fetch.has_been_called_with?(@blob_key, {}))
       assert(Item.fetch(1).readonly?)
     end
   end
@@ -329,7 +322,7 @@ class FetchTest < IdentityCache::TestCase
         Item.cached_primary_index.expects(:load_one_from_db).with(1).once.returns(@record)
 
         refute(IdentityCache.should_use_cache?)
-        refute(fetch.has_been_called_with?(@blob_key))
+        refute(fetch.has_been_called_with?(@blob_key, {}))
         refute(Item.fetch(1).readonly?, "Fetched item was read-only")
       end
     end
@@ -343,6 +336,28 @@ class FetchTest < IdentityCache::TestCase
       assert_queries(1) do
         Item.fetch_by_id(@record.id)
       end
+    end
+  end
+
+  def test_fetch_supports_lock_wait_options
+    @record.save
+
+    # only one client reads from the database on concurrent fetch with lock wait
+    assert_queries(1) do
+      # other client takes fill lock
+      cache_key = Item.cached_primary_index.cache_key(@record.id)
+      lock = IdentityCache::CacheFetcher::FillLock.new(client_id: SecureRandom.uuid, data_version: SecureRandom.uuid)
+      IdentityCache.cache.cache_fetcher.write(cache_key, lock.cache_value)
+
+      # fetch waits on lock
+      IdentityCache.cache.cache_fetcher.expects(:sleep).with do |duration|
+        # other client fills cache
+        assert_queries(1) { Item.fetch(@record.id) }
+        duration == 0.1
+      end
+      Item.fetch(@record.id, fill_lock_duration: 0.1, lock_wait_limit: 1)
+
+      assert_equal(@record, Item.fetch(@record.id))
     end
   end
 end

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -43,7 +43,8 @@ class FetchTest < IdentityCache::TestCase
   end
 
   def test_fetch_cache_hit_publishes_cache_notification
-    IdentityCache.cache.cache_fetcher.expects(:fetch).with(@blob_key, {}).returns(@cached_value)
+    expected_kwargs = {}
+    IdentityCache.cache.cache_fetcher.expects(:fetch).with(@blob_key, **expected_kwargs).returns(@cached_value)
     expected = { memoizing: false, resolve_miss_time: 0, memo_hits: 0, cache_hits: 1, cache_misses: 0 }
 
     events = 0
@@ -59,7 +60,8 @@ class FetchTest < IdentityCache::TestCase
 
   def test_fetch_memoized_hit_publishes_cache_notification
     subscriber = nil
-    IdentityCache.cache.cache_fetcher.expects(:fetch).with(@blob_key, {}).returns(@cached_value)
+    expected_kwargs = {}
+    IdentityCache.cache.cache_fetcher.expects(:fetch).with(@blob_key, **expected_kwargs).returns(@cached_value)
     expected = { memoizing: true, resolve_miss_time: 0, memo_hits: 1, cache_hits: 0, cache_misses: 0 }
 
     IdentityCache.cache.with_memoization do

--- a/test/helpers/cache_connection.rb
+++ b/test/helpers/cache_connection.rb
@@ -16,15 +16,19 @@ module CacheConnection
   end
 
   def backend
-    @backend ||= case ENV['ADAPTER']
+    @backend ||= build_backend
+  end
+
+  def build_backend(address: "#{host}:11211")
+    case ENV['ADAPTER']
     when nil, 'dalli'
       require 'active_support/cache/mem_cache_store'
-      ActiveSupport::Cache::MemCacheStore.new("#{host}:11211", failover: false, expires_in: 6.hours.to_i)
+      ActiveSupport::Cache::MemCacheStore.new(address, failover: false, expires_in: 6.hours.to_i)
     when 'memcached'
       require 'memcached_store'
       require 'active_support/cache/memcached_store'
       ActiveSupport::Cache::MemcachedStore.prepend(MemcachedStoreInstrumentation)
-      ActiveSupport::Cache::MemcachedStore.new("#{host}:11211", support_cas: true, auto_eject_hosts: false)
+      ActiveSupport::Cache::MemcachedStore.new(address, support_cas: true, auto_eject_hosts: false)
     else
       raise "Unknown adapter: #{ENV['ADAPTER']}"
     end

--- a/test/memoized_cache_proxy_test.rb
+++ b/test/memoized_cache_proxy_test.rb
@@ -41,7 +41,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
   end
 
   def test_fetch_should_try_memcached_on_not_memoized_values
-    fetcher.expects(:fetch).with('foo').returns('bar')
+    fetcher.expects(:fetch).with('foo', {}).returns('bar')
 
     IdentityCache.cache.with_memoization do
       assert_equal('bar', IdentityCache.cache.fetch('foo'))

--- a/test/memoized_cache_proxy_test.rb
+++ b/test/memoized_cache_proxy_test.rb
@@ -41,7 +41,8 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
   end
 
   def test_fetch_should_try_memcached_on_not_memoized_values
-    fetcher.expects(:fetch).with('foo', {}).returns('bar')
+    expected_kwargs = {}
+    fetcher.expects(:fetch).with('foo', **expected_kwargs).returns('bar')
 
     IdentityCache.cache.with_memoization do
       assert_equal('bar', IdentityCache.cache.fetch('foo'))

--- a/test/readonly_test.rb
+++ b/test/readonly_test.rb
@@ -48,7 +48,7 @@ class ReadonlyTest < IdentityCache::TestCase
       assert_equal(@record, Item.fetch(1))
     end
     assert_nil(backend.read(@record.primary_cache_index_key))
-    assert(fetch.has_been_called_with?(@record.primary_cache_index_key))
+    assert(fetch.has_been_called_with?(@record.primary_cache_index_key, {}))
   end
 
   def test_fetch_multi_should_not_update_cache


### PR DESCRIPTION
cc @csfrancis

## Problem

Currently there is a thundering herd problem when a cache key is invalidated and multiple readers get a cache miss before the first one fills the cache.  All the readers after the first one are redundant and this can cause a lot of load on the database, especially for records with a lot of embedded associations.

## Solution

Add support for using a fill lock when using the `fetch` and `fetch_by_id` class methods so the first cache miss takes a lock before filling the cache and following clients getting a cache miss do a lock wait for a short duration for the cache to be filled so they can read from the cache rather than from the database.

This feature is opt-in through specifying the `fill_lock_duration` option to control how long to wait on the fill lock before reading the cache key again.  This should be set to just over the typical amount of time it takes to do a cache fill.  This way we typically will only have a single client filling a cache key at a time.

After a lock wait, if the lock is still present (e.g. hasn't been replaced by the value) then the client doing the lock wait will try to take the lock and fill the cache value.  If the original lock is replaced by another client's lock, then that can cause other clients to do another lock wait to avoid a slow cache fill from resulting in a thundering herd problem.  The `lock_wait_limit` option controls how many times a client should wait for different locks before raising an IdentityCache::LockWaitTimeout exception.  It should be set to the maximum amount of time it would take for the cache to be filled outside of a service disruption causing the database to be excessively slow, so that we don't waste server capacity when there are unexpected delays.

There is no performance impact for cache hits or cache invalidations.  There is no impact on performance for cache misses when not using the fill lock.  When using the fill lock, the client getting the first cache miss will make an extra `cas` memcached operation take the lock and an extra `get` operation that is needed to get the CAS token as part of the cache fill.  However, during a thundering herd scenario, most of the clients will only do 2 `get` memcached operations to read the lock then read the value after the lock wait.

Cache invalidations could happen while a cache miss is being resolved which could prevent clients that are in a lock wait from reading the value after the lock wait.  In this case, a fallback key is used so that the client resolving the cache miss can store the value someplace where waiting clients can read it.  A data version that is stored in the lock value is used to derive the fallback key so that it isn't filled with stale data from the perspective of the client reading it.  The fallback key isn't normally written to during a cache fill, so a cache invalidation might also overwrite the value before the lock wait finishes, but this will just cause the waiting clients to take a fill lock on the fallback key which won't be overwritten by further cache invalidations.  If a key happens to be both read and write heavy, then the number of concurrent cache fills is still limited by the frequency of cache invalidations due to the fill lock being taken on the fallback key.

If memcached is down, then lock waits are avoided and the database will be used without a cache fill.  If database exceptions interrupt the cache fill, then the fill failure is marked on the lock so other clients don't wait on the lock when they would otherwise fail fast by querying the database themselves.

## Backwards compatibility

This could be rolled out in a backwards and forwards compatible way by first deploying a commit to bump the gem so that it can handle the lock values, then using a following deploy to start using the fill lock.

## Alternatives

The lock wait was implemented by just using a sleep, so clients could sleep longer than necessary after the cache is filled.  One alternative would be to use redis which supports blocking operations (e.g. `BRPOPLPUSH`) so the value can be returned to other clients as soon as its available.  However, this could put a lot of additional load on redis to write to it for all cache fills and would add a new dependency that we would have to worry about failures for.

Another alternative would be to keep stale values around after a cache invalidation so that we could fallback to stale data on a cache miss when the fill lock is taken.  This is what we do in the cacheable gem.  However, we would need to be careful with stale reads to make sure we don't fill another cache from the stale read (e.g. page cache) and to make sure we don't do stale reads where we can't tolerate stale data.  This would also reduce where we could use this solution.  There would also be a performance trade-off on cache invalidations if we needed to preserve the stale data while also marking it as stale.

Write-through caching is another alternative.  However, this could add a lot of overhead to writes in order to fill the cache, especially when there are embedded associations.  If there are concurrent writes, then this could interrupt the `cas` operation needed to set the new value in the cache, which would need to be resolved by retrying using freshly queried database data.  This could have significant impact on models that are sometimes written heavily, even if in other cases they are read-heavy.  The significantly different trade-offs seem like they would reduce where we could use this solution.  Write-through caching seems like something that could be done a lot more efficiently by using the mysql binlog, which is a longer term project.

## Not Implemented

This PR doesn't implement support for `fetch_multi` and doesn't expose a way to provide a fill lock in all methods that do fetching.  However, we could expand support for this feature on an as needed basis.