### PR TITLE
Reenable CI on identity_cache and remove the upper bound constraint on AR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: ruby
 
 rvm:
   - '2.2.6'
-  - '2.4.1'
+  - 2.4
 
 gemfile:
-  - Gemfile.rails50
-  - Gemfile.rails51
+  - gemfiles/Gemfile.rails50
+  - gemfiles/Gemfile.latest-release
 
 env:
   - DB=mysql2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
 gemfile:
   - gemfiles/Gemfile.rails50
   - gemfiles/Gemfile.latest-release
+  - gemfiles/Gemfile.rails-edge
 
 env:
   - DB=mysql2
@@ -23,3 +24,11 @@ before_script:
   - psql -c 'create database identity_cache_test;' -U postgres
 
 cache: bundler
+
+matrix:
+  exclude:
+    - rvm: 2.2.6
+      gemfile: gemfiles/Gemfile.rails-edge
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,8 @@ matrix:
     - rvm: 2.2.6
       gemfile: gemfiles/Gemfile.rails-edge
 
+addons:
+  postgresql: 9.3
+
 notifications:
   email: false

--- a/Gemfile.rails51
+++ b/Gemfile.rails51
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-gemspec
-
-gem 'activerecord', '~> 5.1.0'
-gem 'activesupport', '~> 5.1.0'
-gem 'mysql2', '>= 0.3.18', '< 0.5'

--- a/gemfiles/Gemfile.latest-release
+++ b/gemfiles/Gemfile.latest-release
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+gemspec path: '..'
+
+gem 'activerecord'
+gem 'activesupport'
+gem 'mysql2', '>= 0.3.18', '< 0.5'

--- a/gemfiles/Gemfile.rails-edge
+++ b/gemfiles/Gemfile.rails-edge
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+gemspec path: '..'
+
+gem 'activerecord', github: 'rails/rails'
+gem 'activesupport', github: 'rails/rails'
+gem 'mysql2', '>= 0.3.18', '< 0.5'

--- a/gemfiles/Gemfile.rails50
+++ b/gemfiles/Gemfile.rails50
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-gemspec
+gemspec path: '..'
 
 gem 'activerecord', '~> 5.0.0'
 gem 'activesupport', '~> 5.0.0'

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.2.0'
 
   gem.add_dependency('ar_transaction_changes', '~> 1.0')
-  gem.add_dependency('activerecord', '~> 5.0')
+  gem.add_dependency('activerecord', '>= 5.0')
 
   gem.add_development_dependency('memcached', '~> 1.8.0')
   gem.add_development_dependency('memcached_store', '~> 1.0.0')

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -90,14 +90,14 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
 
   def test_cache_without_guessable_inverse_name_raises
     assert_raises IdentityCache::InverseAssociationError do
-      Item.cache_has_many :polymorphic_records, :embed => true
+      Item.cache_has_many :no_inverse_of_records, :embed => true
       IdentityCache.eager_load!
     end
   end
 
   def test_cache_without_guessable_inverse_name_does_not_raise_when_inverse_name_specified
     assert_nothing_raised do
-      Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => true
+      Item.cache_has_many :no_inverse_of_records, :inverse_name => :owner, :embed => true
       IdentityCache.eager_load!
     end
   end

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -111,14 +111,14 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
 
   def test_cache_without_guessable_inverse_name_raises
     assert_raises IdentityCache::InverseAssociationError do
-      Item.cache_has_one :polymorphic_record, :embed => true
+      Item.cache_has_one :no_inverse_of_record, :embed => true
       IdentityCache.eager_load!
     end
   end
 
   def test_cache_without_guessable_inverse_name_does_not_raise_when_inverse_name_specified
     assert_nothing_raised do
-      Item.cache_has_one :polymorphic_record, :inverse_name => :owner, :embed => true
+      Item.cache_has_one :no_inverse_of_record, :inverse_name => :owner, :embed => true
       IdentityCache.eager_load!
     end
   end

--- a/test/helpers/active_record_objects.rb
+++ b/test/helpers/active_record_objects.rb
@@ -29,6 +29,7 @@ module ActiveRecordObjects
     Object.send :remove_const, 'NormalizedAssociatedRecord'
     Object.send :remove_const, 'AssociatedRecord'
     Object.send :remove_const, 'NotCachedRecord'
+    Object.send :remove_const, 'NoInverseOfRecord'
     Object.send :remove_const, 'Item'
     Object.send :remove_const, 'ItemTwo'
     Object.send :remove_const, 'KeyedRecord'

--- a/test/helpers/database_connection.rb
+++ b/test/helpers/database_connection.rb
@@ -47,6 +47,7 @@ module DatabaseConnection
     :deeply_associated_records     => [[:string, :name], [:integer, :associated_record_id], [:integer, :item_id], [:timestamps, null: true]],
     :associated_records            => [[:string, :name], [:integer, :item_id], [:integer, :item_two_id]],
     :normalized_associated_records => [[:string, :name], [:integer, :item_id], [:timestamps, null: true]],
+    :no_inverse_of_records         => [[:integer, :owner_id], [:timestamps, null: true]],
     :not_cached_records            => [[:string, :name], [:integer, :item_id], [:timestamps, null: true]],
     :items                         => [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
     :items2                        => [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],

--- a/test/helpers/models.rb
+++ b/test/helpers/models.rb
@@ -28,6 +28,11 @@ class PolymorphicRecord < ActiveRecord::Base
   belongs_to :owner, :polymorphic => true
 end
 
+class NoInverseOfRecord < ActiveRecord::Base
+  include IdentityCache
+  belongs_to :owner
+end
+
 module Deeply
   module Nested
     class AssociatedRecord < ActiveRecord::Base
@@ -44,8 +49,10 @@ class Item < ActiveRecord::Base
   has_many :normalized_associated_records
   has_many :not_cached_records
   has_many :polymorphic_records, :as => 'owner'
+  has_many :no_inverse_of_records
   has_one :polymorphic_record, :as => 'owner'
   has_one :associated, :class_name => 'AssociatedRecord'
+  has_one :no_inverse_of_record
 end
 
 class ItemTwo < ActiveRecord::Base


### PR DESCRIPTION
The initial goal of this PR was to remove the upper bound constraint on ActiveRecord.
I realized that CI on this project has been disabled since few months for a reason I ignore.

This PR removes reenable CI and fix an issue that was making two test to fail on Rails 5.2.
Last commit removes the upper bound constraint on AR without any further changes.







