### PR TITLE
Update mysql2 dependency in Gemfile to be compatibile with latest rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'mysql2', '~> 0.3.13'
+gem 'mysql2', '~> 0.5.2'


### PR DESCRIPTION
## Problem

If I remove Gemfile.lock and `dev up && dev test` to use the latest released rails version then I get the error

```
Error loading the 'mysql2' Active Record adapter. Missing a gem it depends on? can't activate mysql2 (>= 0.4.4, < 0.6.0), already activated mysql2-0.3.21.
```

because Gemfile had the `gem 'mysql2', '~> 0.3.13'` constraint.

## Solution

Update the mysql2 dependency in the Gemfile to be compatible with the latest released version of rails.