### PR TITLE
Mark records as read-only on resolve miss rather than on association fetch

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -210,8 +210,8 @@ module IdentityCache
         record
       end
 
-      def preload_id_embedded_association(records, options)
-        reflection = options.fetch(:association_reflection)
+      def preload_id_embedded_association(records, association_options)
+        reflection = association_options.fetch(:association_reflection)
         child_model = reflection.klass
         scope = child_model.all
         scope = scope.instance_exec(nil, &reflection.scope) if reflection.scope
@@ -224,7 +224,7 @@ module IdentityCache
 
         records.each do |parent|
           child_ids = ids_by_parent[parent.id]
-          parent.instance_variable_set(options.fetch(:ids_variable_name), child_ids)
+          parent.instance_variable_set(association_options.fetch(:ids_variable_name), child_ids)
         end
       end
 

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -57,6 +57,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
 
     assert_equal @record, record_from_cache_miss
     assert_equal expected, record_from_cache_miss.fetch_associated_records
+    assert_equal false, record_from_cache_miss.associated_records.loaded?
   end
 
   def test_changes_in_associated_records_should_expire_the_parents_cache
@@ -150,7 +151,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
       record_from_db = Item.find(@record.id)
       uncached_records = record_from_db.associated_records
       assert uncached_records.none?(&:readonly?)
-      assert record_from_db.fetch_associated_records.all?(&:readonly?)
+      assert record_from_db.fetch_associated_records.none?(&:readonly?)
       assert record_from_db.associated_records.none?(&:readonly?)
     end
   end


### PR DESCRIPTION
## Problem

When Identity Cache resolves a cache miss for an embedded association, it causes the active record association to be loaded where it wouldn't be for a cache hit.  This results in a few different inconsistencies:

1. This can hide N+1 queries during testing if the association is loaded through an identity cache miss, then the association is accessed directly for N parent records (i.e. not through the cache accessor `fetch_#{association_name}`).  Although this wouldn't cause an N+1 on a cache miss, it would cause an N+1 on a cache hit, which doesn't load the active record association.  The code should instead use the cache accessor for an association that was loaded through identity cache.

2. ID embedded associations don't cause the active record association to be loaded, which was inconsistent with recursively embedded associations.

3. This exposes a different between rails 5.2 and rails 6 when deleting a record from an active record association after it has been loaded through resolving an identity cache miss. In rails 5.2, the association target array would be modified which would affect the target array stored in an instance variable from the cache accessor `fetch_#{association_name}`.  In rails 6, the association the target is reassigned with a modified copy of the array, so the change wouldn't be reflected in the array returned by the cache accessor.  This difference wouldn't be noticeable if we used the active record association if it was accessed directly, but we can't detect this if the we leave the association loaded after resolving a cache miss.

## Solution

Reset the association when resolving a cache miss after storing the association target in the instance variable for the cached accessor.  This way the behaviour is the same between a cache hit and a cache miss, which should make it easier to test.

If the active record association hasn't been loaded, then this PR avoids keeping a reference to the target array.  A follow-up PR will further address inconsistency number 3 by using the active record association once it has been loaded.