### PR TITLE
Use Active Record association if already loaded on embedded associations

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -446,7 +446,7 @@ module IdentityCache
     def fetch_recursively_cached_association(ivar_name, dehydrated_ivar_name, association_name) # :nodoc:
       assoc = association(association_name)
 
-      if assoc.klass.should_use_cache?
+      if assoc.klass.should_use_cache? && !assoc.loaded?
         if instance_variable_defined?(ivar_name)
           instance_variable_get(ivar_name)
         elsif instance_variable_defined?(dehydrated_ivar_name)

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -42,13 +42,13 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     record_from_cache_hit = Item.fetch(@record.id)
     assert_equal @record, record_from_cache_hit
 
-    expected = @record.associated_records
+    result = assert_memcache_operations(0) do
+      assert_no_queries do
+        record_from_cache_hit.fetch_associated_records
+      end
+    end
 
-    assoc = mock()
-    assoc.expects(:klass).at_least_once.returns(AssociatedRecord)
-    Item.any_instance.expects(:association).with(:associated_records).returns(assoc).once
-
-    assert_equal expected, record_from_cache_hit.fetch_associated_records
+    assert_equal @record.associated_records, result
   end
 
   def test_on_cache_miss_record_should_embed_associated_objects_and_return
@@ -58,6 +58,15 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     assert_equal @record, record_from_cache_miss
     assert_equal expected, record_from_cache_miss.fetch_associated_records
     assert_equal false, record_from_cache_miss.associated_records.loaded?
+  end
+
+  def test_delegate_to_normal_association_if_loaded
+    Item.fetch(@record.id) # warm cache
+    item = Item.fetch(@record.id)
+    item.fetch_associated_records
+
+    item.associated_records << AssociatedRecord.new(:name => 'buzz')
+    assert_equal item.associated_records.to_a, item.fetch_associated_records
   end
 
   def test_changes_in_associated_records_should_expire_the_parents_cache


### PR DESCRIPTION
Follow-up to #378

## Problem

We have a difference between ID embedded and recursively embedded associations with respect to what happens when the association is loaded from the cache, but then the active record association is loaded and possibly modified.  ID embedded associations use the active record association once it has been loaded on the cache association accessor, but recursively embedded associations continue using the possibly stale association target from the cache fetch.  Rails 6 also changes whether the association target is mutated in-place, which is relevant if the array is stored in an instance variable for the `fetch_#{association_name}` method and returned even after the association is loaded.

## Solution

Use the active record association if it has been loaded for recursively embedded associations