### PR TITLE
Sprinkled AS::Notifications all over

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -26,7 +26,7 @@ module IdentityCache
           require_if_necessary do
             object = nil
             coder = IdentityCache.fetch(rails_cache_key(id)){ instrumented_coder_from_record(object = resolve_cache_miss(id)) }
-            object ||= record_from_coder(coder)
+            object ||= instrumented_record_from_coder(coder)
             if object && object.id != id
               IdentityCache.logger.error "[IDC id mismatch] fetch_by_id_requested=#{id} fetch_by_id_got=#{object.id} for #{object.inspect[(0..100)]}"
             end
@@ -68,7 +68,7 @@ module IdentityCache
               records.map {|record| instrumented_coder_from_record(record) }
             end
 
-            cache_keys.map{ |key| key_to_record_map[key] || record_from_coder(coders_by_key[key]) }
+            cache_keys.map{ |key| key_to_record_map[key] || instrumented_record_from_coder(coders_by_key[key]) }
           end
         else
           find_batch(ids)
@@ -86,14 +86,14 @@ module IdentityCache
         when nil
           # do nothing
         when Symbol
-          prefetch_one_association(associations, records)
+          instrumented_prefetch_one_association(associations, records)
         when Array
           associations.each do |association|
             prefetch_associations(association, records)
           end
         when Hash
           associations.each do |association, sub_associations|
-            next_level_records = prefetch_one_association(association, records)
+            next_level_records = instrumented_prefetch_one_association(association, records)
 
             if sub_associations.present?
               associated_class = reflect_on_association(association).klass
@@ -106,9 +106,16 @@ module IdentityCache
         nil
       end
 
-      def record_from_coder(coder) #:nodoc:
+      def instrumented_record_from_coder(coder) #:nodoc:
         return nil unless coder
+        ActiveSupport::Notifications.instrument('hydration.identity_cache', class: coder[:class]) do
+          record_from_coder(coder)
+        end
+      end
 
+      private
+
+      def record_from_coder(coder) #:nodoc:
         record = instantiate(coder[:attributes].dup)
 
         if coder.has_key?(:associations)
@@ -124,8 +131,6 @@ module IdentityCache
         record.readonly! if IdentityCache.fetch_read_only_records
         record
       end
-
-      private
 
       def raise_if_scoped
         if current_scope
@@ -327,6 +332,12 @@ module IdentityCache
         fetch_embedded_associations(records)
       end
 
+      def instrumented_prefetch_one_association(association, records)
+        ActiveSupport::Notifications.instrument('association_fetch.identity_cache', association: association) do
+          prefetch_one_association(association, records)
+        end
+      end
+
       def prefetch_one_association(association, records)
         unless records.first.class.should_use_cache?
           ActiveRecord::Associations::Preloader.new.preload(records, association)
@@ -430,9 +441,9 @@ module IdentityCache
     def hydrate_association_target(associated_class, dehydrated_value) # :nodoc:
       dehydrated_value = IdentityCache.unmap_cached_nil_for(dehydrated_value)
       if dehydrated_value.is_a?(Array)
-        dehydrated_value.map { |coder| associated_class.record_from_coder(coder) }
+        dehydrated_value.map { |coder| associated_class.instrumented_record_from_coder(coder) }
       else
-        associated_class.record_from_coder(dehydrated_value)
+        associated_class.instrumented_record_from_coder(dehydrated_value)
       end
     end
 

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -38,6 +38,24 @@ class FetchMultiTest < IdentityCache::TestCase
     assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id)
   end
 
+  def test_fetch_multi_with_all_hits_publishes_notifications
+    cache_response = {}
+    cache_response[@bob_blob_key] = cache_response_for(@bob)
+    cache_response[@joe_blob_key] = cache_response_for(@joe)
+    cache_response[@fred_blob_key] = cache_response_for(@fred)
+    IdentityCache.cache.expects(:fetch_multi).with(@bob_blob_key, @joe_blob_key, @fred_blob_key).returns(cache_response)
+
+    events = 0
+    subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
+      events += 1
+      assert_equal "Item", payload[:class]
+    end
+    Item.fetch_multi(@bob.id, @joe.id, @fred.id)
+    assert_equal 3, events
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
   def test_fetch_multi_with_all_misses
     cache_response = {}
     cache_response[@bob_blob_key] = nil

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -26,6 +26,20 @@ class FetchTest < IdentityCache::TestCase
     assert_equal @record, Item.fetch(1)
   end
 
+  def test_fetch_cache_hit_publishes_hydration_notification
+    IdentityCache.cache.expects(:fetch).with(@blob_key).returns(@cached_value)
+
+    events = 0
+    subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
+      events += 1
+      assert_equal "Item", payload[:class]
+    end
+    Item.fetch(1)
+    assert_equal 1, events
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
   def test_fetch_cache_hit_publishes_cache_notification
     IdentityCache.cache.cache_fetcher.expects(:fetch).with(@blob_key).returns(@cached_value)
     expected = { memoizing: false, resolve_miss_time: 0, memo_hits: 0, cache_hits: 1, cache_misses: 0 }

--- a/test/recursive_denormalized_has_many_test.rb
+++ b/test/recursive_denormalized_has_many_test.rb
@@ -66,6 +66,24 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
 
+
+  def test_on_cache_hit_record_should_publish_one_hydration_notification
+    Item.fetch(@record.id) # warm cache
+
+    Item.any_instance.expects(:associated_records).never
+    AssociatedRecord.any_instance.expects(:deeply_associated_records).never
+
+    events = 0
+    subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
+      events += 1
+      assert_equal "Item", payload[:class]
+    end
+    Item.fetch(@record.id)
+    assert_equal 1, events
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
   def test_on_cache_miss_child_record_fetch_should_include_nested_associations_to_avoid_n_plus_ones
     assert_queries(5) do
       # one for the top level record


### PR DESCRIPTION
Adds more support for AS::Nofications. Mostly adding back `hydration.identity_cache`, but also adds `association_fetch` notifications for prefetching... 