### PR TITLE
Fix resetting of inverse association when lazily installing expiry hooks

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -246,8 +246,8 @@ module IdentityCache
             record.send(:set_embedded_association, association_name, target)
             association.reset
             # reset inverse associations
-            if target
-              inverse_name = options.fetch(:inverse_name)
+            if target && association_reflection.has_inverse?
+              inverse_name = association_reflection.inverse_of.name
               if target.is_a?(Array)
                 target.each { |child_record| child_record.association(inverse_name).reset }
               else


### PR DESCRIPTION
cc @selesse who reported this problem to me

## Problem

We were getting `ActiveRecord::AssociationNotFoundError: Association was not found.` in one of our rake tasks in development in the code resetting the association target when resolving a cache miss.  Using a debugger, I found that it was actually trying `child_record.association(inverse_name)` with a `nil` value for `inverse_name`.

I believe this is happening because the `:inverse_name` option isn't set on the cached association options until `ParentModelExpiration#check_association` is called to setup the parent expiry hooks.  This is done lazily to avoid loading all the models when these cached associations are defined, so we can't depend on this during fetching with making sure this association is checked first.

## Solution

However, we can get this information from the active record association reflection object. This is even better, because it is the information used by active record to set the inverse association that this code is trying to undo.