### PR TITLE
Make expire_primary_index a class method

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -113,7 +113,8 @@ module IdentityCache
         end
       end
 
-      def expire_primary_index(id) # :nodoc:
+      # Invalidates the primary cache index for the associated record. Will not invalidate cached attributes.
+      def expire_primary_key_cache_index(id)
         return unless primary_cache_index_enabled
         id = type_for_attribute(primary_key).cast(id)
         IdentityCache.cache.delete(rails_cache_key(id))
@@ -458,6 +459,13 @@ module IdentityCache
       end
     end
 
+    # Invalidate the cache data associated with the record.
+    def expire_cache
+      expire_primary_index
+      expire_attribute_indexes
+      true
+    end
+
     private
 
     def fetch_recursively_cached_association(ivar_name, dehydrated_ivar_name, association_name) # :nodoc:
@@ -514,7 +522,7 @@ module IdentityCache
     end
 
     def expire_primary_index # :nodoc:
-      self.class.expire_primary_index(id)
+      self.class.expire_primary_key_cache_index(id)
     end
 
     def expire_attribute_indexes # :nodoc:
@@ -530,12 +538,6 @@ module IdentityCache
           end
         end
       end
-    end
-
-    def expire_cache # :nodoc:
-      expire_primary_index
-      expire_attribute_indexes
-      true
     end
 
     def was_new_record? # :nodoc:

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -113,6 +113,12 @@ module IdentityCache
         end
       end
 
+      def expire_primary_index(id) # :nodoc:
+        return unless primary_cache_index_enabled
+        id = type_for_attribute(primary_key).cast(id)
+        IdentityCache.cache.delete(rails_cache_key(id))
+      end
+
       private
 
       def record_from_coder(coder) #:nodoc:
@@ -508,21 +514,7 @@ module IdentityCache
     end
 
     def expire_primary_index # :nodoc:
-      return unless self.class.primary_cache_index_enabled
-
-      IdentityCache.logger.debug do
-        extra_keys =
-          if respond_to?(:updated_at)
-            old_updated_at = old_values_for_fields([:updated_at]).first
-            "expiring_last_updated_at=#{old_updated_at}"
-          else
-            ""
-          end
-
-        "[IdentityCache] expiring=#{self.class.name} expiring_id=#{id} #{extra_keys}"
-      end
-
-      IdentityCache.cache.delete(primary_cache_index_key)
+      self.class.expire_primary_index(id)
     end
 
     def expire_attribute_indexes # :nodoc:

--- a/performance/cache_runner.rb
+++ b/performance/cache_runner.rb
@@ -107,7 +107,7 @@ end
 module DeletedRunner
   def prepare
     super
-    (1..@count).each {|i| ::Item.find(i).send(:expire_cache) }
+    (1..@count).each {|i| ::Item.find(i).expire_cache }
   end
 end
 
@@ -118,7 +118,7 @@ module ConflictRunner
     orig_resolve_cache_miss = ::Item.method(:resolve_cache_miss)
 
     ::Item.define_singleton_method(:resolve_cache_miss) do |id|
-      records[id-1].send(:expire_cache)
+      records[id-1].expire_cache
       orig_resolve_cache_miss.call(id)
     end
     IdentityCache.cache.clear
@@ -129,7 +129,7 @@ module DeletedConflictRunner
   include ConflictRunner
   def prepare
     super
-    (1..@count).each {|i| ::Item.find(i).send(:expire_cache) }
+    (1..@count).each {|i| ::Item.find(i).expire_cache }
   end
 end
 

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -122,6 +122,17 @@ class CacheInvalidationTest < IdentityCache::TestCase
     end
   end
 
+  def test_cache_invalidation_expire_properly_when_expired_via_class_method
+    record = Item.create(:title => 'foo')
+    record.class.fetch(record.id)
+
+    refute_nil IdentityCache.cache.fetch(record.primary_cache_index_key) { nil }
+
+    Item.expire_primary_index(record.id)
+
+    assert_nil IdentityCache.cache.fetch(record.primary_cache_index_key) { nil }
+  end
+
   def test_dedup_cache_invalidation_of_records_embedded_twice_through_different_associations
     Item.cache_has_many :associated_records, embed: true
     AssociatedRecord.cache_has_many :deeply_associated_records, embed: true

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -128,7 +128,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
 
     refute_nil IdentityCache.cache.fetch(record.primary_cache_index_key) { nil }
 
-    Item.expire_primary_index(record.id)
+    Item.expire_primary_key_cache_index(record.id)
 
     assert_nil IdentityCache.cache.fetch(record.primary_cache_index_key) { nil }
   end

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -257,7 +257,7 @@ class FetchMultiTest < IdentityCache::TestCase
 
   def test_fetch_multi_after_expiring_a_record
     Item.fetch_multi(@joe.id, @fred.id)
-    @bob.send(:expire_cache)
+    @bob.expire_cache
     assert_equal IdentityCache::DELETED, backend.read(@bob.primary_cache_index_key)
 
     add = Spy.on(IdentityCache.cache.cache_fetcher, :add).and_call_through

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -157,7 +157,7 @@ class FetchTest < IdentityCache::TestCase
 
   def test_fetch_conflict
     resolve_cache_miss = Spy.on(Item, :resolve_cache_miss).and_return do
-      @record.send(:expire_cache)
+      @record.expire_cache
       @record
     end
     add = Spy.on(fetcher, :add).and_call_through
@@ -169,11 +169,11 @@ class FetchTest < IdentityCache::TestCase
   end
 
   def test_fetch_conflict_after_delete
-    @record.send(:expire_cache)
+    @record.expire_cache
     assert_equal IdentityCache::DELETED, backend.read(@record.primary_cache_index_key)
 
     resolve_cache_miss = Spy.on(Item, :resolve_cache_miss).and_return do
-      @record.send(:expire_cache)
+      @record.expire_cache
       @record
     end
     add = Spy.on(IdentityCache.cache.cache_fetcher, :add).and_call_through

--- a/test/save_test.rb
+++ b/test/save_test.rb
@@ -71,7 +71,7 @@ class SaveTest < IdentityCache::TestCase
     expect_cache_delete(@blob_key)
 
     ActiveRecord::Base.transaction do
-      @record.send(:expire_cache)
+      @record.expire_cache
     end
   end
 


### PR DESCRIPTION
### Problem

Sometimes we want to expire the primary key index after updating the record using raw SQL is an `ActiveRecord#update_all` call. For example in the case of doing an atomic increment as seen in the snippet below.

```ruby
Model.where(id: record.id).update_all("#{column} = #{column} + 1")
```

### Solution

Make `expire_primary_index` delegate to a public class method called `expire_primary_key_cache_index(id)` and move the current logic to the new method.

**Example use case:**

```ruby
def increment(id, column)
  Model.where(id: id).update_all("#{column} = #{column} + 1")
  expire_primary_key_cache_index(id)
end
```