### PR TITLE
Fix cached_has_many for polymorphic associations

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -223,6 +223,7 @@ module IdentityCache
         reflection = association_options.fetch(:association_reflection)
         child_model = reflection.klass
         scope = child_model.all
+        scope = scope.where(reflection.type => base_class.name) if reflection.type
         scope = scope.instance_exec(nil, &reflection.scope) if reflection.scope
 
         pairs = scope.where(reflection.foreign_key => records.map(&:id)).pluck(reflection.foreign_key, reflection.association_primary_key)

--- a/test/helpers/models.rb
+++ b/test/helpers/models.rb
@@ -58,6 +58,7 @@ end
 class ItemTwo < ActiveRecord::Base
   include IdentityCache
   has_many :associated_records, inverse_of: :item_two, foreign_key: :item_two_id
+  has_many :polymorphic_records, :as => 'owner'
   self.table_name = 'items2'
 end
 

--- a/test/polymorphic_has_many_test.rb
+++ b/test/polymorphic_has_many_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class PolymorphicHasManyTest < IdentityCache::TestCase
+  def setup
+    super
+    PolymorphicRecord.include(IdentityCache)
+
+    Item.cache_has_many :polymorphic_records, inverse_name: :owner
+    ItemTwo.cache_has_many :polymorphic_records, inverse_name: :owner
+  end
+
+  def test_polymorphic_has_many_filters_by_type
+    item = Item.create(id: 1)
+    item2 = ItemTwo.create(id: 1)
+
+    poly1 = item.polymorphic_records.create
+    poly2 = item.polymorphic_records.create
+    poly3 = item2.polymorphic_records.create
+
+    assert_equal [poly1, poly2], Item.fetch(1).fetch_polymorphic_records
+  end
+end


### PR DESCRIPTION
When Product and Shop both `has_many :translations, as: translatable` with `cache_has_many :translations`, `fetch_translations` returns all translations where `translatable_id` matches, without filtering for `translatable_type == 'Product'`. This patch fixes it, but maybe we're missing an obvious configuration point? Otherwise, I'm happy to add tests / iterate on the implementation.

cc: @christianblais 