### PR TITLE
Try using the default postgres version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 services:
   - memcache
   - mysql
+  - postgresql
 
 sudo: false
 
@@ -29,9 +30,6 @@ matrix:
   exclude:
     - rvm: 2.2.6
       gemfile: gemfiles/Gemfile.rails-edge
-
-addons:
-  postgresql: 9.3
 
 notifications:
   email: false


### PR DESCRIPTION
## Problem

In CI for PR #383, `psql` was failing to connect to postgres during the [travis before_script](https://github.com/Shopify/identity_cache/blob/caa21d8bc5bd1215d48aa972d28d36102aa83369/.travis.yml#L22-L24).  That was completely unrelated to the changes in the PR itself, so I was able to reproduce the problem by pushing the latest master to this new branch.

I'm guessing the problem is with travis not getting the database available before the `before_script` is executed.

## Solution

I tried using travis' default version of postgres, since this library shouldn't need a specific version of postgres and doesn't specify a specific version of the other datastores anyways.  After this change, the build passed, so it seems to workaround this travis issue.  I restarted a CI job in PR #383 and it still failed, so it isn't that the problem has just been fixed in travis itself.