### PR TITLE
Remove cosmetic `reorder(nil)`, it triggers too many deprecations:

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -214,7 +214,7 @@ module IdentityCache
       end
 
       def resolve_cache_miss(id)
-        record = self.includes(cache_fetch_includes).reorder(nil).where(primary_key => id).first
+        record = self.includes(cache_fetch_includes).where(primary_key => id).take
         setup_embedded_associations_on_miss([record]) if record
         record
       end


### PR DESCRIPTION
Remove cosmetic `reorder(nil)`, it triggers too many deprecations:

- ActiveRecord made a recent change to deprecate usage of `first`
  returning a non deterministic result https://github.com/rails/rails/pull/36889

  The change upstream was orginally done in https://github.com/rails/rails/commit/1340498d2102423665cc5cfe7be7cdba32c72928
  but had to be reverted because it shouldn't be part of a release
  candidate.
  For the reference, I had a quick chat about that change https://github.com/rails/rails/commit/1340498d2102423665cc5cfe7be7cdba32c72928#r33986510

  In IdentityCache we call `reorder(nil).first` and the reason was
  purely cosmetic https://github.com/Shopify/identity_cache/pull/148

  > I also added some reorder(nil) calls here and there to prevent useless ORDER clauses to be included in the queries