### PR TITLE
Add a Railtie to automatically eager load IdentityCache in Rails context

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -163,3 +163,5 @@ module IdentityCache
     end
   end
 end
+
+require 'identity_cache/railtie' if defined?(Rails)

--- a/lib/identity_cache/railtie.rb
+++ b/lib/identity_cache/railtie.rb
@@ -1,0 +1,7 @@
+module IdentityCache
+  class Railtie < Rails::Railtie
+    initializer "identity_cache.setup" do |app|
+      app.config.eager_load_namespaces << IdentityCache
+    end
+  end
+end


### PR DESCRIPTION
`IdentityCache` [has an `eager_load!` method](https://github.com/Shopify/identity_cache/blob/ff26ed60abef959b667cecac7265dd370041c92b/lib/identity_cache.rb#L153-L155), so it should be added to `app.config.eager_load_namespaces`.

Might as well add a Railtie so that it's done automatically.