### PR TITLE
Refactor cache options

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -3,6 +3,15 @@ require 'active_support/core_ext/module/attribute_accessors'
 require 'ar_transaction_changes'
 
 require "identity_cache/version"
+require "identity_cache/cached"
+require "identity_cache/cached/association"
+require "identity_cache/cached/recursive/association"
+require "identity_cache/cached/recursive/has_one"
+require "identity_cache/cached/recursive/has_many"
+require "identity_cache/cached/reference/association"
+require "identity_cache/cached/reference/belongs_to"
+require "identity_cache/cached/reference/has_one"
+require "identity_cache/cached/reference/has_many"
 require 'identity_cache/memoized_cache_proxy'
 require 'identity_cache/belongs_to_caching'
 require 'identity_cache/cache_key_generation'

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -12,6 +12,7 @@ require "identity_cache/cached/reference/association"
 require "identity_cache/cached/reference/belongs_to"
 require "identity_cache/cached/reference/has_one"
 require "identity_cache/cached/reference/has_many"
+require "identity_cache/expiry_hook"
 require 'identity_cache/memoized_cache_proxy'
 require 'identity_cache/belongs_to_caching'
 require 'identity_cache/cache_key_generation'

--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -11,47 +11,20 @@ module IdentityCache
       def cache_belongs_to(association)
         ensure_base_model
 
-        unless association_reflection = reflect_on_association(association)
+        unless reflection = reflect_on_association(association)
           raise AssociationError, "Association named '#{association}' was not found on #{self.class}"
         end
-        if association_reflection.scope
+
+        if reflection.scope
           raise UnsupportedAssociationError, "caching association #{self}.#{association} is scoped which isn't supported"
         end
 
-        options = {}
-        self.cached_belongs_tos[association] = options
+        cached_belongs_to = Cached::Reference::BelongsTo.new(
+          association,
+          reflection: reflection,
+        )
 
-        options[:embed]                   = false
-        options[:cached_accessor_name]    = "fetch_#{association}"
-        options[:records_variable_name]   = :"@cached_#{association}"
-        options[:association_reflection]  = association_reflection
-        options[:prepopulate_method_name] = "prepopulate_fetched_#{association}"
-
-        build_normalized_belongs_to_cache(association, options)
-      end
-
-      private
-
-      def build_normalized_belongs_to_cache(association, options)
-        foreign_key = options[:association_reflection].foreign_key
-        self.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
-          def #{options[:cached_accessor_name]}
-            association_klass = association(:#{association}).klass
-            if association_klass.should_use_cache? && #{foreign_key}.present? && !association(:#{association}).loaded?
-              if instance_variable_defined?(:#{options[:records_variable_name]})
-                #{options[:records_variable_name]}
-              else
-                #{options[:records_variable_name]} = association_klass.fetch_by_id(#{foreign_key})
-              end
-            else
-              #{association}
-            end
-          end
-
-          def #{options[:prepopulate_method_name]}(record)
-            #{options[:records_variable_name]} = record
-          end
-        CODE
+        self.cached_belongs_tos[association] = cached_belongs_to.tap(&:build)
       end
     end
   end

--- a/lib/identity_cache/cache_invalidation.rb
+++ b/lib/identity_cache/cache_invalidation.rb
@@ -11,15 +11,8 @@ module IdentityCache
     private
 
     def clear_cached_associations
-      self.class.send(:all_cached_associations).each do |_, data|
-        CACHE_KEY_NAMES.each do |key|
-          if data[key]
-            instance_variable_name = data[key]
-            if instance_variable_defined?(instance_variable_name)
-              remove_instance_variable(instance_variable_name)
-            end
-          end
-        end
+      self.class.send(:all_cached_associations).each_value do |association|
+        association.clear(self)
       end
     end
   end

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -9,15 +9,15 @@ module IdentityCache
 
     def self.denormalized_schema_string(klass)
       schema_to_string(klass.columns).tap do |schema_string|
-        klass.send(:all_cached_associations).sort.each do |name, options|
+        klass.send(:all_cached_associations).sort.each do |name, association|
           klass.send(:check_association_scope, name)
-          ParentModelExpiration.check_association(options) if options[:embed]
-          case options[:embed]
-          when true
-            schema_string << ",#{name}:(#{denormalized_schema_hash(options[:association_reflection].klass)})"
-          when :ids
+          ParentModelExpiration.check_association(association) if association.embedded?
+          case association
+          when Cached::Recursive::Association
+            schema_string << ",#{name}:(#{denormalized_schema_hash(association.reflection.klass)})"
+          when Cached::Reference::HasMany
             schema_string << ",#{name}:ids"
-          when :id
+          when Cached::Reference::HasOne
             schema_string << ",#{name}:id"
           end
         end

--- a/lib/identity_cache/cached.rb
+++ b/lib/identity_cache/cached.rb
@@ -1,0 +1,6 @@
+module IdentityCache
+  module Cached
+  end
+
+  private_constant :Cached
+end

--- a/lib/identity_cache/cached/association.rb
+++ b/lib/identity_cache/cached/association.rb
@@ -1,0 +1,44 @@
+module IdentityCache
+  module Cached
+    class Association # :nodoc:
+      def initialize(name, inverse_name:, reflection:)
+        @name = name
+        @reflection = reflection
+        @inverse_name = inverse_name
+        @cached_accessor_name = "fetch_#{name}"
+        @prepopulate_method_name = "prepopulate_fetched_#{name}"
+        @records_variable_name = :"@cached_#{name}"
+      end
+
+      attr_reader :name, :reflection, :cached_accessor_name,
+                  :prepopulate_method_name, :records_variable_name
+
+      def build
+        raise NotImplementedError
+      end
+
+      def clear(record)
+        raise NotImplementedError
+      end
+
+      def embedded?
+        embedded_by_reference? || embedded_recursively?
+      end
+
+      def embedded_by_reference?
+        raise NotImplementedError
+      end
+
+      def embedded_recursively?
+        raise NotImplementedError
+      end
+
+      def inverse_name
+        @inverse_name ||= begin
+          reflection.inverse_of&.name ||
+          reflection.active_record.name.underscore
+        end
+      end
+    end
+  end
+end

--- a/lib/identity_cache/cached/recursive/association.rb
+++ b/lib/identity_cache/cached/recursive/association.rb
@@ -1,0 +1,46 @@
+module IdentityCache
+  module Cached
+    module Recursive
+      class Association < Cached::Association # :nodoc:
+        def initialize(name, inverse_name:, reflection:)
+          super
+          @dehydrated_variable_name = :"@dehydrated_#{name}"
+        end
+
+        attr_reader :dehydrated_variable_name
+
+        def build
+          reflection.active_record.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+            def #{cached_accessor_name}
+              fetch_recursively_cached_association(
+                :#{records_variable_name},
+                :#{dehydrated_variable_name},
+                :#{name}
+              )
+            end
+
+            def #{prepopulate_method_name}(records)
+              #{records_variable_name} = records
+            end
+          RUBY
+
+          ParentModelExpiration.add_parent_expiry_hook(self)
+        end
+
+        def clear(record)
+          if record.instance_variable_defined?(records_variable_name)
+            record.remove_instance_variable(records_variable_name)
+          end
+        end
+
+        def embedded_by_reference?
+          false
+        end
+
+        def embedded_recursively?
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/identity_cache/cached/recursive/has_many.rb
+++ b/lib/identity_cache/cached/recursive/has_many.rb
@@ -1,0 +1,8 @@
+module IdentityCache
+  module Cached
+    module Recursive
+      class HasMany < Association # :nodoc:
+      end
+    end
+  end
+end

--- a/lib/identity_cache/cached/recursive/has_one.rb
+++ b/lib/identity_cache/cached/recursive/has_one.rb
@@ -1,0 +1,8 @@
+module IdentityCache
+  module Cached
+    module Recursive
+      class HasOne < Association # :nodoc:
+      end
+    end
+  end
+end

--- a/lib/identity_cache/cached/reference/association.rb
+++ b/lib/identity_cache/cached/reference/association.rb
@@ -1,0 +1,15 @@
+module IdentityCache
+  module Cached
+    module Reference
+      class Association < Cached::Association # :nodoc:
+        def embedded_by_reference?
+          true
+        end
+
+        def embedded_recursively?
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/identity_cache/cached/reference/belongs_to.rb
+++ b/lib/identity_cache/cached/reference/belongs_to.rb
@@ -1,0 +1,44 @@
+module IdentityCache
+  module Cached
+    module Reference
+      class BelongsTo < Association # :nodoc:
+        def initialize(name, reflection:)
+          super(name, inverse_name: nil, reflection: reflection)
+        end
+
+        attr_reader :records_variable_name
+
+        def build
+          reflection.active_record.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+            def #{cached_accessor_name}
+              association_klass = association(:#{name}).klass
+              if association_klass.should_use_cache? && #{reflection.foreign_key}.present? && !association(:#{name}).loaded?
+                if defined?(#{records_variable_name})
+                  #{records_variable_name}
+                else
+                  #{records_variable_name} = association_klass.fetch_by_id(#{reflection.foreign_key})
+                end
+              else
+                #{name}
+              end
+            end
+
+            def #{prepopulate_method_name}(record)
+              #{records_variable_name} = record
+            end
+          RUBY
+        end
+
+        def clear(record)
+          if record.instance_variable_defined?(records_variable_name)
+            record.remove_instance_variable(records_variable_name)
+          end
+        end
+
+        def embedded_by_reference?
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/identity_cache/cached/reference/has_many.rb
+++ b/lib/identity_cache/cached/reference/has_many.rb
@@ -1,0 +1,62 @@
+module IdentityCache
+  module Cached
+    module Reference
+      class HasMany < Association # :nodoc:
+        def initialize(name, inverse_name:, reflection:)
+          super
+          @cached_ids_name = "fetch_#{ids_name}"
+          @ids_variable_name = :"@#{ids_cached_reader_name}"
+        end
+
+        attr_reader :cached_ids_name, :ids_variable_name
+
+        def build
+          reflection.active_record.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+            attr_reader :#{ids_cached_reader_name}
+
+            def #{cached_ids_name}
+              #{ids_variable_name} ||= #{ids_name}
+            end
+
+            def #{cached_accessor_name}
+              association_klass = association(:#{name}).klass
+              if association_klass.should_use_cache? && !#{name}.loaded?
+                #{records_variable_name} ||= #{reflection.class_name}.fetch_multi(#{cached_ids_name})
+              else
+                #{name}.to_a
+              end
+            end
+
+            def #{prepopulate_method_name}(records)
+              #{records_variable_name} = records
+            end
+          RUBY
+
+          ParentModelExpiration.add_parent_expiry_hook(self)
+        end
+
+        def clear(record)
+          [ids_variable_name, records_variable_name].each do |ivar|
+            if record.instance_variable_defined?(ivar)
+              record.remove_instance_variable(ivar)
+            end
+          end
+        end
+
+        private
+
+        def singular_name
+          name.to_s.singularize
+        end
+
+        def ids_name
+          "#{singular_name}_ids"
+        end
+
+        def ids_cached_reader_name
+          "cached_#{ids_name}"
+        end
+      end
+    end
+  end
+end

--- a/lib/identity_cache/cached/reference/has_one.rb
+++ b/lib/identity_cache/cached/reference/has_one.rb
@@ -1,0 +1,59 @@
+module IdentityCache
+  module Cached
+    module Reference
+      class HasOne < Association # :nodoc:
+        def initialize(name, inverse_name:, reflection:)
+          super
+          @cached_id_name = "fetch_#{id_name}"
+          @id_variable_name = :"@#{id_cached_reader_name}"
+        end
+
+        attr_reader :cached_id_name, :id_variable_name
+
+        def build
+          reflection.active_record.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+            attr_reader :#{id_cached_reader_name}
+
+            def #{cached_id_name}
+              return #{id_variable_name} if defined?(#{id_variable_name})
+              #{id_variable_name} = association(:#{name}).scope.ids.first
+            end
+
+            def #{cached_accessor_name}
+              association_klass = association(:#{name}).klass
+              if association_klass.should_use_cache? && !association(:#{name}).loaded?
+                #{records_variable_name} ||= #{reflection.class_name}.fetch(#{cached_id_name}) if #{cached_id_name}
+              else
+                #{name}
+              end
+            end
+
+            def #{prepopulate_method_name}(record)
+              #{records_variable_name} = record
+            end
+          RUBY
+
+          ParentModelExpiration.add_parent_expiry_hook(self)
+        end
+
+        def clear(record)
+          [id_variable_name, records_variable_name].each do |ivar|
+            if record.instance_variable_defined?(ivar)
+              record.remove_instance_variable(ivar)
+            end
+          end
+        end
+
+        private
+
+        def id_name
+          "#{name}_id"
+        end
+
+        def id_cached_reader_name
+          "cached_#{id_name}"
+        end
+      end
+    end
+  end
+end

--- a/lib/identity_cache/expiry_hook.rb
+++ b/lib/identity_cache/expiry_hook.rb
@@ -1,0 +1,13 @@
+module IdentityCache
+  class ExpiryHook # :nodoc:
+    def initialize(cached_association)
+      @cached_association = cached_association
+    end
+
+    attr_reader :cached_association
+
+    def only_on_foreign_key_change?
+      cached_association.embedded_by_reference?
+    end
+  end
+end

--- a/lib/identity_cache/parent_model_expiration.rb
+++ b/lib/identity_cache/parent_model_expiration.rb
@@ -3,18 +3,16 @@ module IdentityCache
     extend ActiveSupport::Concern
 
     class << self
-      def add_parent_expiry_hook(cached_association_hash)
-        association_reflection = cached_association_hash[:association_reflection]
-        name = model_basename(association_reflection.class_name)
-        lazy_hooks[name] ||= []
-        lazy_hooks[name] << cached_association_hash
+      def add_parent_expiry_hook(cached_association)
+        name = model_basename(cached_association.reflection.class_name)
+        lazy_hooks[name] << ExpiryHook.new(cached_association)
       end
 
       def install_all_pending_parent_expiry_hooks
         until lazy_hooks.empty?
           lazy_hooks.keys.each do |key|
-            lazy_hooks.delete(key).each do |cached_association_hash|
-              install_hook(cached_association_hash)
+            lazy_hooks.delete(key).each do |expiry_hook|
+              install_hook(expiry_hook)
             end
           end
         end
@@ -22,26 +20,25 @@ module IdentityCache
 
       def install_pending_parent_expiry_hooks(model)
         name = model_basename(model.name)
-        lazy_hooks.delete(name).try!(:each) do |cached_association_hash|
-          install_hook(cached_association_hash)
+        lazy_hooks.delete(name).try!(:each) do |expiry_hook|
+          install_hook(expiry_hook)
         end
       end
 
-      def check_association(cached_association_hash)
-        association_reflection = cached_association_hash[:association_reflection]
-        parent_model = association_reflection.active_record
-        child_model = association_reflection.klass
+      def check_association(cached_association)
+        reflection = cached_association.reflection
+        parent_model = reflection.active_record
+        child_model = reflection.klass
 
         unless child_model < IdentityCache
-          message = "cached association #{parent_model}\##{association_reflection.name} requires" \
+          message = "cached association #{parent_model}\##{reflection.name} requires" \
             " associated class #{child_model} to include IdentityCache"
-          message << " or IdentityCache::WithoutPrimaryIndex" if cached_association_hash[:embed] == true
+          message << " or IdentityCache::WithoutPrimaryIndex" if cached_association.embedded_recursively?
           raise UnsupportedAssociationError, message
         end
 
-        cached_association_hash[:inverse_name] ||= association_reflection.inverse_of.try!(:name) || parent_model.name.underscore.to_sym
-        unless child_model.reflect_on_association(cached_association_hash[:inverse_name])
-          raise InverseAssociationError, "Inverse name for association #{parent_model}\##{association_reflection.name} could not be determined. " \
+        unless child_model.reflect_on_association(cached_association.inverse_name)
+          raise InverseAssociationError, "Inverse name for association #{parent_model}\##{reflection.name} could not be determined. " \
             "Please use the :inverse_name option to specify the inverse association name for this cache."
         end
       end
@@ -53,18 +50,18 @@ module IdentityCache
       end
 
       def lazy_hooks
-        @lazy_hooks ||= {}
+        @lazy_hooks ||= Hash.new { |hash, key| hash[key] = [] }
       end
 
-      def install_hook(cached_association_hash)
-        check_association(cached_association_hash)
+      def install_hook(expiry_hook)
+        check_association(expiry_hook.cached_association)
 
-        association_reflection = cached_association_hash[:association_reflection]
+        association_reflection = expiry_hook.cached_association.reflection
         parent_model = association_reflection.active_record
         child_model = association_reflection.klass
 
-        parent_expiration_entry = [parent_model, cached_association_hash[:only_on_foreign_key_change]]
-        child_model.parent_expiration_entries[cached_association_hash[:inverse_name]] << parent_expiration_entry
+        parent_expiration_entry = [parent_model, expiry_hook.only_on_foreign_key_change?]
+        child_model.parent_expiration_entries[expiry_hook.cached_association.inverse_name] << parent_expiration_entry
       end
     end
 

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -16,7 +16,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
   def test_reload_invalidate_cached_ids
     Item.cache_has_many :associated_records, :embed => :ids
 
-    variable_name = @record.class.send(:embedded_associations)[:associated_records][:ids_variable_name]
+    variable_name = @record.class.send(:embedded_associations)[:associated_records].ids_variable_name
 
     @record.fetch_associated_record_ids
     assert_equal [@baz.id, @bar.id], @record.instance_variable_get(variable_name)
@@ -31,7 +31,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
   def test_reload_invalidate_cached_objects
     Item.cache_has_many :associated_records, :embed => :ids
 
-    variable_name = @record.class.send(:embedded_associations)[:associated_records][:records_variable_name]
+    variable_name = @record.class.send(:embedded_associations)[:associated_records].records_variable_name
 
     @record.fetch_associated_records
     assert_equal [@baz, @bar], @record.instance_variable_get(variable_name)

--- a/test/cached/association_test.rb
+++ b/test/cached/association_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+module IdentityCache
+  module Cached
+    class AssociationTest < IdentityCache::TestCase
+      def setup
+        super
+        @reflection = reflect(AssociatedRecord, :item)
+        @association = Association.new(
+          :item,
+          inverse_name: :associated_record,
+          reflection: @reflection
+        )
+      end
+
+      attr_reader :reflection, :association
+
+      def test_name
+        assert_equal :item, association.name
+      end
+
+      def test_inverse_name
+        assert_equal :associated_record, association.inverse_name
+      end
+
+      def test_reflection
+        assert_same reflection, association.reflection
+      end
+
+      def test_cached_accessor_name
+        assert_equal "fetch_item", association.cached_accessor_name
+      end
+
+      def test_prepopulate_method_name
+        assert_equal "prepopulate_fetched_item", association.prepopulate_method_name
+      end
+    end
+  end
+end

--- a/test/cached/recursive/has_many_test.rb
+++ b/test/cached/recursive/has_many_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+module IdentityCache
+  module Cached
+    module Recursive
+      class HasManyTest < IdentityCache::TestCase
+        def setup
+          super
+          @reflection = reflect(AssociatedRecord, :deeply_associated_records)
+          @has_many = HasMany.new(
+            :deeply_associated_records,
+            inverse_name: :associated_record,
+            reflection: @reflection
+          )
+        end
+
+        attr_reader :reflection, :has_many
+
+        def test_is_cached_association
+          assert_equal Cached::Association, HasMany.superclass.superclass
+        end
+
+        def test_build
+          has_many.build
+          record = AssociatedRecord.new
+
+          assert_operator record, :respond_to?, :fetch_deeply_associated_records
+          assert_operator record, :respond_to?, :prepopulate_fetched_deeply_associated_records
+        end
+
+        def test_clear
+          record = AssociatedRecord.new
+          record.instance_variable_set(:@cached_deeply_associated_records, [])
+
+          has_many.clear(record)
+
+          refute_operator record, :instance_variable_defined?, :@cached_deeply_associated_records
+        end
+
+        def test_embedded
+          assert_predicate has_many, :embedded?
+        end
+
+        def test_embedded_recursively
+          assert_predicate has_many, :embedded_recursively?
+        end
+
+        def test_embedded_by_reference
+          refute_predicate has_many, :embedded_by_reference?
+        end
+      end
+    end
+  end
+end

--- a/test/cached/recursive/has_one_test.rb
+++ b/test/cached/recursive/has_one_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+module IdentityCache
+  module Cached
+    module Recursive
+      class HasOneTest < IdentityCache::TestCase
+        def setup
+          super
+          @reflection = reflect(AssociatedRecord, :deeply_associated)
+          @has_one = HasMany.new(
+            :deeply_associated,
+            inverse_name: :associated_record,
+            reflection: @reflection
+          )
+        end
+
+        attr_reader :reflection, :has_one
+
+        def test_is_cached_association
+          assert_equal Cached::Association, HasOne.superclass.superclass
+        end
+
+        def test_build
+          has_one.build
+          record = AssociatedRecord.new
+
+          assert_operator record, :respond_to?, :fetch_deeply_associated
+          assert_operator record, :respond_to?, :prepopulate_fetched_deeply_associated
+        end
+
+        def test_clear
+          record = AssociatedRecord.new
+          record.instance_variable_set(:@cached_deeply_associated, DeeplyAssociatedRecord.new)
+
+          has_one.clear(record)
+
+          refute_operator record, :instance_variable_defined?, :@cached_deeply_associated
+        end
+
+        def test_embedded
+          assert_predicate has_one, :embedded?
+        end
+
+        def test_embedded_recursively
+          assert_predicate has_one, :embedded_recursively?
+        end
+
+        def test_embedded_by_reference
+          refute_predicate has_one, :embedded_by_reference?
+        end
+      end
+    end
+  end
+end

--- a/test/cached/reference/belongs_to_test.rb
+++ b/test/cached/reference/belongs_to_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+module IdentityCache
+  module Cached
+    module Reference
+      class BelongsToTest < IdentityCache::TestCase
+        def setup
+          super
+          @reflection = reflect(AssociatedRecord, :item)
+          @belongs_to = BelongsTo.new(:item, reflection: @reflection)
+        end
+
+        attr_reader :reflection, :belongs_to
+
+        def test_is_cached_association
+          assert_equal Cached::Association, BelongsTo.superclass.superclass
+        end
+
+        def test_build
+          belongs_to.build
+          record = AssociatedRecord.new
+
+          assert_operator record, :respond_to?, :fetch_item
+          assert_operator record, :respond_to?, :prepopulate_fetched_item
+        end
+
+        def test_clear
+          record = AssociatedRecord.new
+          record.instance_variable_set(:@cached_item, Item.new)
+
+          belongs_to.clear(record)
+
+          refute_operator record, :instance_variable_defined?, :@cached_item
+        end
+
+        def test_embedded
+          refute_predicate belongs_to, :embedded?
+        end
+
+        def test_embedded_recursively
+          refute_predicate belongs_to, :embedded_recursively?
+        end
+
+        def test_embedded_by_reference
+          refute_predicate belongs_to, :embedded_by_reference?
+        end
+      end
+    end
+  end
+end

--- a/test/cached/reference/has_many_test.rb
+++ b/test/cached/reference/has_many_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+module IdentityCache
+  module Cached
+    module Reference
+      class HasManyTest < IdentityCache::TestCase
+        def setup
+          super
+          @reflection = reflect(AssociatedRecord, :deeply_associated_records)
+          @has_many = HasMany.new(
+            :deeply_associated_records,
+            inverse_name: :associated_record,
+            reflection: @reflection
+          )
+        end
+
+        attr_reader :reflection, :has_many
+
+        def test_is_cached_association
+          assert_equal Cached::Association, HasMany.superclass.superclass
+        end
+
+        def test_build
+          has_many.build
+          record = AssociatedRecord.new
+
+          assert_operator record, :respond_to?, :fetch_deeply_associated_record_ids
+          assert_operator record, :respond_to?, :cached_deeply_associated_record_ids
+          assert_operator record, :respond_to?, :fetch_deeply_associated_records
+          assert_operator record, :respond_to?, :prepopulate_fetched_deeply_associated_records
+        end
+
+        def test_clear
+          record = AssociatedRecord.new
+          record.instance_variable_set(:@cached_deeply_associated_record_ids, [])
+          record.instance_variable_set(:@cached_deeply_associated_records, [])
+
+          has_many.clear(record)
+
+          refute_operator record, :instance_variable_defined?, :@cached_deeply_associated_record_ids
+          refute_operator record, :instance_variable_defined?, :@cached_deeply_associated_records
+        end
+
+        def test_embedded
+          assert_predicate has_many, :embedded?
+        end
+
+        def test_embedded_recursively
+          refute_predicate has_many, :embedded_recursively?
+        end
+
+        def test_embedded_by_reference
+          assert_predicate has_many, :embedded_by_reference?
+        end
+      end
+    end
+  end
+end

--- a/test/cached/reference/has_one_test.rb
+++ b/test/cached/reference/has_one_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+module IdentityCache
+  module Cached
+    module Reference
+      class HasOneTest < IdentityCache::TestCase
+        def setup
+          super
+          @reflection = reflect(AssociatedRecord, :deeply_associated)
+          @has_one = HasOne.new(
+            :deeply_associated,
+            inverse_name: :associated_record,
+            reflection: @reflection
+          )
+        end
+
+        attr_reader :reflection, :has_one
+
+        def test_is_cached_association
+          assert_equal Cached::Association, HasOne.superclass.superclass
+        end
+
+        def test_build
+          has_one.build
+          record = AssociatedRecord.new
+
+          assert_operator record, :respond_to?, :cached_deeply_associated_id
+          assert_operator record, :respond_to?, :fetch_deeply_associated_id
+          assert_operator record, :respond_to?, :fetch_deeply_associated
+          assert_operator record, :respond_to?, :prepopulate_fetched_deeply_associated
+        end
+
+        def test_clear
+          record = AssociatedRecord.new
+          record.instance_variable_set(:@cached_deeply_associated_id, [])
+          record.instance_variable_set(:@cached_deeply_associated, [])
+
+          has_one.clear(record)
+
+          refute_operator record, :instance_variable_defined?, :@cached_deeply_associated_id
+          refute_operator record, :instance_variable_defined?, :@cached_deeply_associated
+        end
+
+        def test_embedded
+          assert_predicate has_one, :embedded?
+        end
+
+        def test_embedded_recursively
+          refute_predicate has_one, :embedded_recursively?
+        end
+
+        def test_embedded_by_reference
+          assert_predicate has_one, :embedded_by_reference?
+        end
+      end
+    end
+  end
+end

--- a/test/expiry_hook_test.rb
+++ b/test/expiry_hook_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+module IdentityCache
+  class ExpiryHookTest < IdentityCache::TestCase
+    def test_cached_association
+      hook = ExpiryHook.new(reference_cached_association)
+
+      assert_same reference_cached_association, hook.cached_association
+    end
+
+    def test_only_on_foreign_key_change_true_when_reference_association
+      hook = ExpiryHook.new(reference_cached_association)
+
+      assert_predicate hook, :only_on_foreign_key_change?
+    end
+
+    def test_only_on_foreign_key_change_false_when_recursive_association
+      hook = ExpiryHook.new(recursive_cached_association)
+
+      refute_predicate hook, :only_on_foreign_key_change?
+    end
+
+    def test_only_on_foreign_key_change_false_when_belongs_to
+      hook = ExpiryHook.new(belongs_to_reference_cached_association)
+
+      refute_predicate hook, :only_on_foreign_key_change?
+    end
+
+    private
+
+    def reference_cached_association
+      @reference_assocaition ||= Cached::Reference::HasMany.new(
+        :deeply_associated_records,
+        inverse_name: :associated_record,
+        reflection: reflect(AssociatedRecord, :deeply_associated_records),
+      )
+    end
+
+    def recursive_cached_association
+      @recursive_association ||= Cached::Recursive::HasMany.new(
+        :deeply_associated_records,
+        inverse_name: :associated_record,
+        reflection: reflect(AssociatedRecord, :deeply_associated_records),
+      )
+    end
+
+    def belongs_to_reference_cached_association
+      @reference_assocaition ||= Cached::Reference::BelongsTo.new(
+        :item,
+        reflection: reflect(AssociatedRecord, :item),
+      )
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -101,6 +101,10 @@ class IdentityCache::TestCase < Minitest::Test
   def cache_hash(key)
     IdentityCache.memcache_hash(key)
   end
+
+  def reflect(model, association_name)
+    model.reflect_on_association(association_name)
+  end
 end
 
 class SQLCounter


### PR DESCRIPTION
Refactors cached association hashes into objects. Also starts to add a basic expiry hook object. This ended up getting kinda big so I've sorted it into several commits for your reviewing pleasure.

I discovered two more easy fixes that need to go in before this regarding cache key naming for ID embedded associations, and not including `association_ids` in payloads where there are no ID embedded has manys.