### PR TITLE
Add :id to cache key hashing for ID embedded hash_ones

### DIFF
--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -17,6 +17,8 @@ module IdentityCache
             schema_string << ",#{name}:(#{denormalized_schema_hash(options[:association_reflection].klass)})"
           when :ids
             schema_string << ",#{name}:ids"
+          when :id
+            schema_string << ",#{name}:id"
           end
         end
       end

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -7,18 +7,23 @@ module IdentityCache
       columns.sort_by(&:name).map{|c| "#{c.name}:#{c.type}"}.join(',')
     end
 
-    def self.denormalized_schema_hash(klass)
-      schema_string = schema_to_string(klass.columns)
-      klass.send(:all_cached_associations).sort.each do |name, options|
-        klass.send(:check_association_scope, name)
-        ParentModelExpiration.check_association(options) if options[:embed]
-        case options[:embed]
-        when true
-          schema_string << ",#{name}:(#{denormalized_schema_hash(options[:association_reflection].klass)})"
-        when :ids
-          schema_string << ",#{name}:ids"
+    def self.denormalized_schema_string(klass)
+      schema_to_string(klass.columns).tap do |schema_string|
+        klass.send(:all_cached_associations).sort.each do |name, options|
+          klass.send(:check_association_scope, name)
+          ParentModelExpiration.check_association(options) if options[:embed]
+          case options[:embed]
+          when true
+            schema_string << ",#{name}:(#{denormalized_schema_hash(options[:association_reflection].klass)})"
+          when :ids
+            schema_string << ",#{name}:ids"
+          end
         end
       end
+    end
+
+    def self.denormalized_schema_hash(klass)
+      schema_string = denormalized_schema_string(klass)
       IdentityCache.memcache_hash(schema_string)
     end
 
@@ -36,7 +41,7 @@ module IdentityCache
       end
 
       def rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, values, unique)
-        unique_indicator = unique ? '' : 's' 
+        unique_indicator = unique ? '' : 's'
         "#{rails_cache_key_namespace}" \
           "attr#{unique_indicator}" \
           ":#{base_class.name}" \

--- a/test/cache_key_generation_test.rb
+++ b/test/cache_key_generation_test.rb
@@ -40,7 +40,7 @@ module IdentityCache
       AssociatedRecord.cache_has_one(:deeply_associated, embed: :id)
 
       assert_equal(
-        "id:integer,item_id:integer,item_two_id:integer,name:string",
+        "id:integer,item_id:integer,item_two_id:integer,name:string,deeply_associated:id",
         CacheKeyGeneration.denormalized_schema_string(AssociatedRecord),
       )
     end

--- a/test/cache_key_generation_test.rb
+++ b/test/cache_key_generation_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+module IdentityCache
+  class CacheKeyGenerationTest < IdentityCache::TestCase
+    def test_schema_string
+      assert_equal(
+        "id:integer,item_id:integer,item_two_id:integer,name:string",
+        CacheKeyGeneration.denormalized_schema_string(AssociatedRecord),
+      )
+    end
+
+    def test_schema_string_with_recursive_has_many
+      AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
+
+      assert_equal(
+        "id:integer,item_id:integer,item_two_id:integer,name:string,deeply_associated_records:(319486821334646525)",
+        CacheKeyGeneration.denormalized_schema_string(AssociatedRecord),
+      )
+    end
+
+    def test_schema_string_with_referential_has_many
+      AssociatedRecord.cache_has_many(:deeply_associated_records, embed: :ids)
+
+      assert_equal(
+        "id:integer,item_id:integer,item_two_id:integer,name:string,deeply_associated_records:ids",
+        CacheKeyGeneration.denormalized_schema_string(AssociatedRecord),
+      )
+    end
+
+    def test_schema_string_with_recursive_has_one
+      AssociatedRecord.cache_has_one(:deeply_associated, embed: true)
+
+      assert_equal(
+        "id:integer,item_id:integer,item_two_id:integer,name:string,deeply_associated:(319486821334646525)",
+        CacheKeyGeneration.denormalized_schema_string(AssociatedRecord),
+      )
+    end
+
+    def test_schema_string_with_referential_has_one
+      AssociatedRecord.cache_has_one(:deeply_associated, embed: :id)
+
+      assert_equal(
+        "id:integer,item_id:integer,item_two_id:integer,name:string",
+        CacheKeyGeneration.denormalized_schema_string(AssociatedRecord),
+      )
+    end
+
+    def test_schema_string_with_belongs_to
+      AssociatedRecord.cache_belongs_to(:item)
+
+      # NOTE: Should be the same as a schema without cached assocaitions
+      assert_equal(
+        "id:integer,item_id:integer,item_two_id:integer,name:string",
+        CacheKeyGeneration.denormalized_schema_string(AssociatedRecord),
+      )
+    end
+  end
+end


### PR DESCRIPTION
Changes string that gets hashed into the IDC cache key for ID embedded has_one associations.