### PR TITLE
Require ruby 2.4+, test with 2.4 and 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 
 rvm:
-  - '2.2.6'
-  - 2.5
+  - 2.4
+  - 2.6
 
 gemfile:
   - gemfiles/Gemfile.rails50
@@ -12,6 +12,11 @@ gemfile:
 env:
   - DB=mysql2
   - DB=postgresql
+
+jobs:
+  exclude:
+    - rvm: 2.4
+    - gemfiles/Gemfile.rails-edge
 
 services:
   - memcache

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = IdentityCache::VERSION
 
-  gem.required_ruby_version = '>= 2.2.0'
+  gem.required_ruby_version = '>= 2.4.0'
 
   gem.add_dependency('ar_transaction_changes', '~> 1.0')
   gem.add_dependency('activerecord', '>= 5.0')
@@ -33,6 +33,6 @@ Gem::Specification.new do |gem|
     gem.add_development_dependency('cityhash', '0.6.0')
     gem.add_development_dependency('mysql2')
     gem.add_development_dependency('pg', '~> 0.18')
-    gem.add_development_dependency('stackprof') if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("2.1.0")
+    gem.add_development_dependency('stackprof')
   end
 end


### PR DESCRIPTION
Ruby 2.2 isn't supported anymore, and neither is 2.3. I want to require 2.4+ and start testing with 2.6.