### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_from:
-  - .rubocop_todo.yml
   - https://shopify.github.io/ruby-style-guide/rubocop.yml
+  - .rubocop_todo.yml
 
 AllCops:
   TargetRubyVersion: 2.6

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -367,13 +367,6 @@ Style/IfInsideElse:
   Exclude:
     - 'lib/identity_cache/query_api.rb'
 
-# Offense count: 466
-# Cop supports --auto-correct.
-# Configuration parameters: IgnoreMacros, IgnoredMethods, IgnoredPatterns, IncludedMacros, AllowParenthesesInMultilineCall, AllowParenthesesInChaining, AllowParenthesesInCamelCaseMethod, EnforcedStyle.
-# SupportedStyles: require_parentheses, omit_parentheses
-Style/MethodCallWithArgsParentheses:
-  Enabled: false
-
 # Offense count: 4
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, MinBodyLength.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -354,13 +354,6 @@ Style/EmptyLiteral:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-# Offense count: 217
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
-# SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-Style/HashSyntax:
-  Enabled: false
-
 # Offense count: 1
 # Configuration parameters: AllowIfModifier.
 Style/IfInsideElse:

--- a/Rakefile
+++ b/Rakefile
@@ -4,10 +4,10 @@ require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rdoc/task'
 
-desc 'Default: run unit tests.'
-task :default => :test
+desc('Default: run unit tests.')
+task(:default => :test)
 
-desc 'Test the identity_cache plugin.'
+desc('Test the identity_cache plugin.')
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.libs << 'test'
@@ -15,7 +15,7 @@ Rake::TestTask.new(:test) do |t|
   t.verbose = true
 end
 
-desc 'Update serialization format test fixture.'
+desc('Update serialization format test fixture.')
 task :update_serialization_format do
   %w(mysql2 postgresql).each do |db|
     ENV["DB"] = db

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'rake/testtask'
 require 'rdoc/task'
 
 desc('Default: run unit tests.')
-task(:default => :test)
+task(default: :test)
 
 desc('Test the identity_cache plugin.')
 Rake::TestTask.new(:test) do |t|

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -67,7 +67,7 @@ module IdentityCache
 
     def included(base) #:nodoc:
       raise AlreadyIncludedError if base.respond_to?(:cached_model)
-      base.class_attribute :cached_model
+      base.class_attribute(:cached_model)
       base.cached_model = base
       super
     end
@@ -167,8 +167,8 @@ module IdentityCache
     private
 
     def fetch_in_batches(keys)
-      keys.each_slice(BATCH_SIZE).each_with_object Hash.new do |slice, result|
-        result.merge! cache.fetch_multi(*slice) {|missed_keys| yield missed_keys }
+      keys.each_slice(BATCH_SIZE).each_with_object(Hash.new) do |slice, result|
+        result.merge!(cache.fetch_multi(*slice) {|missed_keys| yield missed_keys })
       end
     end
   end

--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -3,7 +3,7 @@ module IdentityCache
     extend ActiveSupport::Concern
 
     included do |base|
-      base.class_attribute :cached_belongs_tos
+      base.class_attribute(:cached_belongs_tos)
       base.cached_belongs_tos = {}
     end
 

--- a/lib/identity_cache/cache_fetcher.rb
+++ b/lib/identity_cache/cache_fetcher.rb
@@ -11,7 +11,7 @@ module IdentityCache
     end
 
     def delete(key)
-      @cache_backend.write(key, IdentityCache::DELETED, :expires_in => IdentityCache::DELETED_TTL.seconds)
+      @cache_backend.write(key, IdentityCache::DELETED, expires_in: IdentityCache::DELETED_TTL.seconds)
     end
 
     def clear
@@ -81,7 +81,7 @@ module IdentityCache
     end
 
     def add(key, value)
-      @cache_backend.write(key, value, :unless_exist => true) if IdentityCache.should_fill_cache?
+      @cache_backend.write(key, value, unless_exist: true) if IdentityCache.should_fill_cache?
     end
   end
 end

--- a/lib/identity_cache/cache_hash.rb
+++ b/lib/identity_cache/cache_hash.rb
@@ -3,7 +3,7 @@ begin
   require 'cityhash'
 rescue LoadError
   unless RUBY_PLATFORM == 'java'
-    warn <<-NOTICE
+    warn(<<-NOTICE)
       ** Notice: CityHash was not loaded. **
 
       For optimal performance, use of the cityhash gem is recommended.

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -3,10 +3,10 @@ module IdentityCache
     extend ActiveSupport::Concern
 
     included do |base|
-      base.class_attribute :cache_indexes
-      base.class_attribute :cached_has_manys
-      base.class_attribute :cached_has_ones
-      base.class_attribute :primary_cache_index_enabled
+      base.class_attribute(:cache_indexes)
+      base.class_attribute(:cached_has_manys)
+      base.class_attribute(:cached_has_ones)
+      base.class_attribute(:primary_cache_index_enabled)
 
       base.cached_has_manys = {}
       base.cached_has_ones = {}
@@ -196,7 +196,7 @@ module IdentityCache
         unique = !!unique
         fields = Array(by)
 
-        self.cache_indexes.push [alias_name, fields, unique]
+        self.cache_indexes.push([alias_name, fields, unique])
 
         field_list = fields.join("_and_")
         arg_list = (0...fields.size).collect { |i| "arg#{i}" }.join(',')

--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -18,8 +18,8 @@ module IdentityCache
         when ActiveSupport::Cache::MemoryStore, ActiveSupport::Cache::NullStore
           # no need for CAS support
         else
-          warn "[IdentityCache] Missing CAS support in cache backend #{cache_adaptor.class} "\
-               "which is needed for cache consistency"
+          warn("[IdentityCache] Missing CAS support in cache backend #{cache_adaptor.class} "\
+               "which is needed for cache consistency")
         end
         @cache_fetcher = FallbackFetcher.new(cache_adaptor)
       end
@@ -183,9 +183,9 @@ module IdentityCache
         cache_hit_keys = memo_miss_keys - cache_miss_keys
         missed_keys = cache_miss_keys
 
-        memoized_keys.each {|k| IdentityCache.logger.debug "[IdentityCache] (memoized) cache hit for #{k} (multi)" }
-        cache_hit_keys.each {|k| IdentityCache.logger.debug "[IdentityCache] (backend) cache hit for #{k} (multi)" }
-        missed_keys.each {|k| IdentityCache.logger.debug "[IdentityCache] cache miss for #{k} (multi)" }
+        memoized_keys.each {|k| IdentityCache.logger.debug("[IdentityCache] (memoized) cache hit for #{k} (multi)") }
+        cache_hit_keys.each {|k| IdentityCache.logger.debug("[IdentityCache] (backend) cache hit for #{k} (multi)") }
+        missed_keys.each {|k| IdentityCache.logger.debug("[IdentityCache] cache miss for #{k} (multi)") }
       end
     end
   end

--- a/lib/identity_cache/parent_model_expiration.rb
+++ b/lib/identity_cache/parent_model_expiration.rb
@@ -66,10 +66,10 @@ module IdentityCache
     end
 
     included do |base|
-      base.class_attribute :parent_expiration_entries
+      base.class_attribute(:parent_expiration_entries)
       base.parent_expiration_entries = Hash.new{ |hash, key| hash[key] = [] }
 
-      base.after_commit :expire_parent_caches
+      base.after_commit(:expire_parent_caches)
     end
 
     def expire_parent_caches

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -3,7 +3,7 @@ module IdentityCache
     extend ActiveSupport::Concern
 
     included do |base|
-      base.after_commit :expire_cache
+      base.after_commit(:expire_cache)
     end
 
     module ClassMethods
@@ -28,7 +28,7 @@ module IdentityCache
             coder = IdentityCache.fetch(rails_cache_key(id)){ instrumented_coder_from_record(object = resolve_cache_miss(id)) }
             object ||= instrumented_record_from_coder(coder)
             if object && object.id != id
-              IdentityCache.logger.error "[IDC id mismatch] fetch_by_id_requested=#{id} fetch_by_id_got=#{object.id} for #{object.inspect[(0..100)]}"
+              IdentityCache.logger.error("[IDC id mismatch] fetch_by_id_requested=#{id} fetch_by_id_got=#{object.id} for #{object.inspect[(0..100)]}")
             end
             object
           end

--- a/performance/cache_runner.rb
+++ b/performance/cache_runner.rb
@@ -22,7 +22,7 @@ def create_record(id)
 end
 
 def database_ready(count)
-  Item.where(:id => (1..count)).count == count
+  Item.where(id: (1..count)).count == count
 rescue
   false
 end
@@ -58,8 +58,8 @@ end
 
 def setup_embedded_associations
   Item.cache_has_one(:associated)
-  Item.cache_has_many(:associated_records, :embed => true)
-  AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => true)
+  Item.cache_has_many(:associated_records, embed: true)
+  AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
 end
 
 class CacheRunner
@@ -84,7 +84,7 @@ CACHE_RUNNERS = []
 class FindRunner < CacheRunner
   def run
     (1..@count).each do |i|
-      ::Item.includes(:associated, {:associated_records => :deeply_associated_records}).find(i)
+      ::Item.includes(:associated, {associated_records: :deeply_associated_records}).find(i)
     end
   end
 end
@@ -137,8 +137,8 @@ class EmbedRunner < CacheRunner
   def setup_models
     super
     Item.cache_has_one(:associated)
-    Item.cache_has_many(:associated_records, :embed => true)
-    AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => true)
+    Item.cache_has_many(:associated_records, embed: true)
+    AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
   end
 
   def run
@@ -179,8 +179,8 @@ class NormalizedRunner < CacheRunner
   def setup_models
     super
     Item.cache_has_one(:associated) # :embed => false isn't supported
-    Item.cache_has_many(:associated_records, :embed => :ids)
-    AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => :ids)
+    Item.cache_has_many(:associated_records, embed: :ids)
+    AssociatedRecord.cache_has_many(:deeply_associated_records, embed: :ids)
   end
 
   def run

--- a/performance/cache_runner.rb
+++ b/performance/cache_runner.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
 require 'active_record'
 require 'active_support/core_ext'
 require 'active_support/cache'
@@ -57,9 +57,9 @@ ensure
 end
 
 def setup_embedded_associations
-  Item.cache_has_one :associated
-  Item.cache_has_many :associated_records, :embed => true
-  AssociatedRecord.cache_has_many :deeply_associated_records, :embed => true
+  Item.cache_has_one(:associated)
+  Item.cache_has_many(:associated_records, :embed => true)
+  AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => true)
 end
 
 class CacheRunner
@@ -136,9 +136,9 @@ end
 class EmbedRunner < CacheRunner
   def setup_models
     super
-    Item.cache_has_one :associated
-    Item.cache_has_many :associated_records, :embed => true
-    AssociatedRecord.cache_has_many :deeply_associated_records, :embed => true
+    Item.cache_has_one(:associated)
+    Item.cache_has_many(:associated_records, :embed => true)
+    AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => true)
   end
 
   def run
@@ -178,9 +178,9 @@ CACHE_RUNNERS << FetchEmbedDeletedConflictRunner
 class NormalizedRunner < CacheRunner
   def setup_models
     super
-    Item.cache_has_one :associated # :embed => false isn't supported
-    Item.cache_has_many :associated_records, :embed => :ids
-    AssociatedRecord.cache_has_many :deeply_associated_records, :embed => :ids
+    Item.cache_has_one(:associated) # :embed => false isn't supported
+    Item.cache_has_many(:associated_records, :embed => :ids)
+    AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => :ids)
   end
 
   def run

--- a/performance/profile.rb
+++ b/performance/profile.rb
@@ -26,7 +26,7 @@ if runner_name = ENV['RUNNER']
     run(runner.new(RUNS), filename: ENV['FILENAME'])
   else
     puts "Couldn't find cache runner #{runner_name.inspect}"
-    exit 1
+    exit(1)
   end
 else
   CACHE_RUNNERS.each do |runner|

--- a/test/attribute_cache_test.rb
+++ b/test/attribute_cache_test.rb
@@ -5,7 +5,7 @@ class AttributeCacheTest < IdentityCache::TestCase
 
   def setup
     super
-    AssociatedRecord.cache_attribute :name
+    AssociatedRecord.cache_attribute(:name)
 
     @parent = Item.create!(:title => 'bob')
     @record = @parent.associated_records.create!(:name => 'foo')
@@ -19,11 +19,11 @@ class AttributeCacheTest < IdentityCache::TestCase
     assert_queries(1) do
       assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
     end
-    assert fetch.has_been_called_with?(@name_attribute_key)
+    assert(fetch.has_been_called_with?(@name_attribute_key))
   end
 
   def test_attribute_values_are_returned_on_cache_hits
-    assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
+    assert_equal('foo', AssociatedRecord.fetch_name_by_id(1))
 
     assert_queries(0) do
       assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
@@ -31,7 +31,7 @@ class AttributeCacheTest < IdentityCache::TestCase
   end
 
   def test_nil_is_stored_in_the_cache_on_cache_misses
-    assert_nil AssociatedRecord.fetch_name_by_id(2)
+    assert_nil(AssociatedRecord.fetch_name_by_id(2))
 
     assert_queries(0) do
       assert_nil AssociatedRecord.fetch_name_by_id(2)
@@ -84,7 +84,7 @@ class AttributeCacheTest < IdentityCache::TestCase
   end
 
   def test_no_nil_empty_string_cache_key_conflict
-    Item.cache_attribute :id, by: [:title]
+    Item.cache_attribute(:id, by: [:title])
     @parent.update_attributes!(title: "")
     assert_queries(1) { assert_equal @parent.id, Item.fetch_id_by_title("") }
     assert_queries(1) { assert_nil Item.fetch_id_by_title(nil) }
@@ -104,14 +104,14 @@ class AttributeCacheTest < IdentityCache::TestCase
   end
 
   def test_previously_stored_cached_nils_are_busted_by_new_record_saves
-    assert_nil AssociatedRecord.fetch_name_by_id(2)
+    assert_nil(AssociatedRecord.fetch_name_by_id(2))
     AssociatedRecord.create(:name => "Jim")
-    assert_equal "Jim", AssociatedRecord.fetch_name_by_id(2)
+    assert_equal("Jim", AssociatedRecord.fetch_name_by_id(2))
   end
 
   def test_cache_attribute_on_derived_model_raises
     assert_raises(IdentityCache::DerivedModelError) do
-      StiRecordTypeA.cache_attribute :name
+      StiRecordTypeA.cache_attribute(:name)
     end
   end
 

--- a/test/attribute_cache_test.rb
+++ b/test/attribute_cache_test.rb
@@ -7,8 +7,8 @@ class AttributeCacheTest < IdentityCache::TestCase
     super
     AssociatedRecord.cache_attribute(:name)
 
-    @parent = Item.create!(:title => 'bob')
-    @record = @parent.associated_records.create!(:name => 'foo')
+    @parent = Item.create!(title: 'bob')
+    @record = @parent.associated_records.create!(name: 'foo')
     @name_attribute_key = "#{NAMESPACE}attr:AssociatedRecord:name:id:#{cache_hash(@record.id.to_s.inspect)}"
     IdentityCache.cache.clear
   end
@@ -71,7 +71,7 @@ class AttributeCacheTest < IdentityCache::TestCase
     assert_queries(1) { assert_nil AssociatedRecord.fetch_name_by_id(new_id) }
     assert_queries(0) { assert_nil AssociatedRecord.fetch_name_by_id(new_id) }
 
-    @parent.associated_records.create(:name => 'bar')
+    @parent.associated_records.create(name: 'bar')
 
     assert_queries(1) { assert_equal 'bar', AssociatedRecord.fetch_name_by_id(new_id) }
   end
@@ -105,7 +105,7 @@ class AttributeCacheTest < IdentityCache::TestCase
 
   def test_previously_stored_cached_nils_are_busted_by_new_record_saves
     assert_nil(AssociatedRecord.fetch_name_by_id(2))
-    AssociatedRecord.create(:name => "Jim")
+    AssociatedRecord.create(name: "Jim")
     assert_equal("Jim", AssociatedRecord.fetch_name_by_id(2))
   end
 

--- a/test/cache_fetch_includes_test.rb
+++ b/test/cache_fetch_includes_test.rb
@@ -6,12 +6,12 @@ class CacheFetchIncludesTest < IdentityCache::TestCase
   end
 
   def test_cached_embedded_has_manys_are_included_in_includes
-    Item.send(:cache_has_many, :associated_records, :embed => true)
+    Item.send(:cache_has_many, :associated_records, embed: true)
     assert_equal([:associated_records], Item.send(:cache_fetch_includes))
   end
 
   def test_cached_nonembedded_has_manys_are_included_in_includes
-    Item.send(:cache_has_many, :associated_records, :embed => :ids)
+    Item.send(:cache_has_many, :associated_records, embed: :ids)
     assert_equal([], Item.send(:cache_fetch_includes))
   end
 
@@ -26,21 +26,21 @@ class CacheFetchIncludesTest < IdentityCache::TestCase
   end
 
   def test_cached_child_associations_are_included_in_includes
-    Item.send(:cache_has_many, :associated_records, :embed => true)
-    AssociatedRecord.send(:cache_has_many, :deeply_associated_records, :embed => true)
-    assert_equal([{:associated_records => [:deeply_associated_records]}], Item.send(:cache_fetch_includes))
+    Item.send(:cache_has_many, :associated_records, embed: true)
+    AssociatedRecord.send(:cache_has_many, :deeply_associated_records, embed: true)
+    assert_equal([{associated_records: [:deeply_associated_records]}], Item.send(:cache_fetch_includes))
   end
 
   def test_multiple_cached_associations_and_child_associations_are_included_in_includes
-    Item.send(:cache_has_many, :associated_records, :embed => true)
+    Item.send(:cache_has_many, :associated_records, embed: true)
     PolymorphicRecord.send(:include, IdentityCache::WithoutPrimaryIndex)
-    Item.send(:cache_has_many, :polymorphic_records, {:inverse_name => :owner, :embed => true})
-    Item.send(:cache_has_one, :associated, :embed => true)
-    AssociatedRecord.send(:cache_has_many, :deeply_associated_records, :embed => true)
+    Item.send(:cache_has_many, :polymorphic_records, {inverse_name: :owner, embed: true})
+    Item.send(:cache_has_one, :associated, embed: true)
+    AssociatedRecord.send(:cache_has_many, :deeply_associated_records, embed: true)
     assert_equal([
-      {:associated_records => [:deeply_associated_records]},
+      {associated_records: [:deeply_associated_records]},
       :polymorphic_records,
-      {:associated => [:deeply_associated_records]}
+      {associated: [:deeply_associated_records]}
     ],  Item.send(:cache_fetch_includes))
   end
 end

--- a/test/cache_fetch_includes_test.rb
+++ b/test/cache_fetch_includes_test.rb
@@ -7,28 +7,28 @@ class CacheFetchIncludesTest < IdentityCache::TestCase
 
   def test_cached_embedded_has_manys_are_included_in_includes
     Item.send(:cache_has_many, :associated_records, :embed => true)
-    assert_equal [:associated_records], Item.send(:cache_fetch_includes)
+    assert_equal([:associated_records], Item.send(:cache_fetch_includes))
   end
 
   def test_cached_nonembedded_has_manys_are_included_in_includes
     Item.send(:cache_has_many, :associated_records, :embed => :ids)
-    assert_equal [], Item.send(:cache_fetch_includes)
+    assert_equal([], Item.send(:cache_fetch_includes))
   end
 
   def test_cached_has_ones_are_included_in_includes
     Item.send(:cache_has_one, :associated)
-    assert_equal [:associated], Item.send(:cache_fetch_includes)
+    assert_equal([:associated], Item.send(:cache_fetch_includes))
   end
 
   def test_cached_nonembedded_belongs_tos_are_not_included_in_includes
     Item.send(:cache_belongs_to, :item)
-    assert_equal [], Item.send(:cache_fetch_includes)
+    assert_equal([], Item.send(:cache_fetch_includes))
   end
 
   def test_cached_child_associations_are_included_in_includes
     Item.send(:cache_has_many, :associated_records, :embed => true)
     AssociatedRecord.send(:cache_has_many, :deeply_associated_records, :embed => true)
-    assert_equal [{:associated_records => [:deeply_associated_records]}], Item.send(:cache_fetch_includes)
+    assert_equal([{:associated_records => [:deeply_associated_records]}], Item.send(:cache_fetch_includes))
   end
 
   def test_multiple_cached_associations_and_child_associations_are_included_in_includes
@@ -37,10 +37,10 @@ class CacheFetchIncludesTest < IdentityCache::TestCase
     Item.send(:cache_has_many, :polymorphic_records, {:inverse_name => :owner, :embed => true})
     Item.send(:cache_has_one, :associated, :embed => true)
     AssociatedRecord.send(:cache_has_many, :deeply_associated_records, :embed => true)
-    assert_equal [
+    assert_equal([
       {:associated_records => [:deeply_associated_records]},
       :polymorphic_records,
       {:associated => [:deeply_associated_records]}
-    ],  Item.send(:cache_fetch_includes)
+    ],  Item.send(:cache_fetch_includes))
   end
 end

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -4,9 +4,9 @@ class CacheInvalidationTest < IdentityCache::TestCase
   def setup
     super
 
-    @record = Item.new(:title => 'foo')
-    @record.associated_records << AssociatedRecord.new(:name => 'bar')
-    @record.associated_records << AssociatedRecord.new(:name => 'baz')
+    @record = Item.new(title: 'foo')
+    @record.associated_records << AssociatedRecord.new(name: 'bar')
+    @record.associated_records << AssociatedRecord.new(name: 'baz')
     @record.save
     @record.reload
     @baz, @bar = @record.associated_records[0], @record.associated_records[1]
@@ -14,7 +14,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
   end
 
   def test_reload_invalidate_cached_ids
-    Item.cache_has_many(:associated_records, :embed => :ids)
+    Item.cache_has_many(:associated_records, embed: :ids)
 
     variable_name = @record.class.send(:embedded_associations)[:associated_records].ids_variable_name
 
@@ -29,7 +29,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
   end
 
   def test_reload_invalidate_cached_objects
-    Item.cache_has_many(:associated_records, :embed => :ids)
+    Item.cache_has_many(:associated_records, embed: :ids)
 
     variable_name = @record.class.send(:embedded_associations)[:associated_records].records_variable_name
 
@@ -44,7 +44,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
   end
 
   def test_after_a_reload_the_cache_perform_as_expected
-    Item.cache_has_many(:associated_records, :embed => :ids)
+    Item.cache_has_many(:associated_records, embed: :ids)
 
     assert_equal([@baz, @bar], @record.fetch_associated_records)
     assert_equal([@baz, @bar], @record.associated_records)
@@ -70,16 +70,16 @@ class CacheInvalidationTest < IdentityCache::TestCase
   end
 
   def test_cache_invalidation_expire_properly_if_child_is_embed_in_multiple_parents
-    Item.cache_has_many(:associated_records, :embed => true)
-    ItemTwo.cache_has_many(:associated_records, :embed => true)
+    Item.cache_has_many(:associated_records, embed: true)
+    ItemTwo.cache_has_many(:associated_records, embed: true)
 
-    baz = AssociatedRecord.new(:name => 'baz')
+    baz = AssociatedRecord.new(name: 'baz')
 
-    record1 = Item.new(:title => 'foo')
+    record1 = Item.new(title: 'foo')
     record1.associated_records << baz
     record1.save!
 
-    record2 = ItemTwo.new(:title => 'bar')
+    record2 = ItemTwo.new(title: 'bar')
     record2.associated_records << baz
     record2.save!
 
@@ -103,15 +103,15 @@ class CacheInvalidationTest < IdentityCache::TestCase
   end
 
   def test_cache_invalidation_expire_properly_if_child_is_embed_in_multiple_parents_with_ids
-    Item.cache_has_many(:associated_records, :embed => :ids)
-    ItemTwo.cache_has_many(:associated_records, :embed => :ids)
+    Item.cache_has_many(:associated_records, embed: :ids)
+    ItemTwo.cache_has_many(:associated_records, embed: :ids)
 
-    baz = AssociatedRecord.new(:name => 'baz')
+    baz = AssociatedRecord.new(name: 'baz')
 
-    record1 = Item.new(:title => 'foo')
+    record1 = Item.new(title: 'foo')
     record1.save
 
-    record2 = ItemTwo.new(:title => 'bar')
+    record2 = ItemTwo.new(title: 'bar')
     record2.save
 
     record1.class.fetch(record1.id)
@@ -136,7 +136,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
   end
 
   def test_cache_invalidation_expire_properly_when_expired_via_class_method
-    record = Item.create(:title => 'foo')
+    record = Item.create(title: 'foo')
     record.class.fetch(record.id)
 
     refute_nil(IdentityCache.cache.fetch(record.primary_cache_index_key) { nil })

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -14,64 +14,64 @@ class CacheInvalidationTest < IdentityCache::TestCase
   end
 
   def test_reload_invalidate_cached_ids
-    Item.cache_has_many :associated_records, :embed => :ids
+    Item.cache_has_many(:associated_records, :embed => :ids)
 
     variable_name = @record.class.send(:embedded_associations)[:associated_records].ids_variable_name
 
     @record.fetch_associated_record_ids
-    assert_equal [@baz.id, @bar.id], @record.instance_variable_get(variable_name)
+    assert_equal([@baz.id, @bar.id], @record.instance_variable_get(variable_name))
 
     @record.reload
-    assert_equal false, @record.instance_variable_defined?(variable_name)
+    assert_equal(false, @record.instance_variable_defined?(variable_name))
 
     @record.fetch_associated_record_ids
-    assert_equal [@baz.id, @bar.id], @record.instance_variable_get(variable_name)
+    assert_equal([@baz.id, @bar.id], @record.instance_variable_get(variable_name))
   end
 
   def test_reload_invalidate_cached_objects
-    Item.cache_has_many :associated_records, :embed => :ids
+    Item.cache_has_many(:associated_records, :embed => :ids)
 
     variable_name = @record.class.send(:embedded_associations)[:associated_records].records_variable_name
 
     @record.fetch_associated_records
-    assert_equal [@baz, @bar], @record.instance_variable_get(variable_name)
+    assert_equal([@baz, @bar], @record.instance_variable_get(variable_name))
 
     @record.reload
-    assert_equal false, @record.instance_variable_defined?(variable_name)
+    assert_equal(false, @record.instance_variable_defined?(variable_name))
 
     @record.fetch_associated_records
-    assert_equal [@baz, @bar], @record.instance_variable_get(variable_name)
+    assert_equal([@baz, @bar], @record.instance_variable_get(variable_name))
   end
 
   def test_after_a_reload_the_cache_perform_as_expected
-    Item.cache_has_many :associated_records, :embed => :ids
+    Item.cache_has_many(:associated_records, :embed => :ids)
 
-    assert_equal [@baz, @bar], @record.fetch_associated_records
-    assert_equal [@baz, @bar], @record.associated_records
+    assert_equal([@baz, @bar], @record.fetch_associated_records)
+    assert_equal([@baz, @bar], @record.associated_records)
 
     @baz.destroy
     @record.reload
 
-    assert_equal [@bar], @record.fetch_associated_records
-    assert_equal [@bar], @record.associated_records
+    assert_equal([@bar], @record.fetch_associated_records)
+    assert_equal([@bar], @record.associated_records)
   end
 
   def test_after_a_reload_the_cache_perform_as_expected
-    Item.cache_has_one :associated, embed: :id
+    Item.cache_has_one(:associated, embed: :id)
 
-    assert_equal @baz, @record.fetch_associated
-    assert_equal @baz, @record.associated
+    assert_equal(@baz, @record.fetch_associated)
+    assert_equal(@baz, @record.associated)
 
     @baz.destroy
     @record.reload
 
-    assert_equal @bar, @record.fetch_associated
-    assert_equal @bar, @record.associated
+    assert_equal(@bar, @record.fetch_associated)
+    assert_equal(@bar, @record.associated)
   end
 
   def test_cache_invalidation_expire_properly_if_child_is_embed_in_multiple_parents
-    Item.cache_has_many :associated_records, :embed => true
-    ItemTwo.cache_has_many :associated_records, :embed => true
+    Item.cache_has_many(:associated_records, :embed => true)
+    ItemTwo.cache_has_many(:associated_records, :embed => true)
 
     baz = AssociatedRecord.new(:name => 'baz')
 
@@ -103,8 +103,8 @@ class CacheInvalidationTest < IdentityCache::TestCase
   end
 
   def test_cache_invalidation_expire_properly_if_child_is_embed_in_multiple_parents_with_ids
-    Item.cache_has_many :associated_records, :embed => :ids
-    ItemTwo.cache_has_many :associated_records, :embed => :ids
+    Item.cache_has_many(:associated_records, :embed => :ids)
+    ItemTwo.cache_has_many(:associated_records, :embed => :ids)
 
     baz = AssociatedRecord.new(:name => 'baz')
 
@@ -139,17 +139,17 @@ class CacheInvalidationTest < IdentityCache::TestCase
     record = Item.create(:title => 'foo')
     record.class.fetch(record.id)
 
-    refute_nil IdentityCache.cache.fetch(record.primary_cache_index_key) { nil }
+    refute_nil(IdentityCache.cache.fetch(record.primary_cache_index_key) { nil })
 
     Item.expire_primary_key_cache_index(record.id)
 
-    assert_nil IdentityCache.cache.fetch(record.primary_cache_index_key) { nil }
+    assert_nil(IdentityCache.cache.fetch(record.primary_cache_index_key) { nil })
   end
 
   def test_dedup_cache_invalidation_of_records_embedded_twice_through_different_associations
-    Item.cache_has_many :associated_records, embed: true
-    AssociatedRecord.cache_has_many :deeply_associated_records, embed: true
-    Item.cache_has_many :deeply_associated_records, embed: true
+    Item.cache_has_many(:associated_records, embed: true)
+    AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
+    Item.cache_has_many(:deeply_associated_records, embed: true)
 
     deeply_associated_record = DeeplyAssociatedRecord.new(name: 'deep', item_id: @record.id)
     @record.associated_records[0].deeply_associated_records << deeply_associated_record

--- a/test/cached/association_test.rb
+++ b/test/cached/association_test.rb
@@ -16,23 +16,23 @@ module IdentityCache
       attr_reader :reflection, :association
 
       def test_name
-        assert_equal :item, association.name
+        assert_equal(:item, association.name)
       end
 
       def test_inverse_name
-        assert_equal :associated_record, association.inverse_name
+        assert_equal(:associated_record, association.inverse_name)
       end
 
       def test_reflection
-        assert_same reflection, association.reflection
+        assert_same(reflection, association.reflection)
       end
 
       def test_cached_accessor_name
-        assert_equal "fetch_item", association.cached_accessor_name
+        assert_equal("fetch_item", association.cached_accessor_name)
       end
 
       def test_prepopulate_method_name
-        assert_equal "prepopulate_fetched_item", association.prepopulate_method_name
+        assert_equal("prepopulate_fetched_item", association.prepopulate_method_name)
       end
     end
   end

--- a/test/cached/recursive/has_many_test.rb
+++ b/test/cached/recursive/has_many_test.rb
@@ -17,15 +17,15 @@ module IdentityCache
         attr_reader :reflection, :has_many
 
         def test_is_cached_association
-          assert_equal Cached::Association, HasMany.superclass.superclass
+          assert_equal(Cached::Association, HasMany.superclass.superclass)
         end
 
         def test_build
           has_many.build
           record = AssociatedRecord.new
 
-          assert_operator record, :respond_to?, :fetch_deeply_associated_records
-          assert_operator record, :respond_to?, :prepopulate_fetched_deeply_associated_records
+          assert_operator(record, :respond_to?, :fetch_deeply_associated_records)
+          assert_operator(record, :respond_to?, :prepopulate_fetched_deeply_associated_records)
         end
 
         def test_clear
@@ -34,19 +34,19 @@ module IdentityCache
 
           has_many.clear(record)
 
-          refute_operator record, :instance_variable_defined?, :@cached_deeply_associated_records
+          refute_operator(record, :instance_variable_defined?, :@cached_deeply_associated_records)
         end
 
         def test_embedded
-          assert_predicate has_many, :embedded?
+          assert_predicate(has_many, :embedded?)
         end
 
         def test_embedded_recursively
-          assert_predicate has_many, :embedded_recursively?
+          assert_predicate(has_many, :embedded_recursively?)
         end
 
         def test_embedded_by_reference
-          refute_predicate has_many, :embedded_by_reference?
+          refute_predicate(has_many, :embedded_by_reference?)
         end
       end
     end

--- a/test/cached/recursive/has_one_test.rb
+++ b/test/cached/recursive/has_one_test.rb
@@ -17,15 +17,15 @@ module IdentityCache
         attr_reader :reflection, :has_one
 
         def test_is_cached_association
-          assert_equal Cached::Association, HasOne.superclass.superclass
+          assert_equal(Cached::Association, HasOne.superclass.superclass)
         end
 
         def test_build
           has_one.build
           record = AssociatedRecord.new
 
-          assert_operator record, :respond_to?, :fetch_deeply_associated
-          assert_operator record, :respond_to?, :prepopulate_fetched_deeply_associated
+          assert_operator(record, :respond_to?, :fetch_deeply_associated)
+          assert_operator(record, :respond_to?, :prepopulate_fetched_deeply_associated)
         end
 
         def test_clear
@@ -34,19 +34,19 @@ module IdentityCache
 
           has_one.clear(record)
 
-          refute_operator record, :instance_variable_defined?, :@cached_deeply_associated
+          refute_operator(record, :instance_variable_defined?, :@cached_deeply_associated)
         end
 
         def test_embedded
-          assert_predicate has_one, :embedded?
+          assert_predicate(has_one, :embedded?)
         end
 
         def test_embedded_recursively
-          assert_predicate has_one, :embedded_recursively?
+          assert_predicate(has_one, :embedded_recursively?)
         end
 
         def test_embedded_by_reference
-          refute_predicate has_one, :embedded_by_reference?
+          refute_predicate(has_one, :embedded_by_reference?)
         end
       end
     end

--- a/test/cached/reference/belongs_to_test.rb
+++ b/test/cached/reference/belongs_to_test.rb
@@ -13,15 +13,15 @@ module IdentityCache
         attr_reader :reflection, :belongs_to
 
         def test_is_cached_association
-          assert_equal Cached::Association, BelongsTo.superclass.superclass
+          assert_equal(Cached::Association, BelongsTo.superclass.superclass)
         end
 
         def test_build
           belongs_to.build
           record = AssociatedRecord.new
 
-          assert_operator record, :respond_to?, :fetch_item
-          assert_operator record, :respond_to?, :prepopulate_fetched_item
+          assert_operator(record, :respond_to?, :fetch_item)
+          assert_operator(record, :respond_to?, :prepopulate_fetched_item)
         end
 
         def test_clear
@@ -30,19 +30,19 @@ module IdentityCache
 
           belongs_to.clear(record)
 
-          refute_operator record, :instance_variable_defined?, :@cached_item
+          refute_operator(record, :instance_variable_defined?, :@cached_item)
         end
 
         def test_embedded
-          refute_predicate belongs_to, :embedded?
+          refute_predicate(belongs_to, :embedded?)
         end
 
         def test_embedded_recursively
-          refute_predicate belongs_to, :embedded_recursively?
+          refute_predicate(belongs_to, :embedded_recursively?)
         end
 
         def test_embedded_by_reference
-          refute_predicate belongs_to, :embedded_by_reference?
+          refute_predicate(belongs_to, :embedded_by_reference?)
         end
       end
     end

--- a/test/cached/reference/has_many_test.rb
+++ b/test/cached/reference/has_many_test.rb
@@ -17,17 +17,17 @@ module IdentityCache
         attr_reader :reflection, :has_many
 
         def test_is_cached_association
-          assert_equal Cached::Association, HasMany.superclass.superclass
+          assert_equal(Cached::Association, HasMany.superclass.superclass)
         end
 
         def test_build
           has_many.build
           record = AssociatedRecord.new
 
-          assert_operator record, :respond_to?, :fetch_deeply_associated_record_ids
-          assert_operator record, :respond_to?, :cached_deeply_associated_record_ids
-          assert_operator record, :respond_to?, :fetch_deeply_associated_records
-          assert_operator record, :respond_to?, :prepopulate_fetched_deeply_associated_records
+          assert_operator(record, :respond_to?, :fetch_deeply_associated_record_ids)
+          assert_operator(record, :respond_to?, :cached_deeply_associated_record_ids)
+          assert_operator(record, :respond_to?, :fetch_deeply_associated_records)
+          assert_operator(record, :respond_to?, :prepopulate_fetched_deeply_associated_records)
         end
 
         def test_clear
@@ -37,20 +37,20 @@ module IdentityCache
 
           has_many.clear(record)
 
-          refute_operator record, :instance_variable_defined?, :@cached_deeply_associated_record_ids
-          refute_operator record, :instance_variable_defined?, :@cached_deeply_associated_records
+          refute_operator(record, :instance_variable_defined?, :@cached_deeply_associated_record_ids)
+          refute_operator(record, :instance_variable_defined?, :@cached_deeply_associated_records)
         end
 
         def test_embedded
-          assert_predicate has_many, :embedded?
+          assert_predicate(has_many, :embedded?)
         end
 
         def test_embedded_recursively
-          refute_predicate has_many, :embedded_recursively?
+          refute_predicate(has_many, :embedded_recursively?)
         end
 
         def test_embedded_by_reference
-          assert_predicate has_many, :embedded_by_reference?
+          assert_predicate(has_many, :embedded_by_reference?)
         end
       end
     end

--- a/test/cached/reference/has_one_test.rb
+++ b/test/cached/reference/has_one_test.rb
@@ -17,17 +17,17 @@ module IdentityCache
         attr_reader :reflection, :has_one
 
         def test_is_cached_association
-          assert_equal Cached::Association, HasOne.superclass.superclass
+          assert_equal(Cached::Association, HasOne.superclass.superclass)
         end
 
         def test_build
           has_one.build
           record = AssociatedRecord.new
 
-          assert_operator record, :respond_to?, :cached_deeply_associated_id
-          assert_operator record, :respond_to?, :fetch_deeply_associated_id
-          assert_operator record, :respond_to?, :fetch_deeply_associated
-          assert_operator record, :respond_to?, :prepopulate_fetched_deeply_associated
+          assert_operator(record, :respond_to?, :cached_deeply_associated_id)
+          assert_operator(record, :respond_to?, :fetch_deeply_associated_id)
+          assert_operator(record, :respond_to?, :fetch_deeply_associated)
+          assert_operator(record, :respond_to?, :prepopulate_fetched_deeply_associated)
         end
 
         def test_clear
@@ -37,20 +37,20 @@ module IdentityCache
 
           has_one.clear(record)
 
-          refute_operator record, :instance_variable_defined?, :@cached_deeply_associated_id
-          refute_operator record, :instance_variable_defined?, :@cached_deeply_associated
+          refute_operator(record, :instance_variable_defined?, :@cached_deeply_associated_id)
+          refute_operator(record, :instance_variable_defined?, :@cached_deeply_associated)
         end
 
         def test_embedded
-          assert_predicate has_one, :embedded?
+          assert_predicate(has_one, :embedded?)
         end
 
         def test_embedded_recursively
-          refute_predicate has_one, :embedded_recursively?
+          refute_predicate(has_one, :embedded_recursively?)
         end
 
         def test_embedded_by_reference
-          assert_predicate has_one, :embedded_by_reference?
+          assert_predicate(has_one, :embedded_by_reference?)
         end
       end
     end

--- a/test/custom_primary_keys_test.rb
+++ b/test/custom_primary_keys_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class CustomPrimaryKeysTest < IdentityCache::TestCase
   def setup
     super
-    CustomMasterRecord.cache_has_many :custom_child_record
-    CustomChildRecord.cache_belongs_to :custom_master_record
+    CustomMasterRecord.cache_has_many(:custom_child_record)
+    CustomChildRecord.cache_belongs_to(:custom_master_record)
     @master_record = CustomMasterRecord.create!(master_primary_key: 1)
     @child_record_1 = CustomChildRecord.create!(custom_master_record: @master_record, child_primary_key: 1)
     @child_record_2 = CustomChildRecord.create!(custom_master_record: @master_record, child_primary_key: 2)
@@ -12,7 +12,7 @@ class CustomPrimaryKeysTest < IdentityCache::TestCase
 
   def test_fetch_master
     assert_nothing_raised do
-      CustomMasterRecord.fetch @master_record.master_primary_key
+      CustomMasterRecord.fetch(@master_record.master_primary_key)
     end
   end
 end

--- a/test/deeply_nested_associated_record_test.rb
+++ b/test/deeply_nested_associated_record_test.rb
@@ -4,16 +4,16 @@ class DeeplyNestedAssociatedRecordHasOneTest < IdentityCache::TestCase
   def test_deeply_nested_models_can_cache_has_one_associations
     assert_nothing_raised do
       PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
-      Deeply::Nested::AssociatedRecord.has_one :polymorphic_record, as: 'owner'
-      Deeply::Nested::AssociatedRecord.cache_has_one :polymorphic_record, inverse_name: :owner
+      Deeply::Nested::AssociatedRecord.has_one(:polymorphic_record, as: 'owner')
+      Deeply::Nested::AssociatedRecord.cache_has_one(:polymorphic_record, inverse_name: :owner)
     end
   end
 
   def test_deeply_nested_models_can_cache_has_many_associations
     assert_nothing_raised do
       PolymorphicRecord.include(IdentityCache)
-      Deeply::Nested::AssociatedRecord.has_many :polymorphic_records, as: 'owner'
-      Deeply::Nested::AssociatedRecord.cache_has_many :polymorphic_records, inverse_name: :owner
+      Deeply::Nested::AssociatedRecord.has_many(:polymorphic_records, as: 'owner')
+      Deeply::Nested::AssociatedRecord.cache_has_many(:polymorphic_records, inverse_name: :owner)
     end
   end
 end

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -4,7 +4,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
   def setup
     super
     PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
-    Item.cache_has_many :associated_records, :embed => true
+    Item.cache_has_many(:associated_records, :embed => true)
 
     @record = Item.new(:title => 'foo')
     @record.associated_records << AssociatedRecord.new(:name => 'bar')
@@ -15,7 +15,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
 
   def test_uncached_record_from_the_db_should_come_back_with_association_array
     record_from_db = Item.find(@record.id)
-    assert_equal Array, record_from_db.fetch_associated_records.class
+    assert_equal(Array, record_from_db.fetch_associated_records.class)
   end
 
   def test_uncached_record_from_the_db_will_use_normal_association
@@ -24,23 +24,23 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
 
     Item.any_instance.expects(:association).with(:associated_records).returns(expected)
 
-    assert_equal @record, record_from_db
-    assert_equal expected, record_from_db.fetch_associated_records
+    assert_equal(@record, record_from_db)
+    assert_equal(expected, record_from_db.fetch_associated_records)
   end
 
   def test_on_cache_hit_record_should_come_back_with_cached_association_array
     Item.fetch(@record.id) # warm cache
 
     record_from_cache_hit = Item.fetch(@record.id)
-    assert_equal @record, record_from_cache_hit
-    assert_equal Array, record_from_cache_hit.fetch_associated_records.class
+    assert_equal(@record, record_from_cache_hit)
+    assert_equal(Array, record_from_cache_hit.fetch_associated_records.class)
   end
 
   def test_on_cache_hit_record_should_come_back_with_cached_association
     Item.fetch(@record.id) # warm cache
 
     record_from_cache_hit = Item.fetch(@record.id)
-    assert_equal @record, record_from_cache_hit
+    assert_equal(@record, record_from_cache_hit)
 
     result = assert_memcache_operations(0) do
       assert_no_queries do
@@ -48,16 +48,16 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
       end
     end
 
-    assert_equal @record.associated_records, result
+    assert_equal(@record.associated_records, result)
   end
 
   def test_on_cache_miss_record_should_embed_associated_objects_and_return
     record_from_cache_miss = Item.fetch(@record.id)
     expected = @record.associated_records
 
-    assert_equal @record, record_from_cache_miss
-    assert_equal expected, record_from_cache_miss.fetch_associated_records
-    assert_equal false, record_from_cache_miss.associated_records.loaded?
+    assert_equal(@record, record_from_cache_miss)
+    assert_equal(expected, record_from_cache_miss.fetch_associated_records)
+    assert_equal(false, record_from_cache_miss.associated_records.loaded?)
   end
 
   def test_delegate_to_normal_association_if_loaded
@@ -66,13 +66,13 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     item.fetch_associated_records
 
     item.associated_records << AssociatedRecord.new(:name => 'buzz')
-    assert_equal item.associated_records.to_a, item.fetch_associated_records
+    assert_equal(item.associated_records.to_a, item.fetch_associated_records)
   end
 
   def test_changes_in_associated_records_should_expire_the_parents_cache
     Item.fetch(@record.id)
     key = @record.primary_cache_index_key
-    assert_not_nil IdentityCache.cache.fetch(key)
+    assert_not_nil(IdentityCache.cache.fetch(key))
 
     IdentityCache.cache.expects(:delete).with(@record.associated_records.first.primary_cache_index_key)
     IdentityCache.cache.expects(:delete).with(key)
@@ -100,21 +100,21 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
 
   def test_cache_without_guessable_inverse_name_raises
     assert_raises IdentityCache::InverseAssociationError do
-      Item.cache_has_many :no_inverse_of_records, :embed => true
+      Item.cache_has_many(:no_inverse_of_records, :embed => true)
       IdentityCache.eager_load!
     end
   end
 
   def test_cache_without_guessable_inverse_name_does_not_raise_when_inverse_name_specified
     assert_nothing_raised do
-      Item.cache_has_many :no_inverse_of_records, :inverse_name => :owner, :embed => true
+      Item.cache_has_many(:no_inverse_of_records, :inverse_name => :owner, :embed => true)
       IdentityCache.eager_load!
     end
   end
 
   def test_cache_uses_inverse_of_on_association
-    Item.has_many :invertable_association, :inverse_of => :owner, :class_name => 'PolymorphicRecord', :as => "owner"
-    Item.cache_has_many :invertable_association, :embed => true
+    Item.has_many(:invertable_association, :inverse_of => :owner, :class_name => 'PolymorphicRecord', :as => "owner")
+    Item.cache_has_many(:invertable_association, :embed => true)
     IdentityCache.eager_load!
   end
 
@@ -137,7 +137,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     item = Item.fetch(@record.id)
 
     associated_record = item.fetch_associated_records.to_a.first
-    refute_equal item.object_id, associated_record.item.object_id
+    refute_equal(item.object_id, associated_record.item.object_id)
   end
 
   def test_returned_records_should_be_readonly_on_cache_hit
@@ -188,15 +188,15 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
   class CheckAssociationTest < IdentityCache::TestCase
     def test_unsupported_through_assocation
       assert_raises IdentityCache::UnsupportedAssociationError, "caching through associations isn't supported" do
-        Item.has_many :deeply_through_associated_records, :through => :associated_records, foreign_key: 'associated_record_id', inverse_of: :item, :class_name => 'DeeplyAssociatedRecord'
-        Item.cache_has_many :deeply_through_associated_records, :embed => true
+        Item.has_many(:deeply_through_associated_records, :through => :associated_records, foreign_key: 'associated_record_id', inverse_of: :item, :class_name => 'DeeplyAssociatedRecord')
+        Item.cache_has_many(:deeply_through_associated_records, :embed => true)
       end
     end
 
     def test_unsupported_joins_in_assocation_scope
       scope = -> { joins(:associated_record).where(associated_records: { name: 'contrived example' }) }
-      Item.has_many :deeply_joined_associated_records, scope, inverse_of: :item, class_name: 'DeeplyAssociatedRecord'
-      Item.cache_has_many :deeply_joined_associated_records, :embed => true
+      Item.has_many(:deeply_joined_associated_records, scope, inverse_of: :item, class_name: 'DeeplyAssociatedRecord')
+      Item.cache_has_many(:deeply_joined_associated_records, :embed => true)
 
       message = "caching association Item.deeply_joined_associated_records scoped with a join isn't supported"
       assert_raises IdentityCache::UnsupportedAssociationError, message do
@@ -206,7 +206,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
 
     def test_cache_has_many_on_derived_model_raises
       assert_raises(IdentityCache::DerivedModelError) do
-        StiRecordTypeA.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => true
+        StiRecordTypeA.cache_has_many(:polymorphic_records, :inverse_name => :owner, :embed => true)
       end
     end
   end

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -4,11 +4,11 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
   def setup
     super
     PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
-    Item.cache_has_many(:associated_records, :embed => true)
+    Item.cache_has_many(:associated_records, embed: true)
 
-    @record = Item.new(:title => 'foo')
-    @record.associated_records << AssociatedRecord.new(:name => 'bar')
-    @record.associated_records << AssociatedRecord.new(:name => 'baz')
+    @record = Item.new(title: 'foo')
+    @record.associated_records << AssociatedRecord.new(name: 'bar')
+    @record.associated_records << AssociatedRecord.new(name: 'baz')
     @record.save
     @record.reload
   end
@@ -65,7 +65,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     item = Item.fetch(@record.id)
     item.fetch_associated_records
 
-    item.associated_records << AssociatedRecord.new(:name => 'buzz')
+    item.associated_records << AssociatedRecord.new(name: 'buzz')
     assert_equal(item.associated_records.to_a, item.fetch_associated_records)
   end
 
@@ -100,21 +100,21 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
 
   def test_cache_without_guessable_inverse_name_raises
     assert_raises IdentityCache::InverseAssociationError do
-      Item.cache_has_many(:no_inverse_of_records, :embed => true)
+      Item.cache_has_many(:no_inverse_of_records, embed: true)
       IdentityCache.eager_load!
     end
   end
 
   def test_cache_without_guessable_inverse_name_does_not_raise_when_inverse_name_specified
     assert_nothing_raised do
-      Item.cache_has_many(:no_inverse_of_records, :inverse_name => :owner, :embed => true)
+      Item.cache_has_many(:no_inverse_of_records, inverse_name: :owner, embed: true)
       IdentityCache.eager_load!
     end
   end
 
   def test_cache_uses_inverse_of_on_association
-    Item.has_many(:invertable_association, :inverse_of => :owner, :class_name => 'PolymorphicRecord', :as => "owner")
-    Item.cache_has_many(:invertable_association, :embed => true)
+    Item.has_many(:invertable_association, inverse_of: :owner, class_name: 'PolymorphicRecord', as: "owner")
+    Item.cache_has_many(:invertable_association, embed: true)
     IdentityCache.eager_load!
   end
 
@@ -188,15 +188,15 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
   class CheckAssociationTest < IdentityCache::TestCase
     def test_unsupported_through_assocation
       assert_raises IdentityCache::UnsupportedAssociationError, "caching through associations isn't supported" do
-        Item.has_many(:deeply_through_associated_records, :through => :associated_records, foreign_key: 'associated_record_id', inverse_of: :item, :class_name => 'DeeplyAssociatedRecord')
-        Item.cache_has_many(:deeply_through_associated_records, :embed => true)
+        Item.has_many(:deeply_through_associated_records, through: :associated_records, foreign_key: 'associated_record_id', inverse_of: :item, class_name: 'DeeplyAssociatedRecord')
+        Item.cache_has_many(:deeply_through_associated_records, embed: true)
       end
     end
 
     def test_unsupported_joins_in_assocation_scope
       scope = -> { joins(:associated_record).where(associated_records: { name: 'contrived example' }) }
       Item.has_many(:deeply_joined_associated_records, scope, inverse_of: :item, class_name: 'DeeplyAssociatedRecord')
-      Item.cache_has_many(:deeply_joined_associated_records, :embed => true)
+      Item.cache_has_many(:deeply_joined_associated_records, embed: true)
 
       message = "caching association Item.deeply_joined_associated_records scoped with a join isn't supported"
       assert_raises IdentityCache::UnsupportedAssociationError, message do
@@ -206,7 +206,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
 
     def test_cache_has_many_on_derived_model_raises
       assert_raises(IdentityCache::DerivedModelError) do
-        StiRecordTypeA.cache_has_many(:polymorphic_records, :inverse_name => :owner, :embed => true)
+        StiRecordTypeA.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: true)
       end
     end
   end

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -5,9 +5,9 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     super
     PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
     Item.cache_has_one(:associated)
-    Item.cache_index(:title, :unique => true)
-    @record = Item.new(:title => 'foo')
-    @record.associated = AssociatedRecord.new(:name => 'bar')
+    Item.cache_index(:title, unique: true)
+    @record = Item.new(title: 'foo')
+    @record.associated = AssociatedRecord.new(name: 'bar')
     @record.save
 
     @record.reload
@@ -132,28 +132,28 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
 
   def test_cache_without_guessable_inverse_name_raises
     assert_raises IdentityCache::InverseAssociationError do
-      Item.cache_has_one(:no_inverse_of_record, :embed => true)
+      Item.cache_has_one(:no_inverse_of_record, embed: true)
       IdentityCache.eager_load!
     end
   end
 
   def test_cache_without_guessable_inverse_name_does_not_raise_when_inverse_name_specified
     assert_nothing_raised do
-      Item.cache_has_one(:no_inverse_of_record, :inverse_name => :owner, :embed => true)
+      Item.cache_has_one(:no_inverse_of_record, inverse_name: :owner, embed: true)
       IdentityCache.eager_load!
     end
   end
 
   def test_unsupported_through_assocation
     assert_raises IdentityCache::UnsupportedAssociationError, "caching through associations isn't supported" do
-      Item.has_one(:deeply_associated, :through => :associated, :class_name => 'DeeplyAssociatedRecord')
-      Item.cache_has_one(:deeply_associated, :embed => true)
+      Item.has_one(:deeply_associated, through: :associated, class_name: 'DeeplyAssociatedRecord')
+      Item.cache_has_one(:deeply_associated, embed: true)
     end
   end
 
   def test_cache_has_one_on_derived_model_raises
     assert_raises(IdentityCache::DerivedModelError) do
-      StiRecordTypeA.cache_has_one(:polymorphic_record, :inverse_name => :owner, :embed => true)
+      StiRecordTypeA.cache_has_one(:polymorphic_record, inverse_name: :owner, embed: true)
     end
   end
 

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -4,8 +4,8 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
   def setup
     super
     PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
-    Item.cache_has_one :associated
-    Item.cache_index :title, :unique => true
+    Item.cache_has_one(:associated)
+    Item.cache_index(:title, :unique => true)
     @record = Item.new(:title => 'foo')
     @record.associated = AssociatedRecord.new(:name => 'bar')
     @record.save
@@ -18,11 +18,11 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
 
     record_from_cache_miss = Item.fetch_by_title('foo')
 
-    assert_equal @record, record_from_cache_miss
-    assert_not_nil @record.fetch_associated
-    assert_equal @record.associated, record_from_cache_miss.fetch_associated
-    assert fetch.has_been_called_with?(@record.attribute_cache_key_for_attribute_and_current_values(:id, [:title], true))
-    assert fetch.has_been_called_with?(@record.primary_cache_index_key)
+    assert_equal(@record, record_from_cache_miss)
+    assert_not_nil(@record.fetch_associated)
+    assert_equal(@record.associated, record_from_cache_miss.fetch_associated)
+    assert(fetch.has_been_called_with?(@record.attribute_cache_key_for_attribute_and_current_values(:id, [:title], true)))
+    assert(fetch.has_been_called_with?(@record.primary_cache_index_key))
   end
 
   def test_on_cache_miss_record_should_embed_nil_object
@@ -37,19 +37,19 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     record_from_cache_miss = Item.fetch_by_title('foo')
     record_from_cache_miss.expects(:associated).never
 
-    assert_equal @record, record_from_cache_miss
+    assert_equal(@record, record_from_cache_miss)
     5.times do
       assert_nil record_from_cache_miss.fetch_associated
     end
-    assert fetch.has_been_called_with?(@record.attribute_cache_key_for_attribute_and_current_values(:id, [:title], true))
-    assert fetch.has_been_called_with?(@record.primary_cache_index_key)
+    assert(fetch.has_been_called_with?(@record.attribute_cache_key_for_attribute_and_current_values(:id, [:title], true)))
+    assert(fetch.has_been_called_with?(@record.primary_cache_index_key))
   end
 
   def test_on_record_from_the_db_will_use_normal_association
     record_from_db = Item.find_by_title('foo')
 
-    assert_equal @record, record_from_db
-    assert_not_nil record_from_db.fetch_associated
+    assert_equal(@record, record_from_db)
+    assert_not_nil(record_from_db.fetch_associated)
   end
 
   def test_on_cache_hit_record_should_come_back_with_cached_association
@@ -59,8 +59,8 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     record_from_cache_hit = Item.fetch_by_title('foo')
     expected = @record.associated
 
-    assert_equal @record, record_from_cache_hit
-    assert_equal expected, record_from_cache_hit.fetch_associated
+    assert_equal(@record, record_from_cache_hit)
+    assert_equal(expected, record_from_cache_hit.fetch_associated)
   end
 
 
@@ -95,7 +95,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     record_from_cache_hit = Item.fetch_by_title('foo')
     record_from_cache_hit.expects(:associated).never
 
-    assert_equal @record, record_from_cache_hit
+    assert_equal(@record, record_from_cache_hit)
     5.times do
       assert_nil record_from_cache_hit.fetch_associated
     end
@@ -104,7 +104,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
   def test_changes_in_associated_record_should_expire_the_parents_cache
     Item.fetch_by_title('foo')
     key = @record.primary_cache_index_key
-    assert_not_nil IdentityCache.cache.fetch(key)
+    assert_not_nil(IdentityCache.cache.fetch(key))
 
     IdentityCache.cache.expects(:delete).at_least(1).with(key)
     IdentityCache.cache.expects(:delete).with(@record.associated.primary_cache_index_key)
@@ -119,7 +119,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
   end
 
   def test_set_inverse_cached_association
-    AssociatedRecord.cache_belongs_to :item
+    AssociatedRecord.cache_belongs_to(:item)
     Item.fetch(@record.id) # warm cache
     item = Item.fetch(@record.id)
 
@@ -132,28 +132,28 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
 
   def test_cache_without_guessable_inverse_name_raises
     assert_raises IdentityCache::InverseAssociationError do
-      Item.cache_has_one :no_inverse_of_record, :embed => true
+      Item.cache_has_one(:no_inverse_of_record, :embed => true)
       IdentityCache.eager_load!
     end
   end
 
   def test_cache_without_guessable_inverse_name_does_not_raise_when_inverse_name_specified
     assert_nothing_raised do
-      Item.cache_has_one :no_inverse_of_record, :inverse_name => :owner, :embed => true
+      Item.cache_has_one(:no_inverse_of_record, :inverse_name => :owner, :embed => true)
       IdentityCache.eager_load!
     end
   end
 
   def test_unsupported_through_assocation
     assert_raises IdentityCache::UnsupportedAssociationError, "caching through associations isn't supported" do
-      Item.has_one :deeply_associated, :through => :associated, :class_name => 'DeeplyAssociatedRecord'
-      Item.cache_has_one :deeply_associated, :embed => true
+      Item.has_one(:deeply_associated, :through => :associated, :class_name => 'DeeplyAssociatedRecord')
+      Item.cache_has_one(:deeply_associated, :embed => true)
     end
   end
 
   def test_cache_has_one_on_derived_model_raises
     assert_raises(IdentityCache::DerivedModelError) do
-      StiRecordTypeA.cache_has_one :polymorphic_record, :inverse_name => :owner, :embed => true
+      StiRecordTypeA.cache_has_one(:polymorphic_record, :inverse_name => :owner, :embed => true)
     end
   end
 

--- a/test/expiry_hook_test.rb
+++ b/test/expiry_hook_test.rb
@@ -5,25 +5,25 @@ module IdentityCache
     def test_cached_association
       hook = ExpiryHook.new(reference_cached_association)
 
-      assert_same reference_cached_association, hook.cached_association
+      assert_same(reference_cached_association, hook.cached_association)
     end
 
     def test_only_on_foreign_key_change_true_when_reference_association
       hook = ExpiryHook.new(reference_cached_association)
 
-      assert_predicate hook, :only_on_foreign_key_change?
+      assert_predicate(hook, :only_on_foreign_key_change?)
     end
 
     def test_only_on_foreign_key_change_false_when_recursive_association
       hook = ExpiryHook.new(recursive_cached_association)
 
-      refute_predicate hook, :only_on_foreign_key_change?
+      refute_predicate(hook, :only_on_foreign_key_change?)
     end
 
     def test_only_on_foreign_key_change_false_when_belongs_to
       hook = ExpiryHook.new(belongs_to_reference_cached_association)
 
-      refute_predicate hook, :only_on_foreign_key_change?
+      refute_predicate(hook, :only_on_foreign_key_change?)
     end
 
     private

--- a/test/fetch_multi_by_test.rb
+++ b/test/fetch_multi_by_test.rb
@@ -15,49 +15,49 @@ class FetchMultiByTest < IdentityCache::TestCase
   end
 
   def test_fetch_multi_by_cache_key
-    Item.cache_index :title, unique: false
+    Item.cache_index(:title, unique: false)
 
     @bob.save!
     @bertha.save!
 
-    assert_equal [@bob], Item.fetch_by_title('bob')
+    assert_equal([@bob], Item.fetch_by_title('bob'))
 
-    assert_equal [@bob, @bertha], Item.fetch_multi_by_title(['bob', 'bertha'])
+    assert_equal([@bob, @bertha], Item.fetch_multi_by_title(['bob', 'bertha']))
   end
 
   def test_fetch_multi_by_cache_key_with_unknown_key
-    Item.cache_index :title, unique: false
+    Item.cache_index(:title, unique: false)
 
     @bob.save!
     @bertha.save!
 
-    assert_equal [@bob], Item.fetch_multi_by_title(['bob', 'garbage_title'])
+    assert_equal([@bob], Item.fetch_multi_by_title(['bob', 'garbage_title']))
   end
 
   def test_fetch_multi_by_unique_cache_key
-    Item.cache_index :title, unique: true
+    Item.cache_index(:title, unique: true)
 
     @bob.save!
     @bertha.save!
 
-    assert_equal @bob, Item.fetch_by_title('bob')
+    assert_equal(@bob, Item.fetch_by_title('bob'))
 
-    assert_equal [@bob, @bertha], Item.fetch_multi_by_title(['bob', 'bertha'])
+    assert_equal([@bob, @bertha], Item.fetch_multi_by_title(['bob', 'bertha']))
   end
 
   def test_fetch_multi_attribute_by_cache_key
-    Item.cache_attribute :title, by: :id, unique: false
+    Item.cache_attribute(:title, by: :id, unique: false)
 
     @bob.save!
     @bertha.save!
 
-    assert_equal ['bob'], Item.fetch_title_by_id(1)
+    assert_equal(['bob'], Item.fetch_title_by_id(1))
 
     assert_equal({ 1 => ['bob'], 2 => ['bertha'] }, Item.fetch_multi_title_by_id([1, 2]))
   end
 
   def test_fetch_multi_attribute_by_cache_key_with_unknown_key
-    Item.cache_attribute :title, by: :id, unique: false
+    Item.cache_attribute(:title, by: :id, unique: false)
 
     @bob.save!
     @bertha.save!
@@ -66,18 +66,18 @@ class FetchMultiByTest < IdentityCache::TestCase
   end
 
   def test_fetch_multi_attribute_by_unique_cache_key
-    Item.cache_attribute :title, by: :id, unique: true
+    Item.cache_attribute(:title, by: :id, unique: true)
 
     @bob.save!
     @bertha.save!
 
-    assert_equal 'bob', Item.fetch_title_by_id(1)
+    assert_equal('bob', Item.fetch_title_by_id(1))
 
     assert_equal({ 1 => 'bob', 2 => 'bertha' }, Item.fetch_multi_title_by_id([1, 2]))
   end
 
   def test_fetch_multi_attribute_by_unique_cache_key_with_unknown_key
-    Item.cache_attribute :title, by: :id, unique: true
+    Item.cache_attribute(:title, by: :id, unique: true)
 
     @bob.save!
     @bertha.save!

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -5,9 +5,9 @@ class FetchMultiTest < IdentityCache::TestCase
 
   def setup
     super
-    @bob = Item.create!(:title => 'bob')
-    @joe = Item.create!(:title => 'joe')
-    @fred = Item.create!(:title => 'fred')
+    @bob = Item.create!(title: 'bob')
+    @joe = Item.create!(title: 'joe')
+    @fred = Item.create!(title: 'fred')
     @bob_blob_key = "#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:1"
     @joe_blob_key = "#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:2"
     @fred_blob_key = "#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:3"
@@ -213,7 +213,7 @@ class FetchMultiTest < IdentityCache::TestCase
   def test_find_batch_coerces_ids_to_primary_key_type
     mock_relation = mock("ActiveRecord::Relation")
     Item.expects(:where).returns(mock_relation)
-    mock_relation.expects(:includes).returns(stub(:to_a => [@bob, @joe, @fred]))
+    mock_relation.expects(:includes).returns(stub(to_a: [@bob, @joe, @fred]))
 
     Item.send(:find_batch, [@bob, @joe, @fred].map(&:id).map(&:to_s))
   end
@@ -251,7 +251,7 @@ class FetchMultiTest < IdentityCache::TestCase
   end
 
   def test_fetch_multi_with_non_id_primary_key
-    fixture = KeyedRecord.create!(:value => "a") { |r| r.hashed_key = 123 }
+    fixture = KeyedRecord.create!(value: "a") { |r| r.hashed_key = 123 }
     assert_equal([fixture], KeyedRecord.fetch_multi(123, 456))
   end
 
@@ -295,7 +295,7 @@ class FetchMultiTest < IdentityCache::TestCase
     poly1 = item.polymorphic_record = PolymorphicRecord.create!
 
     assert_queries(2) do
-      stuff = PolymorphicRecord.fetch_multi(poly1.id, :includes => :owner)
+      stuff = PolymorphicRecord.fetch_multi(poly1.id, includes: :owner)
     end
   end
 
@@ -311,7 +311,7 @@ class FetchMultiTest < IdentityCache::TestCase
     poly3 = item2.polymorphic_records.create
 
     assert_queries(3) do
-      stuff = PolymorphicRecord.fetch_multi([poly1.id, poly2.id, poly3.id], :includes => :owner)
+      stuff = PolymorphicRecord.fetch_multi([poly1.id, poly2.id, poly3.id], includes: :owner)
     end
   end
 
@@ -322,7 +322,7 @@ class FetchMultiTest < IdentityCache::TestCase
     poly1 = PolymorphicRecord.create!
 
     assert_queries(1) do
-      stuff = PolymorphicRecord.fetch_multi(poly1.id, :includes => :owner)
+      stuff = PolymorphicRecord.fetch_multi(poly1.id, includes: :owner)
     end
   end
 

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -15,7 +15,7 @@ class FetchMultiTest < IdentityCache::TestCase
   end
 
   def test_fetch_multi_with_no_records
-    assert_equal [], Item.fetch_multi
+    assert_equal([], Item.fetch_multi)
   end
 
   def test_fetch_multi_namespace
@@ -26,7 +26,7 @@ class FetchMultiTest < IdentityCache::TestCase
     cache_response[joe_blob_key] = cache_response_for(@joe)
     cache_response[fred_blob_key] = cache_response_for(@fred)
     IdentityCache.cache.expects(:fetch_multi).with(bob_blob_key, joe_blob_key, fred_blob_key).returns(cache_response)
-    assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id)
+    assert_equal([@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id))
   end
 
   def test_fetch_multi_with_all_hits
@@ -35,7 +35,7 @@ class FetchMultiTest < IdentityCache::TestCase
     cache_response[@joe_blob_key] = cache_response_for(@joe)
     cache_response[@fred_blob_key] = cache_response_for(@fred)
     IdentityCache.cache.expects(:fetch_multi).with(@bob_blob_key, @joe_blob_key, @fred_blob_key).returns(cache_response)
-    assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id)
+    assert_equal([@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id))
   end
 
   def test_fetch_multi_with_all_hits_publishes_notifications
@@ -51,7 +51,7 @@ class FetchMultiTest < IdentityCache::TestCase
       assert_equal "Item", payload[:class]
     end
     Item.fetch_multi(@bob.id, @joe.id, @fred.id)
-    assert_equal 3, events
+    assert_equal(3, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
@@ -62,8 +62,8 @@ class FetchMultiTest < IdentityCache::TestCase
     cache_response[@joe_blob_key] = nil
     cache_response[@fred_blob_key] = nil
     fetch_multi = fetch_multi_stub(cache_response)
-    assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id)
-    assert fetch_multi.has_been_called_with?(@bob_blob_key, @joe_blob_key, @fred_blob_key)
+    assert_equal([@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id))
+    assert(fetch_multi.has_been_called_with?(@bob_blob_key, @joe_blob_key, @fred_blob_key))
   end
 
   def test_fetch_multi_with_all_misses_publishes_notifications
@@ -79,7 +79,7 @@ class FetchMultiTest < IdentityCache::TestCase
       assert_equal "Item", payload[:class]
     end
     Item.fetch_multi(@bob.id, @joe.id, @fred.id)
-    assert_equal 3, events
+    assert_equal(3, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
@@ -90,8 +90,8 @@ class FetchMultiTest < IdentityCache::TestCase
     cache_response[@joe_blob_key] = nil
     cache_response[@fred_blob_key] = cache_response_for(@fred)
     fetch_multi = fetch_multi_stub(cache_response)
-    assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id)
-    assert fetch_multi.has_been_called_with?(@bob_blob_key, @joe_blob_key, @fred_blob_key)
+    assert_equal([@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id))
+    assert(fetch_multi.has_been_called_with?(@bob_blob_key, @joe_blob_key, @fred_blob_key))
   end
 
   def test_fetch_multi_with_mixed_hits_and_misses_notifies
@@ -120,24 +120,24 @@ class FetchMultiTest < IdentityCache::TestCase
     cache_response[@joe_blob_key] = nil
     cache_response[@fred_blob_key] = cache_response_for(@fred)
     fetch_multi = fetch_multi_stub(cache_response)
-    assert_equal [@bob, @fred, @joe], Item.fetch_multi(@bob.id, @fred.id, @joe.id)
-    assert fetch_multi.has_been_called_with?(@bob_blob_key, @fred_blob_key, @joe_blob_key)
+    assert_equal([@bob, @fred, @joe], Item.fetch_multi(@bob.id, @fred.id, @joe.id))
+    assert(fetch_multi.has_been_called_with?(@bob_blob_key, @fred_blob_key, @joe_blob_key))
   end
 
   def test_fetch_multi_with_mixed_hits_and_misses_and_non_existant_keys_1
     populate_only_fred
 
     fetch_multi = fetch_multi_stub(@cache_response)
-    assert_equal [@bob, @joe, @fred], Item.fetch_multi(10, @bob.id, @joe.id, @fred.id)
-    assert fetch_multi.has_been_called_with?(@tenth_blob_key, @bob_blob_key, @joe_blob_key, @fred_blob_key)
+    assert_equal([@bob, @joe, @fred], Item.fetch_multi(10, @bob.id, @joe.id, @fred.id))
+    assert(fetch_multi.has_been_called_with?(@tenth_blob_key, @bob_blob_key, @joe_blob_key, @fred_blob_key))
   end
 
   def test_fetch_multi_with_mixed_hits_and_misses_and_non_existant_keys_2
     populate_only_fred
 
     fetch_multi = fetch_multi_stub(@cache_response)
-    assert_equal [@fred, @bob, @joe], Item.fetch_multi(@fred.id, @bob.id, 10, @joe.id)
-    assert fetch_multi.has_been_called_with?(@fred_blob_key, @bob_blob_key, @tenth_blob_key, @joe_blob_key)
+    assert_equal([@fred, @bob, @joe], Item.fetch_multi(@fred.id, @bob.id, 10, @joe.id))
+    assert(fetch_multi.has_been_called_with?(@fred_blob_key, @bob_blob_key, @tenth_blob_key, @joe_blob_key))
   end
 
 
@@ -152,13 +152,13 @@ class FetchMultiTest < IdentityCache::TestCase
     results = IdentityCache.fetch_multi(1,2) do |keys|
       [nil, nil]
     end
-    assert_equal fetch_result, results
+    assert_equal(fetch_result, results)
 
     results = IdentityCache.fetch_multi(1,2) do |keys|
       flunk "Contents should have been fetched from cache successfully"
     end
 
-    assert_equal fetch_result, results
+    assert_equal(fetch_result, results)
   end
 
   def test_fetch_multi_works_with_blanks
@@ -170,11 +170,11 @@ class FetchMultiTest < IdentityCache::TestCase
       flunk "Contents should have been fetched from cache successfully"
     end
 
-    assert_equal cache_result, results
+    assert_equal(cache_result, results)
   end
 
   def test_fetch_multi_duplicate_ids
-    assert_equal [@joe, @bob, @joe], Item.fetch_multi(@joe.id, @bob.id, @joe.id)
+    assert_equal([@joe, @bob, @joe], Item.fetch_multi(@joe.id, @bob.id, @joe.id))
   end
 
   def test_fetch_multi_with_duplicate_ids_hits_backend_once_per_id
@@ -186,28 +186,28 @@ class FetchMultiTest < IdentityCache::TestCase
     fetcher.expects(:fetch_multi).with([@joe_blob_key, @bob_blob_key]).returns(cache_response)
     result = Item.fetch_multi(@joe.id, @bob.id, @joe.id)
 
-    assert_equal [@joe, @bob, @joe], result
+    assert_equal([@joe, @bob, @joe], result)
   end
 
   def test_fetch_multi_with_open_transactions_hits_the_database
     Item.connection.expects(:open_transactions).at_least_once.returns(1)
     fetcher.expects(:fetch_multi).never
-    assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id)
+    assert_equal([@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id))
   end
 
   def test_fetch_multi_with_open_transactions_returns_results_in_the_order_of_the_passed_ids
     Item.connection.expects(:open_transactions).at_least_once.returns(1)
-    assert_equal [@joe, @bob, @fred], Item.fetch_multi(@joe.id, @bob.id, @fred.id)
+    assert_equal([@joe, @bob, @fred], Item.fetch_multi(@joe.id, @bob.id, @fred.id))
   end
 
   def test_fetch_multi_with_open_transactions_should_compacts_returned_array
     Item.connection.expects(:open_transactions).at_least_once.returns(1)
-    assert_equal [@joe, @fred], Item.fetch_multi(@joe.id, 0, @fred.id)
+    assert_equal([@joe, @fred], Item.fetch_multi(@joe.id, 0, @fred.id))
   end
 
   def test_fetch_multi_with_duplicate_ids_in_transaction_returns_results_in_the_order_of_the_passed_ids
     Item.connection.expects(:open_transactions).at_least_once.returns(1)
-    assert_equal [@joe, @bob, @joe], Item.fetch_multi(@joe.id, @bob.id, @joe.id)
+    assert_equal([@joe, @bob, @joe], Item.fetch_multi(@joe.id, @bob.id, @joe.id))
   end
 
   def test_find_batch_coerces_ids_to_primary_key_type
@@ -229,7 +229,7 @@ class FetchMultiTest < IdentityCache::TestCase
   end
 
   def test_fetch_multi_array
-    assert_equal [@joe, @bob], Item.fetch_multi([@joe.id, @bob.id])
+    assert_equal([@joe, @bob], Item.fetch_multi([@joe.id, @bob.id]))
   end
 
   def test_fetch_multi_reads_in_batches
@@ -252,26 +252,26 @@ class FetchMultiTest < IdentityCache::TestCase
 
   def test_fetch_multi_with_non_id_primary_key
     fixture = KeyedRecord.create!(:value => "a") { |r| r.hashed_key = 123 }
-    assert_equal [fixture], KeyedRecord.fetch_multi(123, 456)
+    assert_equal([fixture], KeyedRecord.fetch_multi(123, 456))
   end
 
   def test_fetch_multi_after_expiring_a_record
     Item.fetch_multi(@joe.id, @fred.id)
     @bob.expire_cache
-    assert_equal IdentityCache::DELETED, backend.read(@bob.primary_cache_index_key)
+    assert_equal(IdentityCache::DELETED, backend.read(@bob.primary_cache_index_key))
 
     add = Spy.on(IdentityCache.cache.cache_fetcher, :add).and_call_through
 
-    assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id)
-    refute add.has_been_called?
-    assert_equal cache_response_for(Item.find(@bob.id)), backend.read(@bob.primary_cache_index_key)
+    assert_equal([@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id))
+    refute(add.has_been_called?)
+    assert_equal(cache_response_for(Item.find(@bob.id)), backend.read(@bob.primary_cache_index_key))
   end
 
   def test_fetch_multi_id_coercion
-    assert_equal @joe.title, Item.fetch_multi(@joe.id.to_f).first.title
+    assert_equal(@joe.title, Item.fetch_multi(@joe.id.to_f).first.title)
     @joe.update_attributes!(title: "#{@joe.title} changed")
 
-    assert_equal @joe.title, Item.fetch_multi(@joe.id.to_f).first.title
+    assert_equal(@joe.title, Item.fetch_multi(@joe.id.to_f).first.title)
   end
 
   def test_fetch_multi_raises_when_called_on_a_scope

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -5,8 +5,8 @@ class FetchTest < IdentityCache::TestCase
 
   def setup
     super
-    Item.cache_index :title, :unique => true
-    Item.cache_index :id, :title, :unique => true
+    Item.cache_index(:title, :unique => true)
+    Item.cache_index(:id, :title, :unique => true)
 
     @record = Item.new
     @record.id = 1
@@ -17,13 +17,13 @@ class FetchTest < IdentityCache::TestCase
   end
 
   def test_fetch_with_garbage_input
-    assert_nil Item.fetch_by_id('garbage')
+    assert_nil(Item.fetch_by_id('garbage'))
   end
 
   def test_fetch_cache_hit
     IdentityCache.cache.expects(:fetch).with(@blob_key).returns(@cached_value)
 
-    assert_equal @record, Item.fetch(1)
+    assert_equal(@record, Item.fetch(1))
   end
 
   def test_fetch_cache_hit_publishes_hydration_notification
@@ -35,7 +35,7 @@ class FetchTest < IdentityCache::TestCase
       assert_equal "Item", payload[:class]
     end
     Item.fetch(1)
-    assert_equal 1, events
+    assert_equal(1, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
@@ -50,7 +50,7 @@ class FetchTest < IdentityCache::TestCase
       assert_equal expected, payload
     end
     Item.fetch(1)
-    assert_equal 1, events
+    assert_equal(1, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
@@ -81,7 +81,7 @@ class FetchTest < IdentityCache::TestCase
     new_blob_key = "items:#{@blob_key}"
     IdentityCache.cache.expects(:fetch).with(new_blob_key).returns(@cached_value)
 
-    assert_equal @record, Item.fetch(1)
+    assert_equal(@record, Item.fetch(1))
   ensure
     IdentityCache.cache_namespace = old_ns
   end
@@ -89,23 +89,23 @@ class FetchTest < IdentityCache::TestCase
   def test_exists_with_identity_cache_when_cache_hit
     IdentityCache.cache.expects(:fetch).with(@blob_key).returns(@cached_value)
 
-    assert Item.exists_with_identity_cache?(1)
+    assert(Item.exists_with_identity_cache?(1))
   end
 
   def test_exists_with_identity_cache_when_cache_miss_and_in_db
     fetch = Spy.on(IdentityCache.cache, :fetch).and_call_through
     Item.expects(:resolve_cache_miss).with(1).once.returns(@record)
 
-    assert Item.exists_with_identity_cache?(1)
-    assert fetch.has_been_called_with?(@blob_key)
+    assert(Item.exists_with_identity_cache?(1))
+    assert(fetch.has_been_called_with?(@blob_key))
   end
 
   def test_exists_with_identity_cache_when_cache_miss_and_not_in_db
     fetch = Spy.on(IdentityCache.cache, :fetch).and_call_through
     Item.expects(:resolve_cache_miss).with(1).once.returns(nil)
 
-    assert !Item.exists_with_identity_cache?(1)
-    assert fetch.has_been_called_with?(@blob_key)
+    assert(!Item.exists_with_identity_cache?(1))
+    assert(fetch.has_been_called_with?(@blob_key))
   end
 
   def test_fetch_miss_published_dehydration_notification
@@ -117,7 +117,7 @@ class FetchTest < IdentityCache::TestCase
       assert_equal "Item", payload[:class]
     end
     Item.fetch(1)
-    assert_equal 1, events
+    assert_equal(1, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
@@ -133,7 +133,7 @@ class FetchTest < IdentityCache::TestCase
       assert_equal expected, payload
     end
     Item.fetch(1)
-    assert_equal 1, events
+    assert_equal(1, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
@@ -144,15 +144,15 @@ class FetchTest < IdentityCache::TestCase
     results = []
     fetch = Spy.on(IdentityCache.cache, :fetch).and_return {|_, &block| block.call.tap {|result| results << result}}
 
-    assert_equal @record, Item.fetch(1)
-    assert fetch.has_been_called_with?(@blob_key)
-    assert_equal [@cached_value], results
+    assert_equal(@record, Item.fetch(1))
+    assert(fetch.has_been_called_with?(@blob_key))
+    assert_equal([@cached_value], results)
   end
 
   def test_fetch_miss_with_non_id_primary_key
     hashed_key = Zlib::crc32("foo") % (2 ** 30 - 1)
     fixture = KeyedRecord.create!(:value => "foo") { |r| r.hashed_key = hashed_key }
-    assert_equal fixture, KeyedRecord.fetch(hashed_key)
+    assert_equal(fixture, KeyedRecord.fetch(hashed_key))
   end
 
   def test_fetch_conflict
@@ -162,15 +162,15 @@ class FetchTest < IdentityCache::TestCase
     end
     add = Spy.on(fetcher, :add).and_call_through
 
-    assert_equal @record, Item.fetch(1)
-    assert resolve_cache_miss.has_been_called_with?(1)
-    assert add.has_been_called_with?(@blob_key, @cached_value)
-    assert_equal IdentityCache::DELETED, backend.read(@record.primary_cache_index_key)
+    assert_equal(@record, Item.fetch(1))
+    assert(resolve_cache_miss.has_been_called_with?(1))
+    assert(add.has_been_called_with?(@blob_key, @cached_value))
+    assert_equal(IdentityCache::DELETED, backend.read(@record.primary_cache_index_key))
   end
 
   def test_fetch_conflict_after_delete
     @record.expire_cache
-    assert_equal IdentityCache::DELETED, backend.read(@record.primary_cache_index_key)
+    assert_equal(IdentityCache::DELETED, backend.read(@record.primary_cache_index_key))
 
     resolve_cache_miss = Spy.on(Item, :resolve_cache_miss).and_return do
       @record.expire_cache
@@ -178,17 +178,17 @@ class FetchTest < IdentityCache::TestCase
     end
     add = Spy.on(IdentityCache.cache.cache_fetcher, :add).and_call_through
 
-    assert_equal @record, Item.fetch(1)
-    assert resolve_cache_miss.has_been_called_with?(1)
-    refute add.has_been_called?
-    assert_equal IdentityCache::DELETED, backend.read(@record.primary_cache_index_key)
+    assert_equal(@record, Item.fetch(1))
+    assert(resolve_cache_miss.has_been_called_with?(1))
+    refute(add.has_been_called?)
+    assert_equal(IdentityCache::DELETED, backend.read(@record.primary_cache_index_key))
   end
 
   def test_fetch_by_id_not_found_should_return_nil
     nonexistent_record_id = 10
     fetcher.expects(:add).with(@blob_key + '0', IdentityCache::CACHED_NIL)
 
-    assert_nil Item.fetch_by_id(nonexistent_record_id)
+    assert_nil(Item.fetch_by_id(nonexistent_record_id))
   end
 
   def test_fetch_not_found_should_raise
@@ -201,18 +201,18 @@ class FetchTest < IdentityCache::TestCase
   def test_cached_nil_expiry_on_record_creation
     key = @record.primary_cache_index_key
 
-    assert_nil Item.fetch_by_id(@record.id)
-    assert_equal IdentityCache::CACHED_NIL, backend.read(key)
+    assert_nil(Item.fetch_by_id(@record.id))
+    assert_equal(IdentityCache::CACHED_NIL, backend.read(key))
 
     @record.save!
-    assert_equal IdentityCache::DELETED, backend.read(key)
+    assert_equal(IdentityCache::DELETED, backend.read(key))
   end
 
   def test_fetch_id_coercion
-    assert_nil Item.fetch_by_id(@record.id.to_f)
+    assert_nil(Item.fetch_by_id(@record.id.to_f))
     @record.save!
 
-    assert_equal @record, Item.fetch_by_id(@record.id.to_f)
+    assert_equal(@record, Item.fetch_by_id(@record.id.to_f))
   end
 
   def test_fetch_by_title_hit
@@ -229,10 +229,10 @@ class FetchTest < IdentityCache::TestCase
     # Id not found, use sql, SELECT id FROM records WHERE title = '...' LIMIT 1"
     Item.connection.expects(:exec_query).returns(ActiveRecord::Result.new(['id'], [[1]]))
 
-    assert_equal @record, Item.fetch_by_title('bob')
-    assert_equal [1], values
-    assert fetch.has_been_called_with?(@index_key)
-    assert fetch.has_been_called_with?(@blob_key)
+    assert_equal(@record, Item.fetch_by_title('bob'))
+    assert_equal([1], values)
+    assert(fetch.has_been_called_with?(@index_key))
+    assert(fetch.has_been_called_with?(@blob_key))
   end
 
   def test_fetch_by_title_cache_namespace
@@ -240,20 +240,20 @@ class FetchTest < IdentityCache::TestCase
     IdentityCache.cache.expects(:fetch).with("ns:#{@index_key}").returns(1)
     IdentityCache.cache.expects(:fetch).with("ns:#{@blob_key}").returns(@cached_value)
 
-    assert_equal @record, Item.fetch_by_title('bob')
+    assert_equal(@record, Item.fetch_by_title('bob'))
   end
 
   def test_fetch_by_title_stores_idcnil
     Item.connection.expects(:exec_query).once.returns(ActiveRecord::Result.new([], []))
     add = Spy.on(fetcher, :add).and_call_through
     fetch = Spy.on(fetcher, :fetch).and_call_through
-    assert_nil Item.fetch_by_title('bob') # exec_query => nil
+    assert_nil(Item.fetch_by_title('bob')) # exec_query => nil
 
-    assert_nil Item.fetch_by_title('bob') # returns cached nil
-    assert_nil Item.fetch_by_title('bob') # returns cached nil
+    assert_nil(Item.fetch_by_title('bob')) # returns cached nil
+    assert_nil(Item.fetch_by_title('bob')) # returns cached nil
 
-    assert add.has_been_called_with?(@index_key, IdentityCache::CACHED_NIL)
-    assert_equal 3, fetch.calls.length
+    assert(add.has_been_called_with?(@index_key, IdentityCache::CACHED_NIL))
+    assert_equal(3, fetch.calls.length)
   end
 
   def test_fetch_by_bang_method
@@ -275,9 +275,9 @@ class FetchTest < IdentityCache::TestCase
 
     ActiveRecord::Base.clear_active_connections!
 
-    assert_equal record, Item.fetch(@record.id)
+    assert_equal(record, Item.fetch(@record.id))
 
-    assert_equal false, ActiveRecord::Base.connection_handler.active_connections?
+    assert_equal(false, ActiveRecord::Base.connection_handler.active_connections?)
   end
 
   def test_fetch_raises_when_called_on_a_scope

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -5,8 +5,8 @@ class FetchTest < IdentityCache::TestCase
 
   def setup
     super
-    Item.cache_index(:title, :unique => true)
-    Item.cache_index(:id, :title, :unique => true)
+    Item.cache_index(:title, unique: true)
+    Item.cache_index(:id, :title, unique: true)
 
     @record = Item.new
     @record.id = 1
@@ -151,7 +151,7 @@ class FetchTest < IdentityCache::TestCase
 
   def test_fetch_miss_with_non_id_primary_key
     hashed_key = Zlib::crc32("foo") % (2 ** 30 - 1)
-    fixture = KeyedRecord.create!(:value => "foo") { |r| r.hashed_key = hashed_key }
+    fixture = KeyedRecord.create!(value: "foo") { |r| r.hashed_key = hashed_key }
     assert_equal(fixture, KeyedRecord.fetch(hashed_key))
   end
 

--- a/test/helpers/active_record_objects.rb
+++ b/test/helpers/active_record_objects.rb
@@ -7,7 +7,7 @@ module SwitchNamespace
   end
 
   def self.included(base)
-    base.extend ClassMethods
+    base.extend(ClassMethods)
     base.class_eval do
       class_attribute :namespace
       self.namespace = 'ns'
@@ -24,22 +24,22 @@ module ActiveRecordObjects
   def teardown_models
     ActiveSupport::DescendantsTracker.clear
     ActiveSupport::Dependencies.clear
-    Object.send :remove_const, 'DeeplyAssociatedRecord'
-    Object.send :remove_const, 'PolymorphicRecord'
-    Object.send :remove_const, 'NormalizedAssociatedRecord'
-    Object.send :remove_const, 'AssociatedRecord'
-    Object.send :remove_const, 'NotCachedRecord'
-    Object.send :remove_const, 'NoInverseOfRecord'
-    Object.send :remove_const, 'Item'
-    Object.send :remove_const, 'ItemTwo'
-    Object.send :remove_const, 'KeyedRecord'
-    Object.send :remove_const, 'StiRecord'
-    Object.send :remove_const, 'StiRecordTypeA'
-    Deeply::Nested.send :remove_const, 'AssociatedRecord'
-    Deeply.send :remove_const, 'Nested'
-    Object.send :remove_const, 'Deeply'
-    Object.send :remove_const, 'CustomMasterRecord'
-    Object.send :remove_const, 'CustomChildRecord'
+    Object.send(:remove_const, 'DeeplyAssociatedRecord')
+    Object.send(:remove_const, 'PolymorphicRecord')
+    Object.send(:remove_const, 'NormalizedAssociatedRecord')
+    Object.send(:remove_const, 'AssociatedRecord')
+    Object.send(:remove_const, 'NotCachedRecord')
+    Object.send(:remove_const, 'NoInverseOfRecord')
+    Object.send(:remove_const, 'Item')
+    Object.send(:remove_const, 'ItemTwo')
+    Object.send(:remove_const, 'KeyedRecord')
+    Object.send(:remove_const, 'StiRecord')
+    Object.send(:remove_const, 'StiRecordTypeA')
+    Deeply::Nested.send(:remove_const, 'AssociatedRecord')
+    Deeply.send(:remove_const, 'Nested')
+    Object.send(:remove_const, 'Deeply')
+    Object.send(:remove_const, 'CustomMasterRecord')
+    Object.send(:remove_const, 'CustomChildRecord')
     IdentityCache.const_get(:ParentModelExpiration).send(:lazy_hooks).clear
   end
 end

--- a/test/helpers/database_connection.rb
+++ b/test/helpers/database_connection.rb
@@ -43,18 +43,18 @@ module DatabaseConnection
   end
 
   TABLES = {
-    :polymorphic_records           => [[:string, :owner_type], [:integer, :owner_id], [:timestamps, null: true]],
-    :deeply_associated_records     => [[:string, :name], [:integer, :associated_record_id], [:integer, :item_id], [:timestamps, null: true]],
-    :associated_records            => [[:string, :name], [:integer, :item_id], [:integer, :item_two_id]],
-    :normalized_associated_records => [[:string, :name], [:integer, :item_id], [:timestamps, null: true]],
-    :no_inverse_of_records         => [[:integer, :owner_id], [:timestamps, null: true]],
-    :not_cached_records            => [[:string, :name], [:integer, :item_id], [:timestamps, null: true]],
-    :items                         => [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
-    :items2                        => [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
-    :keyed_records                 => [[:string, :value], :primary_key => "hashed_key"],
-    :sti_records                   => [[:string, :type], [:string, :name]],
-    :custom_master_records         => [[:integer, :master_primary_key], :id => false, :primary_key => 'master_primary_key'],
-    :custom_child_records          => [[:integer, :child_primary_key], [:integer, :master_id], :id => false, :primary_key => 'child_primary_key' ]
+    polymorphic_records: [[:string, :owner_type], [:integer, :owner_id], [:timestamps, null: true]],
+    deeply_associated_records: [[:string, :name], [:integer, :associated_record_id], [:integer, :item_id], [:timestamps, null: true]],
+    associated_records: [[:string, :name], [:integer, :item_id], [:integer, :item_two_id]],
+    normalized_associated_records: [[:string, :name], [:integer, :item_id], [:timestamps, null: true]],
+    no_inverse_of_records: [[:integer, :owner_id], [:timestamps, null: true]],
+    not_cached_records: [[:string, :name], [:integer, :item_id], [:timestamps, null: true]],
+    items: [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
+    items2: [[:integer, :item_id], [:string, :title], [:timestamps, null: true]],
+    keyed_records: [[:string, :value], primary_key: "hashed_key"],
+    sti_records: [[:string, :type], [:string, :name]],
+    custom_master_records: [[:integer, :master_primary_key], id: false, primary_key: 'master_primary_key'],
+    custom_child_records: [[:integer, :child_primary_key], [:integer, :master_id], id: false, primary_key: 'child_primary_key' ]
   }
 
   DEFAULT_CONFIG = {

--- a/test/helpers/models.rb
+++ b/test/helpers/models.rb
@@ -21,12 +21,12 @@ class NormalizedAssociatedRecord < ActiveRecord::Base
 end
 
 class NotCachedRecord < ActiveRecord::Base
-  belongs_to :item, :touch => true
+  belongs_to :item, touch: true
   default_scope { order('id DESC') }
 end
 
 class PolymorphicRecord < ActiveRecord::Base
-  belongs_to :owner, :polymorphic => true
+  belongs_to :owner, polymorphic: true
 end
 
 class NoInverseOfRecord < ActiveRecord::Base
@@ -49,17 +49,17 @@ class Item < ActiveRecord::Base
   has_many :deeply_associated_records, inverse_of: :item
   has_many :normalized_associated_records
   has_many :not_cached_records
-  has_many :polymorphic_records, :as => 'owner'
+  has_many :polymorphic_records, as: 'owner'
   has_many :no_inverse_of_records
-  has_one :polymorphic_record, :as => 'owner'
-  has_one :associated, :class_name => 'AssociatedRecord'
+  has_one :polymorphic_record, as: 'owner'
+  has_one :associated, class_name: 'AssociatedRecord'
   has_one :no_inverse_of_record
 end
 
 class ItemTwo < ActiveRecord::Base
   include IdentityCache
   has_many :associated_records, inverse_of: :item_two, foreign_key: :item_two_id
-  has_many :polymorphic_records, :as => 'owner'
+  has_many :polymorphic_records, as: 'owner'
   self.table_name = 'items2'
 end
 
@@ -70,7 +70,7 @@ end
 
 class StiRecord < ActiveRecord::Base
   include IdentityCache
-  has_many :polymorphic_records, :as => 'owner'
+  has_many :polymorphic_records, as: 'owner'
 end
 
 class StiRecordTypeA < StiRecord

--- a/test/helpers/serialization_format.rb
+++ b/test/helpers/serialization_format.rb
@@ -1,9 +1,9 @@
 module SerializationFormat
   def serialized_record
-    AssociatedRecord.cache_has_many :deeply_associated_records, :embed => true
-    AssociatedRecord.cache_belongs_to :item
-    Item.cache_has_many :associated_records, :embed => true
-    Item.cache_has_one :associated
+    AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => true)
+    AssociatedRecord.cache_belongs_to(:item)
+    Item.cache_has_many(:associated_records, :embed => true)
+    Item.cache_has_one(:associated)
     time = Time.parse('1970-01-01T00:00:00 UTC')
 
     record = Item.new(:title => 'foo')

--- a/test/helpers/serialization_format.rb
+++ b/test/helpers/serialization_format.rb
@@ -1,18 +1,18 @@
 module SerializationFormat
   def serialized_record
-    AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => true)
+    AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
     AssociatedRecord.cache_belongs_to(:item)
-    Item.cache_has_many(:associated_records, :embed => true)
+    Item.cache_has_many(:associated_records, embed: true)
     Item.cache_has_one(:associated)
     time = Time.parse('1970-01-01T00:00:00 UTC')
 
-    record = Item.new(:title => 'foo')
-    record.associated_records << AssociatedRecord.new(:name => 'bar')
-    record.associated_records << AssociatedRecord.new(:name => 'baz')
-    record.associated = AssociatedRecord.new(:name => 'bork')
-    record.not_cached_records << NotCachedRecord.new(:name => 'NoCache', created_at: time)
-    record.associated.deeply_associated_records << DeeplyAssociatedRecord.new(:name => "corge", created_at: time)
-    record.associated.deeply_associated_records << DeeplyAssociatedRecord.new(:name => "qux", created_at: time)
+    record = Item.new(title: 'foo')
+    record.associated_records << AssociatedRecord.new(name: 'bar')
+    record.associated_records << AssociatedRecord.new(name: 'baz')
+    record.associated = AssociatedRecord.new(name: 'bork')
+    record.not_cached_records << NotCachedRecord.new(name: 'NoCache', created_at: time)
+    record.associated.deeply_associated_records << DeeplyAssociatedRecord.new(name: "corge", created_at: time)
+    record.associated.deeply_associated_records << DeeplyAssociatedRecord.new(name: "qux", created_at: time)
     record.created_at = time
     record.save
     [Item, NotCachedRecord, DeeplyAssociatedRecord].each do |model|
@@ -38,8 +38,8 @@ module SerializationFormat
 
   def serialize(record, anIO = nil)
     hash = {
-      :version => IdentityCache::CACHE_VERSION,
-      :record => record
+      version: IdentityCache::CACHE_VERSION,
+      record: record
     }
 
     if anIO

--- a/test/helpers/update_serialization_format.rb
+++ b/test/helpers/update_serialization_format.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path("../../../lib", __FILE__)
+$LOAD_PATH.unshift(File.expand_path("../../../lib", __FILE__))
 
 require 'logger'
 require 'active_record'
@@ -10,8 +10,8 @@ require_relative 'cache_connection'
 require_relative 'active_record_objects'
 require 'identity_cache'
 
-include SerializationFormat
-include ActiveRecordObjects
+include(SerializationFormat)
+include(ActiveRecordObjects)
 
 DatabaseConnection.setup
 DatabaseConnection.drop_tables

--- a/test/identity_cache_test.rb
+++ b/test/identity_cache_test.rb
@@ -18,7 +18,7 @@ class IdentityCacheTest < IdentityCache::TestCase
   end
 
   def test_should_use_cache_outside_transaction
-    assert_equal true, IdentityCache.should_use_cache?
+    assert_equal(true, IdentityCache.should_use_cache?)
   end
 
   def test_should_use_cache_in_transaction

--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -11,7 +11,7 @@ class IndexCacheTest < IdentityCache::TestCase
   end
 
   def test_fetch_with_garbage_input
-    Item.cache_index :title, :id
+    Item.cache_index(:title, :id)
 
     assert_queries(1) do
       assert_equal [], Item.fetch_by_title_and_id('garbage_title', 'garbage_id')
@@ -19,37 +19,37 @@ class IndexCacheTest < IdentityCache::TestCase
   end
 
   def test_fetch_with_unique_adds_limit_clause
-    Item.cache_index :title, :id, :unique => true
+    Item.cache_index(:title, :id, :unique => true)
 
     Item.connection.expects(:exec_query)
       .with(regexp_matches(/ LIMIT 1\Z/i), any_parameters)
       .returns(ActiveRecord::Result.new([], []))
 
-    assert_nil Item.fetch_by_title_and_id('title', '2')
+    assert_nil(Item.fetch_by_title_and_id('title', '2'))
   end
 
   def test_unique_index_caches_nil
-    Item.cache_index :title, :unique => true
-    assert_nil Item.fetch_by_title('bob')
-    assert_equal IdentityCache::CACHED_NIL, backend.read(cache_key(unique: true))
+    Item.cache_index(:title, :unique => true)
+    assert_nil(Item.fetch_by_title('bob'))
+    assert_equal(IdentityCache::CACHED_NIL, backend.read(cache_key(unique: true)))
   end
 
   def test_unique_index_expired_by_new_record
-    Item.cache_index :title, :unique => true
+    Item.cache_index(:title, :unique => true)
     IdentityCache.cache.write(cache_key(unique: true), IdentityCache::CACHED_NIL)
     @record.save!
-    assert_equal IdentityCache::DELETED, backend.read(cache_key(unique: true))
+    assert_equal(IdentityCache::DELETED, backend.read(cache_key(unique: true)))
   end
 
   def test_unique_index_filled_on_fetch_by
-    Item.cache_index :title, :unique => true
+    Item.cache_index(:title, :unique => true)
     @record.save!
-    assert_equal @record, Item.fetch_by_title('bob')
-    assert_equal @record.id, backend.read(cache_key(unique: true))
+    assert_equal(@record, Item.fetch_by_title('bob'))
+    assert_equal(@record.id, backend.read(cache_key(unique: true)))
   end
 
   def test_unique_index_expired_by_updated_record
-    Item.cache_index :title, :unique => true
+    Item.cache_index(:title, :unique => true)
     @record.save!
     old_cache_key = cache_key(unique: true)
     IdentityCache.cache.write(old_cache_key, @record.id)
@@ -58,41 +58,41 @@ class IndexCacheTest < IdentityCache::TestCase
     new_cache_key = cache_key(unique: true)
     IdentityCache.cache.write(new_cache_key, IdentityCache::CACHED_NIL)
     @record.save!
-    assert_equal IdentityCache::DELETED, backend.read(old_cache_key)
-    assert_equal IdentityCache::DELETED, backend.read(new_cache_key)
+    assert_equal(IdentityCache::DELETED, backend.read(old_cache_key))
+    assert_equal(IdentityCache::DELETED, backend.read(new_cache_key))
   end
 
   def test_non_unique_index_caches_empty_result
-    Item.cache_index :title
-    assert_equal [], Item.fetch_by_title('bob')
-    assert_equal [], backend.read(cache_key)
+    Item.cache_index(:title)
+    assert_equal([], Item.fetch_by_title('bob'))
+    assert_equal([], backend.read(cache_key))
   end
 
   def test_non_unique_index_expired_by_new_record
-    Item.cache_index :title
+    Item.cache_index(:title)
     IdentityCache.cache.write(cache_key, [])
     @record.save!
-    assert_equal IdentityCache::DELETED, backend.read(cache_key)
+    assert_equal(IdentityCache::DELETED, backend.read(cache_key))
   end
 
   def test_non_unique_index_filled_on_fetch_by
-    Item.cache_index :title
+    Item.cache_index(:title)
     @record.save!
-    assert_equal [@record], Item.fetch_by_title('bob')
-    assert_equal [@record.id], backend.read(cache_key)
+    assert_equal([@record], Item.fetch_by_title('bob'))
+    assert_equal([@record.id], backend.read(cache_key))
   end
 
   def test_non_unique_index_fetches_multiple_records
-    Item.cache_index :title
+    Item.cache_index(:title)
     @record.save!
     record2 = Item.create(:title => 'bob') { |item| item.id = 2 }
 
-    assert_equal [@record, record2], Item.fetch_by_title('bob')
-    assert_equal [1, 2], backend.read(cache_key)
+    assert_equal([@record, record2], Item.fetch_by_title('bob'))
+    assert_equal([1, 2], backend.read(cache_key))
   end
 
   def test_non_unique_index_expired_by_updating_record
-    Item.cache_index :title
+    Item.cache_index(:title)
     @record.save!
     old_cache_key = cache_key
     IdentityCache.cache.write(old_cache_key, [@record.id])
@@ -101,35 +101,35 @@ class IndexCacheTest < IdentityCache::TestCase
     new_cache_key = cache_key
     IdentityCache.cache.write(new_cache_key, [])
     @record.save!
-    assert_equal IdentityCache::DELETED, backend.read(old_cache_key)
-    assert_equal IdentityCache::DELETED, backend.read(new_cache_key)
+    assert_equal(IdentityCache::DELETED, backend.read(old_cache_key))
+    assert_equal(IdentityCache::DELETED, backend.read(new_cache_key))
   end
 
   def test_non_unique_index_expired_by_destroying_record
-    Item.cache_index :title
+    Item.cache_index(:title)
     @record.save!
     IdentityCache.cache.write(cache_key, [@record.id])
     @record.destroy
-    assert_equal IdentityCache::DELETED, backend.read(cache_key)
+    assert_equal(IdentityCache::DELETED, backend.read(cache_key))
   end
 
   def test_set_table_name_cache_fetch
-    Item.cache_index :title
+    Item.cache_index(:title)
     Item.table_name = 'items2'
     @record.save!
-    assert_equal [@record], Item.fetch_by_title('bob')
-    assert_equal [@record.id], backend.read(cache_key)
+    assert_equal([@record], Item.fetch_by_title('bob'))
+    assert_equal([@record.id], backend.read(cache_key))
   end
 
   def test_fetch_by_index_raises_when_called_on_a_scope
-    Item.cache_index :title
+    Item.cache_index(:title)
     assert_raises(IdentityCache::UnsupportedScopeError) do
       Item.where(updated_at: nil).fetch_by_title('bob')
     end
   end
 
   def test_fetch_by_unique_index_raises_when_called_on_a_scope
-    Item.cache_index :title, :id, :unique => true
+    Item.cache_index(:title, :id, :unique => true)
     assert_raises(IdentityCache::UnsupportedScopeError) do
       Item.where(updated_at: nil).fetch_by_title_and_id('bob', 2)
     end
@@ -137,20 +137,20 @@ class IndexCacheTest < IdentityCache::TestCase
 
   def test_cache_index_on_derived_model_raises
     assert_raises(IdentityCache::DerivedModelError) do
-      StiRecordTypeA.cache_index :name, :id
+      StiRecordTypeA.cache_index(:name, :id)
     end
   end
 
   def test_cache_index_with_non_id_primary_key
-    KeyedRecord.cache_index :value
+    KeyedRecord.cache_index(:value)
     KeyedRecord.create!(value: "a") { |r| r.hashed_key = 123 }
-    assert_equal [123], KeyedRecord.fetch_by_value('a').map(&:id)
+    assert_equal([123], KeyedRecord.fetch_by_value('a').map(&:id))
   end
 
   def test_unique_cache_index_with_non_id_primary_key
-    KeyedRecord.cache_index :value, unique: true
+    KeyedRecord.cache_index(:value, unique: true)
     KeyedRecord.create!(value: "a") { |r| r.hashed_key = 123 }
-    assert_equal 123, KeyedRecord.fetch_by_value('a').id
+    assert_equal(123, KeyedRecord.fetch_by_value('a').id)
   end
 
   private

--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -19,7 +19,7 @@ class IndexCacheTest < IdentityCache::TestCase
   end
 
   def test_fetch_with_unique_adds_limit_clause
-    Item.cache_index(:title, :id, :unique => true)
+    Item.cache_index(:title, :id, unique: true)
 
     Item.connection.expects(:exec_query)
       .with(regexp_matches(/ LIMIT 1\Z/i), any_parameters)
@@ -29,27 +29,27 @@ class IndexCacheTest < IdentityCache::TestCase
   end
 
   def test_unique_index_caches_nil
-    Item.cache_index(:title, :unique => true)
+    Item.cache_index(:title, unique: true)
     assert_nil(Item.fetch_by_title('bob'))
     assert_equal(IdentityCache::CACHED_NIL, backend.read(cache_key(unique: true)))
   end
 
   def test_unique_index_expired_by_new_record
-    Item.cache_index(:title, :unique => true)
+    Item.cache_index(:title, unique: true)
     IdentityCache.cache.write(cache_key(unique: true), IdentityCache::CACHED_NIL)
     @record.save!
     assert_equal(IdentityCache::DELETED, backend.read(cache_key(unique: true)))
   end
 
   def test_unique_index_filled_on_fetch_by
-    Item.cache_index(:title, :unique => true)
+    Item.cache_index(:title, unique: true)
     @record.save!
     assert_equal(@record, Item.fetch_by_title('bob'))
     assert_equal(@record.id, backend.read(cache_key(unique: true)))
   end
 
   def test_unique_index_expired_by_updated_record
-    Item.cache_index(:title, :unique => true)
+    Item.cache_index(:title, unique: true)
     @record.save!
     old_cache_key = cache_key(unique: true)
     IdentityCache.cache.write(old_cache_key, @record.id)
@@ -85,7 +85,7 @@ class IndexCacheTest < IdentityCache::TestCase
   def test_non_unique_index_fetches_multiple_records
     Item.cache_index(:title)
     @record.save!
-    record2 = Item.create(:title => 'bob') { |item| item.id = 2 }
+    record2 = Item.create(title: 'bob') { |item| item.id = 2 }
 
     assert_equal([@record, record2], Item.fetch_by_title('bob'))
     assert_equal([1, 2], backend.read(cache_key))
@@ -129,7 +129,7 @@ class IndexCacheTest < IdentityCache::TestCase
   end
 
   def test_fetch_by_unique_index_raises_when_called_on_a_scope
-    Item.cache_index(:title, :id, :unique => true)
+    Item.cache_index(:title, :id, unique: true)
     assert_raises(IdentityCache::UnsupportedScopeError) do
       Item.where(updated_at: nil).fetch_by_title_and_id('bob', 2)
     end

--- a/test/lazy_load_associated_classes_test.rb
+++ b/test/lazy_load_associated_classes_test.rb
@@ -2,22 +2,22 @@ require "test_helper"
 
 class LazyLoadAssociatedClassesTest < IdentityCache::TestCase
   def test_cache_has_many_does_not_load_associated_class
-    Item.has_many :missing_model
-    Item.cache_has_many :missing_model
+    Item.has_many(:missing_model)
+    Item.cache_has_many(:missing_model)
   end
 
   def test_cache_has_many_embed_does_not_load_associated_class
-    Item.has_many :missing_model
-    Item.cache_has_many :missing_model, embed: true
+    Item.has_many(:missing_model)
+    Item.cache_has_many(:missing_model, embed: true)
   end
 
   def test_cache_has_one_does_not_load_associated_class
-    Item.has_one :missing_model
-    Item.cache_has_one :missing_model
+    Item.has_one(:missing_model)
+    Item.cache_has_one(:missing_model)
   end
 
   def test_cache_invalidation
-    Item.cache_has_many :associated_records, embed: true
+    Item.cache_has_many(:associated_records, embed: true)
     associated_record = AssociatedRecord.new(name: 'baz')
     item = Item.new(title: 'foo')
     item.associated_records << associated_record
@@ -34,7 +34,7 @@ class LazyLoadAssociatedClassesTest < IdentityCache::TestCase
   end
 
   def test_avoid_caching_embed_association_missing_include_identity_cache
-    Item.cache_has_many :not_cached_records, embed: true
+    Item.cache_has_many(:not_cached_records, embed: true)
 
     assert_memcache_operations(0) do
       err1 = assert_raises(IdentityCache::UnsupportedAssociationError) do
@@ -49,7 +49,7 @@ class LazyLoadAssociatedClassesTest < IdentityCache::TestCase
   end
 
   def test_avoid_caching_id_embed_association_missing_include_identity_cache
-    Item.cache_has_many :not_cached_records, embed: :ids
+    Item.cache_has_many(:not_cached_records, embed: :ids)
 
     assert_memcache_operations(0) do
       err1 = assert_raises(IdentityCache::UnsupportedAssociationError) do

--- a/test/memoized_attributes_test.rb
+++ b/test/memoized_attributes_test.rb
@@ -19,7 +19,7 @@ class MemoizedAttributesTest < IdentityCache::TestCase
       Item.fetch(item.id).update!(title: "my title")
     end
 
-    assert_equal "my title", Item.find(item.id).title
+    assert_equal("my title", Item.find(item.id).title)
   end
 
   def test_memoization_should_not_break_dirty_tracking_with_filled_cache
@@ -31,7 +31,7 @@ class MemoizedAttributesTest < IdentityCache::TestCase
       Item.fetch(item.id).update!(title: "my title")
     end
 
-    assert_equal "my title", Item.find(item.id).title
+    assert_equal("my title", Item.find(item.id).title)
   end
 
   def test_memoization_with_fetch_multi_should_not_break_dirty_tracking_with_empty_cache
@@ -42,7 +42,7 @@ class MemoizedAttributesTest < IdentityCache::TestCase
       Item.fetch_multi(item.id).first.update!(title: "my title")
     end
 
-    assert_equal "my title", Item.find(item.id).title
+    assert_equal("my title", Item.find(item.id).title)
   end
 
   def test_memoization_with_fetch_multi_should_not_break_dirty_tracking_with_filled_cache
@@ -54,6 +54,6 @@ class MemoizedAttributesTest < IdentityCache::TestCase
       Item.fetch_multi(item.id).first.update!(title: "my title")
     end
 
-    assert_equal "my title", Item.find(item.id).title
+    assert_equal("my title", Item.find(item.id).title)
   end
 end

--- a/test/memoized_cache_proxy_test.rb
+++ b/test/memoized_cache_proxy_test.rb
@@ -4,7 +4,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
   def test_changing_default_cache
     IdentityCache.cache_backend = ActiveSupport::Cache::MemoryStore.new
     IdentityCache.cache.write('foo', 'bar')
-    assert_equal 'bar', IdentityCache.cache.fetch('foo')
+    assert_equal('bar', IdentityCache.cache.fetch('foo'))
   end
 
   def test_fetch_multi_with_fallback_fetcher
@@ -13,7 +13,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
     backend.expects(:write).with('bar', 'baz')
     yielded = nil
     assert_equal({'foo' => 'bar', 'bar' => 'baz'}, IdentityCache.cache.fetch_multi('foo', 'bar') {|_| yielded = ['baz'] })
-    assert_equal ['baz'], yielded
+    assert_equal(['baz'], yielded)
   end
 
   def test_fetch_should_short_circuit_on_memoized_values
@@ -102,7 +102,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
     IdentityCache.cache.with_memoization do
       IdentityCache.cache.write('foo', 'bar')
     end
-    assert_equal 'bar', @backend.fetch('foo')
+    assert_equal('bar', @backend.fetch('foo'))
   end
 
   def test_write_notifies
@@ -113,7 +113,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
       assert_equal expected, payload
     end
     IdentityCache.cache.write('foo', 'bar')
-    assert_equal 1, events
+    assert_equal(1, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
@@ -126,7 +126,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
       assert_equal expected, payload
     end
     IdentityCache.cache.delete('foo')
-    assert_equal 1, events
+    assert_equal(1, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
@@ -138,7 +138,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
       assert payload.empty?
     end
     IdentityCache.cache.clear
-    assert_equal 1, events
+    assert_equal(1, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end

--- a/test/normalized_belongs_to_test.rb
+++ b/test/normalized_belongs_to_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class NormalizedBelongsToTest < IdentityCache::TestCase
   def setup
     super
-    AssociatedRecord.cache_belongs_to :item
+    AssociatedRecord.cache_belongs_to(:item)
 
     @parent_record = Item.new(:title => 'foo')
     @parent_record.associated_records << AssociatedRecord.new(:name => 'bar')
@@ -26,39 +26,39 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
     @record.item
 
     Item.expects(:fetch_by_id).never
-    assert_equal @parent_record, @record.fetch_item
+    assert_equal(@parent_record, @record.fetch_item)
   end
 
   def test_fetching_the_association_should_fetch_the_record_from_identity_cache
     Item.expects(:fetch_by_id).with(@parent_record.id).returns(@parent_record)
-    assert_equal @parent_record, @record.fetch_item
+    assert_equal(@parent_record, @record.fetch_item)
   end
 
   def test_fetching_the_association_should_assign_the_result_to_an_instance_variable_so_that_successive_accesses_are_cached
     Item.expects(:fetch_by_id).with(@parent_record.id).returns(@parent_record)
-    assert_equal @parent_record, @record.fetch_item
-    assert_equal false, @record.association(:item).loaded?
-    assert_equal @parent_record, @record.fetch_item
+    assert_equal(@parent_record, @record.fetch_item)
+    assert_equal(false, @record.association(:item).loaded?)
+    assert_equal(@parent_record, @record.fetch_item)
   end
 
   def test_fetching_the_association_should_cache_nil_and_not_raise_if_the_record_cant_be_found
     Item.expects(:fetch_by_id).with(@parent_record.id).returns(nil)
-    assert_nil @record.fetch_item # miss
-    assert_nil @record.fetch_item # hit
+    assert_nil(@record.fetch_item) # miss
+    assert_nil(@record.fetch_item) # hit
   end
 
   def test_cache_belongs_to_on_derived_model_raises
     assert_raises(IdentityCache::DerivedModelError) do
-      StiRecordTypeA.cache_belongs_to :item
+      StiRecordTypeA.cache_belongs_to(:item)
     end
   end
 
   def test_fetching_polymorphic_belongs_to_association
-    PolymorphicRecord.include IdentityCache
-    PolymorphicRecord.cache_belongs_to :owner
+    PolymorphicRecord.include(IdentityCache)
+    PolymorphicRecord.cache_belongs_to(:owner)
     PolymorphicRecord.create!(owner: @parent_record)
 
-    assert_equal @parent_record, PolymorphicRecord.first.fetch_owner
+    assert_equal(@parent_record, PolymorphicRecord.first.fetch_owner)
   end
 
   def test_returned_record_should_be_readonly_on_cache_hit
@@ -106,10 +106,10 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
   end
 
   def test_cache_belongs_to_with_scope
-    AssociatedRecord.belongs_to :item_with_scope, -> { where.not(timestamp: nil) },
-      class_name: 'Item', foreign_key: 'item_id'
+    AssociatedRecord.belongs_to(:item_with_scope, -> { where.not(timestamp: nil) },
+      class_name: 'Item', foreign_key: 'item_id')
     assert_raises(IdentityCache::UnsupportedAssociationError) do
-      AssociatedRecord.cache_belongs_to :item_with_scope
+      AssociatedRecord.cache_belongs_to(:item_with_scope)
     end
   end
 end

--- a/test/normalized_belongs_to_test.rb
+++ b/test/normalized_belongs_to_test.rb
@@ -5,8 +5,8 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
     super
     AssociatedRecord.cache_belongs_to(:item)
 
-    @parent_record = Item.new(:title => 'foo')
-    @parent_record.associated_records << AssociatedRecord.new(:name => 'bar')
+    @parent_record = Item.new(title: 'foo')
+    @parent_record.associated_records << AssociatedRecord.new(name: 'bar')
     @parent_record.save
     @parent_record.reload
     @record = @parent_record.associated_records.first

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -3,12 +3,12 @@ require "test_helper"
 class NormalizedHasManyTest < IdentityCache::TestCase
   def setup
     super
-    Item.cache_has_many(:associated_records, :embed => :ids)
+    Item.cache_has_many(:associated_records, embed: :ids)
 
-    @record = Item.new(:title => 'foo')
-    @record.not_cached_records << NotCachedRecord.new(:name => 'NoCache')
-    @record.associated_records << AssociatedRecord.new(:name => 'bar')
-    @record.associated_records << AssociatedRecord.new(:name => 'baz')
+    @record = Item.new(title: 'foo')
+    @record.not_cached_records << NotCachedRecord.new(name: 'NoCache')
+    @record.associated_records << AssociatedRecord.new(name: 'bar')
+    @record.associated_records << AssociatedRecord.new(name: 'baz')
     @record.save
     @record.reload
     @baz, @bar  = @record.associated_records[0], @record.associated_records[1]
@@ -36,9 +36,9 @@ class NormalizedHasManyTest < IdentityCache::TestCase
   end
 
   def test_batch_fetching_of_association_for_multiple_parent_records
-    record2 = Item.new(:title => 'two')
-    record2.associated_records << AssociatedRecord.new(:name => 'a')
-    record2.associated_records << AssociatedRecord.new(:name => 'b')
+    record2 = Item.new(title: 'two')
+    record2.associated_records << AssociatedRecord.new(name: 'a')
+    record2.associated_records << AssociatedRecord.new(name: 'b')
     record2.save!
 
     fetched_records = assert_queries(2) do
@@ -52,8 +52,8 @@ class NormalizedHasManyTest < IdentityCache::TestCase
     Item.has_many(:denormalized_associated_records, class_name: 'AssociatedRecord')
     Item.cache_has_many(:denormalized_associated_records, embed: true)
     AssociatedRecord.cache_has_many(:deeply_associated_records, embed: :ids)
-    @record.associated_records[0].deeply_associated_records << DeeplyAssociatedRecord.new(:name => 'deep1')
-    @record.associated_records[1].deeply_associated_records << DeeplyAssociatedRecord.new(:name => 'deep2')
+    @record.associated_records[0].deeply_associated_records << DeeplyAssociatedRecord.new(name: 'deep1')
+    @record.associated_records[1].deeply_associated_records << DeeplyAssociatedRecord.new(name: 'deep2')
     @record.associated_records.each(&:save!)
 
     fetched_records = assert_queries(4) do
@@ -145,7 +145,7 @@ class NormalizedHasManyTest < IdentityCache::TestCase
   def test_creating_a_child_record_should_expire_the_parents_cache_blob
     IdentityCache.cache.expects(:delete).with(@record.primary_cache_index_key).once
     IdentityCache.cache.expects(:delete).with(@bar.primary_cache_index_key[0...-1] + '3')
-    @qux = @record.associated_records.create!(:name => 'qux')
+    @qux = @record.associated_records.create!(name: 'qux')
     assert_equal([@qux, @baz, @bar], Item.fetch(@record.id).fetch_associated_records)
   end
 

--- a/test/normalized_has_one_test.rb
+++ b/test/normalized_has_one_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class NormalizedHasOneTest < IdentityCache::TestCase
   def setup
     super
-    Item.cache_has_one :associated, embed: :id
+    Item.cache_has_one(:associated, embed: :id)
 
     @record = Item.new(title: 'foo')
     @record.build_associated(name: 'bar')
@@ -14,14 +14,14 @@ class NormalizedHasOneTest < IdentityCache::TestCase
 
   def test_not_implemented_error
     assert_raises(NotImplementedError) do
-      Item.cache_has_one :associated, embed: false
+      Item.cache_has_one(:associated, embed: false)
     end
   end
 
   def test_defining_a_denormalized_has_one_cache_caches_the_associated_id_on_the_parent_record_during_cache_miss
     fetched_record = Item.fetch(@record.id)
-    assert_equal 1, fetched_record.cached_associated_id
-    refute_predicate fetched_record.association(:associated), :loaded?
+    assert_equal(1, fetched_record.cached_associated_id)
+    refute_predicate(fetched_record.association(:associated), :loaded?)
   end
 
   def test_batch_fetching_of_association_for_multiple_parent_records
@@ -32,7 +32,7 @@ class NormalizedHasOneTest < IdentityCache::TestCase
     fetched_records = assert_queries(2) do
       Item.fetch_multi(@record.id, record2.id)
     end
-    assert_equal [1, 2], fetched_records.map(&:cached_associated_id)
+    assert_equal([1, 2], fetched_records.map(&:cached_associated_id))
 
     fetched_records.each do |record|
       refute_predicate record.association(:associated), :loaded?
@@ -40,9 +40,9 @@ class NormalizedHasOneTest < IdentityCache::TestCase
   end
 
   def test_batch_fetching_of_deeply_associated_records
-    Item.has_one :denormalized_associated, class_name: 'AssociatedRecord'
-    Item.cache_has_one :denormalized_associated, embed: true
-    AssociatedRecord.cache_has_one :deeply_associated, embed: :id
+    Item.has_one(:denormalized_associated, class_name: 'AssociatedRecord')
+    Item.cache_has_one(:denormalized_associated, embed: true)
+    AssociatedRecord.cache_has_one(:deeply_associated, embed: :id)
 
     @record.associated.build_deeply_associated(name: 'deep1')
     @record.associated.save!
@@ -58,7 +58,7 @@ class NormalizedHasOneTest < IdentityCache::TestCase
   end
 
   def test_fetching_associated_id_will_populate_the_value_if_the_record_isnt_from_the_cache
-    assert_equal 1, @record.fetch_associated_id
+    assert_equal(1, @record.fetch_associated_id)
   end
 
   def test_fetching_associated_id_will_use_the_cached_value_if_the_record_is_from_the_cache
@@ -69,11 +69,11 @@ class NormalizedHasOneTest < IdentityCache::TestCase
   end
 
   def test_the_cached_associated_id_on_the_parent_record_should_not_be_populated_by_default
-    assert_nil @record.cached_associated_id
+    assert_nil(@record.cached_associated_id)
   end
 
   def test_fetching_the_association_should_fetch_each_record_by_id
-    assert_equal @baz, @record.fetch_associated
+    assert_equal(@baz, @record.fetch_associated)
   end
 
   def test_fetching_the_association_from_a_record_on_a_cache_hit_should_not_issue_any_queries
@@ -110,8 +110,8 @@ class NormalizedHasOneTest < IdentityCache::TestCase
     IdentityCache.cache.expects(:delete).with(@baz.primary_cache_index_key)
     @baz.name = 'foo'
     @baz.save!
-    assert_equal @baz.id, Item.fetch(@record.id).cached_associated_id
-    assert_equal @baz, Item.fetch(@record.id).fetch_associated
+    assert_equal(@baz.id, Item.fetch(@record.id).cached_associated_id)
+    assert_equal(@baz, Item.fetch(@record.id).fetch_associated)
   end
 
   def test_saving_the_child_in_a_transaction_should_expire_the_new_and_old_parents_cache_blob
@@ -127,8 +127,8 @@ class NormalizedHasOneTest < IdentityCache::TestCase
       @baz.reload
     end
 
-    assert_nil Item.fetch(@record.id).cached_associated_id
-    assert_nil Item.fetch(@record.id).fetch_associated
+    assert_nil(Item.fetch(@record.id).cached_associated_id)
+    assert_nil(Item.fetch(@record.id).fetch_associated)
   end
 
   def test_saving_a_child_record_should_expire_only_itself

--- a/test/polymorphic_has_many_test.rb
+++ b/test/polymorphic_has_many_test.rb
@@ -5,8 +5,8 @@ class PolymorphicHasManyTest < IdentityCache::TestCase
     super
     PolymorphicRecord.include(IdentityCache)
 
-    Item.cache_has_many :polymorphic_records, inverse_name: :owner
-    ItemTwo.cache_has_many :polymorphic_records, inverse_name: :owner
+    Item.cache_has_many(:polymorphic_records, inverse_name: :owner)
+    ItemTwo.cache_has_many(:polymorphic_records, inverse_name: :owner)
   end
 
   def test_polymorphic_has_many_filters_by_type
@@ -17,6 +17,6 @@ class PolymorphicHasManyTest < IdentityCache::TestCase
     poly2 = item.polymorphic_records.create
     poly3 = item2.polymorphic_records.create
 
-    assert_equal [poly1, poly2], Item.fetch(1).fetch_polymorphic_records
+    assert_equal([poly1, poly2], Item.fetch(1).fetch_polymorphic_records)
   end
 end

--- a/test/prefetch_associations_test.rb
+++ b/test/prefetch_associations_test.rb
@@ -26,7 +26,7 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
 
     Item.prefetch_associations(:item, items)
 
-    assert spy.calls.one?{ |call| call.args == [[john.id, jim.id]] }
+    assert(spy.calls.one?{ |call| call.args == [[john.id, jim.id]] })
   end
 
   def test_prefetch_associations_on_db_records
@@ -106,7 +106,7 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
       assert_equal :item, payload[:association]
     end
     Item.prefetch_associations(:item, items)
-    assert_equal 1, events
+    assert_equal(1, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
@@ -124,7 +124,7 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
       assert_equal "Item", payload[:class]
     end
     Item.prefetch_associations(:item, items)
-    assert_equal 2, events
+    assert_equal(2, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
@@ -132,7 +132,7 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
   def test_prefetch_associations_with_nil_cached_belongs_to
     Item.send(:cache_belongs_to, :item)
     @bob.update_attributes!(item_id: 1234)
-    assert_nil @bob.fetch_item
+    assert_nil(@bob.fetch_item)
 
     assert_no_queries do
       assert_memcache_operations(0) do
@@ -182,9 +182,9 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
 
     spy = Spy.on(Item, :fetch_multi).and_call_through
 
-    assert_equal @bob, Item.fetch(@bob.id, includes: :item)
+    assert_equal(@bob, Item.fetch(@bob.id, includes: :item))
 
-    assert spy.calls.one?{ |call| call.args == [[john.id]] }
+    assert(spy.calls.one?{ |call| call.args == [[john.id]] })
   end
 
   def test_fetch_multi_with_includes_option
@@ -196,9 +196,9 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
 
     spy = Spy.on(Item, :fetch_multi).and_call_through
 
-    assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id, :includes => :item)
+    assert_equal([@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id, :includes => :item))
 
-    assert spy.calls.one?{ |call| call.args == [[john.id, jim.id]] }
+    assert(spy.calls.one?{ |call| call.args == [[john.id, jim.id]] })
   end
 
   def test_fetch_multi_batch_fetches_non_embedded_first_level_has_many_associations
@@ -377,28 +377,28 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
 
   def test_fetch_by_index_with_includes_option
     Item.send(:cache_belongs_to, :item)
-    Item.cache_index :title
+    Item.cache_index(:title)
     john = Item.create!(title: 'john')
     @bob.update_column(:item_id, john.id)
 
     spy = Spy.on(Item, :fetch_multi).and_call_through
 
-    assert_equal [@bob], Item.fetch_by_title('bob', includes: :item)
+    assert_equal([@bob], Item.fetch_by_title('bob', includes: :item))
 
-    assert spy.calls.one?{ |call| call.args == [[john.id]] }
+    assert(spy.calls.one?{ |call| call.args == [[john.id]] })
   end
 
   def test_fetch_by_unique_index_with_includes_option
     Item.send(:cache_belongs_to, :item)
-    Item.cache_index :title, :unique => true
+    Item.cache_index(:title, :unique => true)
     john = Item.create!(title: 'john')
     @bob.update_column(:item_id, john.id)
 
     spy = Spy.on(Item, :fetch_multi).and_call_through
 
-    assert_equal @bob, Item.fetch_by_title('bob', includes: :item)
+    assert_equal(@bob, Item.fetch_by_title('bob', includes: :item))
 
-    assert spy.calls.one?{ |call| call.args == [[john.id]] }
+    assert(spy.calls.one?{ |call| call.args == [[john.id]] })
   end
 
   private
@@ -410,7 +410,7 @@ class PrefetchAssociationsTest < IdentityCache::TestCase
     parents.each do |parent|
       3.times do |i|
         child_records << (child = parent.associated_records.create!(:name => i.to_s))
-        grandchildren.concat setup_grandchildren(child)
+        grandchildren.concat(setup_grandchildren(child))
         AssociatedRecord.fetch(child.id)
       end
     end

--- a/test/readonly_test.rb
+++ b/test/readonly_test.rb
@@ -7,9 +7,9 @@ class ReadonlyTest < IdentityCache::TestCase
     @record = Item.new
     @record.id = 1
     @record.title = 'bob'
-    @bob = Item.create!(:title => 'bob')
-    @joe = Item.create!(:title => 'joe')
-    @fred = Item.create!(:title => 'fred')
+    @bob = Item.create!(title: 'bob')
+    @joe = Item.create!(title: 'joe')
+    @fred = Item.create!(title: 'fred')
     IdentityCache.cache.clear
     IdentityCache.readonly = true
   end

--- a/test/readonly_test.rb
+++ b/test/readonly_test.rb
@@ -23,7 +23,7 @@ class ReadonlyTest < IdentityCache::TestCase
     assert_memcache_operations(0) do
       fetcher.write(@key, @value)
     end
-    assert_nil backend.read(@key)
+    assert_nil(backend.read(@key))
   end
 
   def test_delete_should_update_cache
@@ -35,7 +35,7 @@ class ReadonlyTest < IdentityCache::TestCase
   def test_clear_should_update_cache
     backend.write(@key, @value)
     fetcher.clear
-    assert_nil backend.read(@key)
+    assert_nil(backend.read(@key))
   end
 
   def test_fetch_should_not_update_cache
@@ -45,8 +45,8 @@ class ReadonlyTest < IdentityCache::TestCase
     assert_readonly_fetch do
       assert_equal @record, Item.fetch(1)
     end
-    assert_nil backend.read(@record.primary_cache_index_key)
-    assert fetch.has_been_called_with?(@record.primary_cache_index_key)
+    assert_nil(backend.read(@record.primary_cache_index_key))
+    assert(fetch.has_been_called_with?(@record.primary_cache_index_key))
   end
 
   def test_fetch_multi_should_not_update_cache
@@ -56,26 +56,26 @@ class ReadonlyTest < IdentityCache::TestCase
       assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id)
     end
     keys = [@bob, @joe, @fred].map(&:primary_cache_index_key)
-    assert_empty backend.read_multi(*keys)
-    assert fetch_multi.has_been_called_with?(*keys)
+    assert_empty(backend.read_multi(*keys))
+    assert(fetch_multi.has_been_called_with?(*keys))
   end
 
   protected
 
   def assert_key_deleted(key)
-    assert_equal IdentityCache::DELETED, backend.read(key)
+    assert_equal(IdentityCache::DELETED, backend.read(key))
   end
 
   def assert_readonly_fetch
     cas = Spy.on(backend, :cas).and_call_through
     yield
-    assert cas.has_been_called?
+    assert(cas.has_been_called?)
   end
 
   def assert_readonly_fetch_multi
     cas_multi = Spy.on(backend, :cas_multi).and_call_through
     yield
-    assert cas_multi.has_been_called?
+    assert(cas_multi.has_been_called?)
   end
 end
 
@@ -91,19 +91,19 @@ class FallbackReadonlyTest < ReadonlyTest
     read = Spy.on(backend, :read).and_call_through
     write = Spy.on(backend, :write).and_call_through
     yield
-    assert read.has_been_called?
-    refute write.has_been_called?
+    assert(read.has_been_called?)
+    refute(write.has_been_called?)
   end
 
   def assert_readonly_fetch_multi
     read_multi = Spy.on(backend, :read_multi).and_call_through
     write = Spy.on(backend, :write).and_call_through
     yield
-    assert read_multi.has_been_called?
-    refute write.has_been_called?
+    assert(read_multi.has_been_called?)
+    refute(write.has_been_called?)
   end
 
   def assert_key_deleted(key)
-    assert_nil backend.read(key)
+    assert_nil(backend.read(key))
   end
 end

--- a/test/recursive_denormalized_has_many_test.rb
+++ b/test/recursive_denormalized_has_many_test.rb
@@ -3,9 +3,9 @@ require "test_helper"
 class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
   def setup
     super
-    AssociatedRecord.cache_has_many :deeply_associated_records, :embed => true
-    Item.cache_has_many :associated_records, :embed => true
-    Item.cache_has_one :associated
+    AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => true)
+    Item.cache_has_many(:associated_records, :embed => true)
+    Item.cache_has_one(:associated)
 
     @record = Item.new(:title => 'foo')
 
@@ -23,13 +23,13 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
   end
 
   def test_cache_fetch_includes
-    assert_equal [{:associated_records => [:deeply_associated_records]}, :associated => [:deeply_associated_records]], Item.send(:cache_fetch_includes)
+    assert_equal([{:associated_records => [:deeply_associated_records]}, :associated => [:deeply_associated_records]], Item.send(:cache_fetch_includes))
   end
 
   def test_uncached_record_from_the_db_will_use_normal_association_for_deeply_associated_records
     expected = @associated_record.deeply_associated_records
     record_from_db = Item.find(@record.id)
-    assert_equal expected, record_from_db.fetch_associated_records[0].fetch_deeply_associated_records
+    assert_equal(expected, record_from_db.fetch_associated_records[0].fetch_deeply_associated_records)
   end
 
   def test_on_cache_miss_record_should_embed_associated_objects_and_return
@@ -37,8 +37,8 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
     expected = @associated_record.deeply_associated_records
 
     child_record_from_cache_miss = record_from_cache_miss.fetch_associated_records[0]
-    assert_equal @associated_record, child_record_from_cache_miss
-    assert_equal expected, child_record_from_cache_miss.fetch_deeply_associated_records
+    assert_equal(@associated_record, child_record_from_cache_miss)
+    assert_equal(expected, child_record_from_cache_miss.fetch_deeply_associated_records)
   end
 
   def test_on_cache_hit_record_should_return_embed_associated_objects
@@ -50,8 +50,8 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
 
     record_from_cache_hit = Item.fetch(@record.id)
     child_record_from_cache_hit = record_from_cache_hit.fetch_associated_records[0]
-    assert_equal @associated_record, child_record_from_cache_hit
-    assert_equal expected, child_record_from_cache_hit.fetch_deeply_associated_records
+    assert_equal(@associated_record, child_record_from_cache_hit)
+    assert_equal(expected, child_record_from_cache_hit.fetch_deeply_associated_records)
   end
 
   def test_on_cache_hit_record_should_publish_one_dehydration_notification
@@ -61,7 +61,7 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
       assert_equal "Item", payload[:class]
     end
     Item.fetch(@record.id)
-    assert_equal 1, events
+    assert_equal(1, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
@@ -79,7 +79,7 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
       assert_equal "Item", payload[:class]
     end
     Item.fetch(@record.id)
-    assert_equal 1, events
+    assert_equal(1, events)
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
@@ -119,8 +119,8 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
   end
 
   def test_set_inverse_associations
-    DeeplyAssociatedRecord.cache_belongs_to :associated_record
-    AssociatedRecord.cache_belongs_to :item
+    DeeplyAssociatedRecord.cache_belongs_to(:associated_record)
+    AssociatedRecord.cache_belongs_to(:item)
     Item.fetch(@record.id) # warm cache
 
     item = Item.fetch(@record.id)
@@ -139,8 +139,8 @@ end
 class RecursiveNormalizedHasManyTest < IdentityCache::TestCase
   def setup
     super
-    AssociatedRecord.cache_has_many :deeply_associated_records, :embed => true
-    Item.cache_has_many :associated_records, :embed => :ids
+    AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => true)
+    Item.cache_has_many(:associated_records, :embed => :ids)
 
     @record = Item.new(:title => 'foo')
     @record.save

--- a/test/recursive_denormalized_has_many_test.rb
+++ b/test/recursive_denormalized_has_many_test.rb
@@ -3,19 +3,19 @@ require "test_helper"
 class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
   def setup
     super
-    AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => true)
-    Item.cache_has_many(:associated_records, :embed => true)
+    AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
+    Item.cache_has_many(:associated_records, embed: true)
     Item.cache_has_one(:associated)
 
-    @record = Item.new(:title => 'foo')
+    @record = Item.new(title: 'foo')
 
-    @associated_record = AssociatedRecord.new(:name => 'bar')
-    @record.associated_records << AssociatedRecord.new(:name => 'baz')
+    @associated_record = AssociatedRecord.new(name: 'bar')
+    @record.associated_records << AssociatedRecord.new(name: 'baz')
     @record.associated_records << @associated_record
 
-    @deeply_associated_record = DeeplyAssociatedRecord.new(:name => "corge")
+    @deeply_associated_record = DeeplyAssociatedRecord.new(name: "corge")
     @associated_record.deeply_associated_records << @deeply_associated_record
-    @associated_record.deeply_associated_records << DeeplyAssociatedRecord.new(:name => "qux")
+    @associated_record.deeply_associated_records << DeeplyAssociatedRecord.new(name: "qux")
 
     @record.save
     @record.reload
@@ -23,7 +23,7 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
   end
 
   def test_cache_fetch_includes
-    assert_equal([{:associated_records => [:deeply_associated_records]}, :associated => [:deeply_associated_records]], Item.send(:cache_fetch_includes))
+    assert_equal([{associated_records: [:deeply_associated_records]}, associated: [:deeply_associated_records]], Item.send(:cache_fetch_includes))
   end
 
   def test_uncached_record_from_the_db_will_use_normal_association_for_deeply_associated_records
@@ -139,10 +139,10 @@ end
 class RecursiveNormalizedHasManyTest < IdentityCache::TestCase
   def setup
     super
-    AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => true)
-    Item.cache_has_many(:associated_records, :embed => :ids)
+    AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
+    Item.cache_has_many(:associated_records, embed: :ids)
 
-    @record = Item.new(:title => 'foo')
+    @record = Item.new(title: 'foo')
     @record.save
     @record.reload
   end

--- a/test/save_test.rb
+++ b/test/save_test.rb
@@ -5,10 +5,10 @@ class SaveTest < IdentityCache::TestCase
 
   def setup
     super
-    Item.cache_index(:title, :unique => true)
-    Item.cache_index(:id, :title, :unique => true)
+    Item.cache_index(:title, unique: true)
+    Item.cache_index(:id, :title, unique: true)
 
-    @record = Item.create(:title => 'bob')
+    @record = Item.create(title: 'bob')
     @blob_key_prefix = "#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:"
     @blob_key = "#{@blob_key_prefix}1"
   end

--- a/test/save_test.rb
+++ b/test/save_test.rb
@@ -5,8 +5,8 @@ class SaveTest < IdentityCache::TestCase
 
   def setup
     super
-    Item.cache_index :title, :unique => true
-    Item.cache_index :id, :title, :unique => true
+    Item.cache_index(:title, :unique => true)
+    Item.cache_index(:id, :title, :unique => true)
 
     @record = Item.create(:title => 'bob')
     @blob_key_prefix = "#{NAMESPACE}blob:Item:#{cache_hash("created_at:datetime,id:integer,item_id:integer,title:string,updated_at:datetime")}:"

--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -20,14 +20,14 @@ class SchemaChangeTest < IdentityCache::TestCase
     ActiveRecord::Migration.verbose = false
 
     read_new_schema
-    Item.cache_has_one(:associated, :embed => true)
-    AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => true)
+    Item.cache_has_one(:associated, embed: true)
+    AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
 
-    @associated_record = AssociatedRecord.new(:name => 'bar')
-    @deeply_associated_record = DeeplyAssociatedRecord.new(:name => "corge")
+    @associated_record = AssociatedRecord.new(name: 'bar')
+    @deeply_associated_record = DeeplyAssociatedRecord.new(name: "corge")
     @associated_record.deeply_associated_records << @deeply_associated_record
-    @associated_record.deeply_associated_records << DeeplyAssociatedRecord.new(:name => "qux")
-    @record = Item.new(:title => 'foo')
+    @associated_record.deeply_associated_records << DeeplyAssociatedRecord.new(name: "qux")
+    @record = Item.new(title: 'foo')
     @record.associated = @associated_record
 
     @associated_record.save!
@@ -78,7 +78,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     record = Item.fetch(@record.id)
 
     PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
-    Item.cache_has_many(:polymorphic_records, :inverse_name => :owner, :embed => true)
+    Item.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: true)
     read_new_schema
 
     Item.expects(:resolve_cache_miss).returns(@record)
@@ -87,7 +87,7 @@ class SchemaChangeTest < IdentityCache::TestCase
 
   def test_embed_existing_cache_has_many
     PolymorphicRecord.include(IdentityCache)
-    Item.cache_has_many(:polymorphic_records, :inverse_name => :owner, :embed => :ids)
+    Item.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: :ids)
     read_new_schema
 
     record = Item.fetch(@record.id)
@@ -96,7 +96,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     setup_models
 
     PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
-    Item.cache_has_many(:polymorphic_records, :inverse_name => :owner, :embed => true)
+    Item.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: true)
     read_new_schema
 
     record = Item.fetch(@record.id)
@@ -145,7 +145,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     PolymorphicRecord.include(IdentityCache)
     record = Item.fetch(@record.id)
 
-    Item.cache_has_many(:polymorphic_records, :inverse_name => :owner, :embed => :ids)
+    Item.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: :ids)
     read_new_schema
 
     record = Item.fetch(@record.id)

--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -5,13 +5,13 @@ class SchemaChangeTest < IdentityCache::TestCase
 
   class AddColumnToChild < Migration
     def up
-      add_column :associated_records, :shiny, :string
+      add_column(:associated_records, :shiny, :string)
     end
   end
 
   class AddColumnToDeepChild < Migration
     def up
-      add_column :deeply_associated_records, :new_column, :string
+      add_column(:deeply_associated_records, :new_column, :string)
     end
   end
 
@@ -20,8 +20,8 @@ class SchemaChangeTest < IdentityCache::TestCase
     ActiveRecord::Migration.verbose = false
 
     read_new_schema
-    Item.cache_has_one :associated, :embed => true
-    AssociatedRecord.cache_has_many :deeply_associated_records, :embed => true
+    Item.cache_has_one(:associated, :embed => true)
+    AssociatedRecord.cache_has_many(:deeply_associated_records, :embed => true)
 
     @associated_record = AssociatedRecord.new(:name => 'bar')
     @deeply_associated_record = DeeplyAssociatedRecord.new(:name => "corge")
@@ -78,7 +78,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     record = Item.fetch(@record.id)
 
     PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
-    Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => true
+    Item.cache_has_many(:polymorphic_records, :inverse_name => :owner, :embed => true)
     read_new_schema
 
     Item.expects(:resolve_cache_miss).returns(@record)
@@ -87,7 +87,7 @@ class SchemaChangeTest < IdentityCache::TestCase
 
   def test_embed_existing_cache_has_many
     PolymorphicRecord.include(IdentityCache)
-    Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => :ids
+    Item.cache_has_many(:polymorphic_records, :inverse_name => :owner, :embed => :ids)
     read_new_schema
 
     record = Item.fetch(@record.id)
@@ -96,7 +96,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     setup_models
 
     PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
-    Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => true
+    Item.cache_has_many(:polymorphic_records, :inverse_name => :owner, :embed => true)
     read_new_schema
 
     record = Item.fetch(@record.id)
@@ -126,7 +126,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     define_models.call(:AssociatedRecord)
 
     record = self.class::Item.fetch(@record.id) # warm cache
-    assert_equal ['bar'], record.fetch_associated_records.map(&:name)
+    assert_equal(['bar'], record.fetch_associated_records.map(&:name))
 
     self.class.send(:remove_const, :Item)
     self.class.send(:remove_const, :AssociatedRecord)
@@ -145,7 +145,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     PolymorphicRecord.include(IdentityCache)
     record = Item.fetch(@record.id)
 
-    Item.cache_has_many :polymorphic_records, :inverse_name => :owner, :embed => :ids
+    Item.cache_has_many(:polymorphic_records, :inverse_name => :owner, :embed => :ids)
     read_new_schema
 
     record = Item.fetch(@record.id)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,7 +76,7 @@ class IdentityCache::TestCase < Minitest::Test
     raise
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber)
-    assert_equal num, counter.log.size, "#{counter.log.size} instead of #{num} queries were executed.#{counter.log.size == 0 ? '' : "\nQueries:\n#{counter.log.join("\n")}"}" unless exception
+    assert_equal(num, counter.log.size, "#{counter.log.size} instead of #{num} queries were executed.#{counter.log.size == 0 ? '' : "\nQueries:\n#{counter.log.join("\n")}"}") unless exception
   end
 
   def assert_memcache_operations(num)
@@ -89,7 +89,7 @@ class IdentityCache::TestCase < Minitest::Test
     raise
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber)
-    assert_equal num, counter.log.size, "#{counter.log.size} instead of #{num} memcache operations were executed. #{counter.log.size == 0 ? '' : "\nOperations:\n#{counter.log.join("\n")}"}" unless exception
+    assert_equal(num, counter.log.size, "#{counter.log.size} instead of #{num} memcache operations were executed. #{counter.log.size == 0 ? '' : "\nOperations:\n#{counter.log.join("\n")}"}") unless exception
   end
 
   def assert_no_queries
@@ -113,7 +113,7 @@ class SQLCounter
 
   # FIXME: this needs to be refactored so specific database can add their own
   # ignored SQL.  This ignored SQL is for Oracle.
-  ignored_sql.concat [/^select .*nextval/i, /^SAVEPOINT/, /^ROLLBACK TO/, /^\s*select .* from all_triggers/im]
+  ignored_sql.concat([/^select .*nextval/i, /^SAVEPOINT/, /^ROLLBACK TO/, /^\s*select .* from all_triggers/im])
 
   attr_reader :ignore
   attr_accessor :log


### PR DESCRIPTION
Fixes for `Style/MethodCallWithArgsParentheses` and `Style/HashSyntax` offences.