### PR TITLE
Remove prepopulate methods

### DIFF
--- a/lib/identity_cache/cached/association.rb
+++ b/lib/identity_cache/cached/association.rb
@@ -6,12 +6,10 @@ module IdentityCache
         @reflection = reflection
         @inverse_name = inverse_name
         @cached_accessor_name = "fetch_#{name}"
-        @prepopulate_method_name = "prepopulate_fetched_#{name}"
         @records_variable_name = :"@cached_#{name}"
       end
 
-      attr_reader :name, :reflection, :cached_accessor_name,
-                  :prepopulate_method_name, :records_variable_name
+      attr_reader :name, :reflection, :cached_accessor_name, :records_variable_name
 
       def build
         raise NotImplementedError

--- a/lib/identity_cache/cached/recursive/association.rb
+++ b/lib/identity_cache/cached/recursive/association.rb
@@ -18,10 +18,6 @@ module IdentityCache
                 :#{name}
               )
             end
-
-            def #{prepopulate_method_name}(records)
-              #{records_variable_name} = records
-            end
           RUBY
 
           ParentModelExpiration.add_parent_expiry_hook(self)

--- a/lib/identity_cache/cached/reference/belongs_to.rb
+++ b/lib/identity_cache/cached/reference/belongs_to.rb
@@ -22,10 +22,6 @@ module IdentityCache
                 #{name}
               end
             end
-
-            def #{prepopulate_method_name}(record)
-              #{records_variable_name} = record
-            end
           RUBY
         end
 

--- a/lib/identity_cache/cached/reference/has_many.rb
+++ b/lib/identity_cache/cached/reference/has_many.rb
@@ -26,10 +26,6 @@ module IdentityCache
                 #{name}.to_a
               end
             end
-
-            def #{prepopulate_method_name}(records)
-              #{records_variable_name} = records
-            end
           RUBY
 
           ParentModelExpiration.add_parent_expiry_hook(self)

--- a/lib/identity_cache/cached/reference/has_one.rb
+++ b/lib/identity_cache/cached/reference/has_one.rb
@@ -27,10 +27,6 @@ module IdentityCache
                 #{name}
               end
             end
-
-            def #{prepopulate_method_name}(record)
-              #{records_variable_name} = record
-            end
           RUBY
 
           ParentModelExpiration.add_parent_expiry_hook(self)

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -429,7 +429,7 @@ module IdentityCache
             end
 
             parent_record_to_child_records.each do |parent, children|
-              parent.send(cached_association.prepopulate_method_name, children)
+              parent.instance_variable_set(cached_association.records_variable_name, children)
             end
           end
 
@@ -459,7 +459,7 @@ module IdentityCache
                 type_parent_records = type.fetch_multi(ids_to_child_record.keys)
                 type_parent_records.each do |parent_record|
                   child_record = ids_to_child_record[parent_record.id]
-                  child_record.send(cached_association.prepopulate_method_name, parent_record)
+                  child_record.instance_variable_set(cached_association.records_variable_name, parent_record)
                 end
                 parent_records.append(type_parent_records)
               end
@@ -473,7 +473,7 @@ module IdentityCache
               parent_records = reflection.klass.fetch_multi(ids_to_child_record.keys)
               parent_records.each do |parent_record|
                 child_record = ids_to_child_record[parent_record.id]
-                child_record.send(cached_association.prepopulate_method_name, parent_record)
+                child_record.instance_variable_set(cached_association.records_variable_name, parent_record)
               end
             end
           end
@@ -498,7 +498,7 @@ module IdentityCache
             end
 
             parent_record_to_child_record.each do |parent, child|
-              parent.send(cached_association.prepopulate_method_name, child)
+              parent.instance_variable_set(cached_association.records_variable_name, child)
             end
           end
 
@@ -554,8 +554,7 @@ module IdentityCache
 
       set_inverse_of_cached_association(cached_association, association_target)
 
-      prepopulate_method_name = cached_association.prepopulate_method_name
-      send(prepopulate_method_name, association_target)
+      instance_variable_set(cached_association.records_variable_name, association_target)
     end
 
     def set_inverse_of_cached_association(cached_association, association_target)
@@ -565,11 +564,16 @@ module IdentityCache
       inverse_cached_association = associated_class.cached_belongs_tos[inverse_name]
       return unless inverse_cached_association
 
-      prepopulate_method_name = inverse_cached_association.prepopulate_method_name
       if association_target.is_a?(Array)
-        association_target.each { |child_record| child_record.send(prepopulate_method_name, self) }
+        association_target.each do |child_record|
+          child_record.instance_variable_set(
+            inverse_cached_association.records_variable_name, self
+          )
+        end
       else
-        association_target.send(prepopulate_method_name, self)
+        association_target.instance_variable_set(
+          inverse_cached_association.records_variable_name, self
+        )
       end
     end
 

--- a/test/cached/association_test.rb
+++ b/test/cached/association_test.rb
@@ -30,10 +30,6 @@ module IdentityCache
       def test_cached_accessor_name
         assert_equal("fetch_item", association.cached_accessor_name)
       end
-
-      def test_prepopulate_method_name
-        assert_equal("prepopulate_fetched_item", association.prepopulate_method_name)
-      end
     end
   end
 end

--- a/test/cached/recursive/has_many_test.rb
+++ b/test/cached/recursive/has_many_test.rb
@@ -25,7 +25,6 @@ module IdentityCache
           record = AssociatedRecord.new
 
           assert_operator(record, :respond_to?, :fetch_deeply_associated_records)
-          assert_operator(record, :respond_to?, :prepopulate_fetched_deeply_associated_records)
         end
 
         def test_clear

--- a/test/cached/recursive/has_one_test.rb
+++ b/test/cached/recursive/has_one_test.rb
@@ -25,7 +25,6 @@ module IdentityCache
           record = AssociatedRecord.new
 
           assert_operator(record, :respond_to?, :fetch_deeply_associated)
-          assert_operator(record, :respond_to?, :prepopulate_fetched_deeply_associated)
         end
 
         def test_clear

--- a/test/cached/reference/belongs_to_test.rb
+++ b/test/cached/reference/belongs_to_test.rb
@@ -21,7 +21,6 @@ module IdentityCache
           record = AssociatedRecord.new
 
           assert_operator(record, :respond_to?, :fetch_item)
-          assert_operator(record, :respond_to?, :prepopulate_fetched_item)
         end
 
         def test_clear

--- a/test/cached/reference/has_many_test.rb
+++ b/test/cached/reference/has_many_test.rb
@@ -27,7 +27,6 @@ module IdentityCache
           assert_operator(record, :respond_to?, :fetch_deeply_associated_record_ids)
           assert_operator(record, :respond_to?, :cached_deeply_associated_record_ids)
           assert_operator(record, :respond_to?, :fetch_deeply_associated_records)
-          assert_operator(record, :respond_to?, :prepopulate_fetched_deeply_associated_records)
         end
 
         def test_clear

--- a/test/cached/reference/has_one_test.rb
+++ b/test/cached/reference/has_one_test.rb
@@ -27,7 +27,6 @@ module IdentityCache
           assert_operator(record, :respond_to?, :cached_deeply_associated_id)
           assert_operator(record, :respond_to?, :fetch_deeply_associated_id)
           assert_operator(record, :respond_to?, :fetch_deeply_associated)
-          assert_operator(record, :respond_to?, :prepopulate_fetched_deeply_associated)
         end
 
         def test_clear


### PR DESCRIPTION
Remove prepopulate methods on cached associations. They can be replaced with `instance_variable_set`.