### PR TITLE
Fix ruby warnings

### DIFF
--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -251,9 +251,9 @@ module IdentityCache
         end
 
         fields = [field]
-        index_by_cache_key = index_values.each_with_object({}) do |index_value, index_by_cache_key|
+        index_by_cache_key = index_values.each_with_object({}) do |index_value, index_hash|
           cache_key = rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, [index_value], unique_index)
-          index_by_cache_key[cache_key] = index_value
+          index_hash[cache_key] = index_value
         end
         attribute_by_cache_key = IdentityCache.fetch_multi(index_by_cache_key.keys) do |unresolved_keys|
           unresolved_index_values = unresolved_keys.map { |cache_key| index_by_cache_key.fetch(cache_key) }

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -43,7 +43,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
     assert_equal([@baz, @bar], @record.instance_variable_get(variable_name))
   end
 
-  def test_after_a_reload_the_cache_perform_as_expected
+  def test_reload_cache_ids
     Item.cache_has_many(:associated_records, embed: :ids)
 
     assert_equal([@baz, @bar], @record.fetch_associated_records)
@@ -56,7 +56,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
     assert_equal([@bar], @record.associated_records)
   end
 
-  def test_after_a_reload_the_cache_perform_as_expected
+  def test_reload_cache_id
     Item.cache_has_one(:associated, embed: :id)
 
     assert_equal(@baz, @record.fetch_associated)

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -295,7 +295,7 @@ class FetchMultiTest < IdentityCache::TestCase
     poly1 = item.polymorphic_record = PolymorphicRecord.create!
 
     assert_queries(2) do
-      stuff = PolymorphicRecord.fetch_multi(poly1.id, includes: :owner)
+      PolymorphicRecord.fetch_multi(poly1.id, includes: :owner)
     end
   end
 
@@ -311,7 +311,7 @@ class FetchMultiTest < IdentityCache::TestCase
     poly3 = item2.polymorphic_records.create
 
     assert_queries(3) do
-      stuff = PolymorphicRecord.fetch_multi([poly1.id, poly2.id, poly3.id], includes: :owner)
+      PolymorphicRecord.fetch_multi([poly1.id, poly2.id, poly3.id], includes: :owner)
     end
   end
 
@@ -322,7 +322,7 @@ class FetchMultiTest < IdentityCache::TestCase
     poly1 = PolymorphicRecord.create!
 
     assert_queries(1) do
-      stuff = PolymorphicRecord.fetch_multi(poly1.id, includes: :owner)
+      PolymorphicRecord.fetch_multi(poly1.id, includes: :owner)
     end
   end
 

--- a/test/polymorphic_has_many_test.rb
+++ b/test/polymorphic_has_many_test.rb
@@ -15,7 +15,7 @@ class PolymorphicHasManyTest < IdentityCache::TestCase
 
     poly1 = item.polymorphic_records.create
     poly2 = item.polymorphic_records.create
-    poly3 = item2.polymorphic_records.create
+    item2.polymorphic_records.create
 
     assert_equal([poly1, poly2], Item.fetch(1).fetch_polymorphic_records)
   end

--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -75,14 +75,14 @@ class SchemaChangeTest < IdentityCache::TestCase
   end
 
   def test_schema_changes_on_new_cached_child_association
-    record = Item.fetch(@record.id)
+    Item.fetch(@record.id)
 
     PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
     Item.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: true)
     read_new_schema
 
     Item.expects(:resolve_cache_miss).returns(@record)
-    record = Item.fetch(@record.id)
+    Item.fetch(@record.id)
   end
 
   def test_embed_existing_cache_has_many
@@ -90,7 +90,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     Item.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: :ids)
     read_new_schema
 
-    record = Item.fetch(@record.id)
+    Item.fetch(@record.id)
 
     teardown_models
     setup_models
@@ -99,7 +99,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     Item.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: true)
     read_new_schema
 
-    record = Item.fetch(@record.id)
+    Item.fetch(@record.id)
   end
 
   def test_cache_reusable_after_associated_class_name_changes
@@ -143,11 +143,11 @@ class SchemaChangeTest < IdentityCache::TestCase
 
   def test_add_non_embedded_cache_has_many
     PolymorphicRecord.include(IdentityCache)
-    record = Item.fetch(@record.id)
+    Item.fetch(@record.id)
 
     Item.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: :ids)
     read_new_schema
 
-    record = Item.fetch(@record.id)
+    Item.fetch(@record.id)
   end
 end


### PR DESCRIPTION
Fixes warnings that get raised by running the test suite (aside from the ones in memcached).