### PR TITLE
Avoid exposing primary index methods on models including WithoutPrimaryIndex

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -29,18 +29,12 @@ require "identity_cache/cache_invalidation"
 require "identity_cache/cache_fetcher"
 require "identity_cache/fallback_fetcher"
 require 'identity_cache/without_primary_index'
+require 'identity_cache/with_primary_index'
 
 module IdentityCache
   extend ActiveSupport::Concern
 
-  include ArTransactionChanges
-  include IdentityCache::BelongsToCaching
-  include IdentityCache::CacheKeyGeneration
-  include IdentityCache::ConfigurationDSL
-  include IdentityCache::QueryAPI
-  include IdentityCache::CacheInvalidation
-  include IdentityCache::ShouldUseCache
-  include ParentModelExpiration
+  include WithPrimaryIndex
 
   CACHED_NIL = :idc_cached_nil
   BATCH_SIZE = 1000
@@ -69,10 +63,8 @@ module IdentityCache
     mattr_accessor :fetch_read_only_records
     self.fetch_read_only_records = true
 
-    def included(base) #:nodoc:
-      raise AlreadyIncludedError if base.respond_to?(:cached_model)
-      base.class_attribute(:cached_model)
-      base.cached_model = base
+    def append_features(base) #:nodoc:
+      raise AlreadyIncludedError if base.include?(IdentityCache)
       super
     end
 

--- a/lib/identity_cache/cache_key_generation.rb
+++ b/lib/identity_cache/cache_key_generation.rb
@@ -31,18 +31,6 @@ module IdentityCache
     end
 
     module ClassMethods
-      def rails_cache_key(id)
-        "#{prefixed_rails_cache_key}#{id}"
-      end
-
-      def rails_cache_key_prefix
-        @rails_cache_key_prefix ||= IdentityCache::CacheKeyGeneration.denormalized_schema_hash(self)
-      end
-
-      def prefixed_rails_cache_key
-        "#{rails_cache_key_namespace}blob:#{base_class.name}:#{rails_cache_key_prefix}:"
-      end
-
       def rails_cache_key_for_attribute_and_fields_and_values(attribute, fields, values, unique)
         unique_indicator = unique ? '' : 's'
         "#{rails_cache_key_namespace}" \
@@ -61,10 +49,6 @@ module IdentityCache
       def rails_cache_string_for_fields_and_values(fields, values)
         "#{fields.join('/')}:#{IdentityCache.memcache_hash(values.map { |v| v.try!(:to_s).inspect }.join('/'))}"
       end
-    end
-
-    def primary_cache_index_key # :nodoc:
-      self.class.rails_cache_key(id)
     end
 
     def attribute_cache_key_for_attribute_and_current_values(attribute, fields, unique) # :nodoc:

--- a/lib/identity_cache/cached/association.rb
+++ b/lib/identity_cache/cached/association.rb
@@ -57,7 +57,7 @@ module IdentityCache
         parent_class = reflection.active_record
         child_class  = reflection.klass
 
-        unless child_class < IdentityCache
+        unless child_class < IdentityCache::WithoutPrimaryIndex
           if embedded_recursively?
             raise UnsupportedAssociationError, <<~MSG.squish
               cached association #{parent_class}\##{reflection.name} requires

--- a/lib/identity_cache/parent_model_expiration.rb
+++ b/lib/identity_cache/parent_model_expiration.rb
@@ -41,10 +41,10 @@ module IdentityCache
 
     def expire_parent_caches
       ParentModelExpiration.install_pending_parent_expiry_hooks(cached_model)
-      parents_to_expire = {}
+      parents_to_expire = Set.new
       add_parents_to_cache_expiry_set(parents_to_expire)
-      parents_to_expire.each_value do |parent|
-        parent.send(:expire_primary_index)
+      parents_to_expire.each do |parent|
+        parent.expire_primary_index if parent.class.primary_cache_index_enabled
       end
     end
 
@@ -55,9 +55,7 @@ module IdentityCache
     end
 
     def add_record_to_cache_expiry_set(parents_to_expire, record)
-      key = record.primary_cache_index_key
-      unless parents_to_expire[key]
-        parents_to_expire[key] = record
+      if parents_to_expire.add?(record)
         record.add_parents_to_cache_expiry_set(parents_to_expire)
       end
     end

--- a/lib/identity_cache/with_primary_index.rb
+++ b/lib/identity_cache/with_primary_index.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+module IdentityCache
+  module WithPrimaryIndex
+    extend ActiveSupport::Concern
+
+    include WithoutPrimaryIndex
+
+    def expire_cache
+      expire_primary_index
+      super
+    end
+
+    # @api private
+    def expire_primary_index # :nodoc:
+      self.class.expire_primary_key_cache_index(id)
+    end
+
+    # @api private
+    def primary_cache_index_key # :nodoc:
+      self.class.rails_cache_key(id)
+    end
+
+    module ClassMethods
+      def primary_cache_index_enabled
+        true
+      end
+
+      # Declares a new index in the cache for the class where IdentityCache was
+      # included.
+      #
+      # IdentityCache will add a fetch_by_field1_and_field2_and_...field for every
+      # index.
+      #
+      # == Example:
+      #
+      #  class Product
+      #    include IdentityCache
+      #    cache_index :name, :vendor
+      #  end
+      #
+      # Will add Product.fetch_by_name_and_vendor
+      #
+      # == Parameters
+      #
+      # +fields+ Array of symbols or strings representing the fields in the index
+      #
+      # == Options
+      # * unique: if the index would only have unique values. Default is false
+      #
+      def cache_index(*fields, unique: false)
+        cache_attribute_by_alias('primary_key', 'id', by: fields, unique: unique)
+
+        field_list = fields.join("_and_")
+        arg_list = (0...fields.size).collect { |i| "arg#{i}" }.join(',')
+
+        if unique
+          instance_eval(<<-CODE, __FILE__, __LINE__ + 1)
+            def fetch_by_#{field_list}(#{arg_list}, includes: nil)
+              id = fetch_id_by_#{field_list}(#{arg_list})
+              id && fetch_by_id(id, includes: includes)
+            end
+
+            # exception throwing variant
+            def fetch_by_#{field_list}!(#{arg_list}, includes: nil)
+              fetch_by_#{field_list}(#{arg_list}, includes: includes) or raise ActiveRecord::RecordNotFound
+            end
+          CODE
+        else
+          instance_eval(<<-CODE, __FILE__, __LINE__ + 1)
+            def fetch_by_#{field_list}(#{arg_list}, includes: nil)
+              ids = fetch_id_by_#{field_list}(#{arg_list})
+              ids.empty? ? ids : fetch_multi(ids, includes: includes)
+            end
+          CODE
+        end
+
+        if fields.length == 1
+          instance_eval(<<-CODE, __FILE__, __LINE__ + 1)
+            def fetch_multi_by_#{field_list}(index_values, includes: nil)
+              ids = fetch_multi_id_by_#{field_list}(index_values).values.flatten(1)
+              return ids if ids.empty?
+              fetch_multi(ids, includes: includes)
+            end
+          CODE
+        end
+      end
+
+      # Similar to ActiveRecord::Base#exists? will return true if the id can be
+      # found in the cache or in the DB.
+      def exists_with_identity_cache?(id)
+        !!fetch_by_id(id)
+      end
+
+      # Default fetcher added to the model on inclusion, it behaves like
+      # ActiveRecord::Base.where(id: id).first
+      def fetch_by_id(id, includes: nil)
+        ensure_base_model
+        raise_if_scoped
+        id = type_for_attribute(primary_key).cast(id)
+        return unless id
+        record = if should_use_cache?
+          object = nil
+          coder  = IdentityCache.fetch(rails_cache_key(id)) do
+            Encoder.encode(object = resolve_cache_miss(id))
+          end
+          object ||= Encoder.decode(coder, self)
+          if object && object.id != id
+            IdentityCache.logger.error(
+              <<~MSG.squish
+                [IDC id mismatch] fetch_by_id_requested=#{id}
+                fetch_by_id_got=#{object.id}
+                for #{object.inspect[(0..100)]}
+              MSG
+            )
+          end
+          object
+        else
+          resolve_cache_miss(id)
+        end
+        prefetch_associations(includes, [record]) if record && includes
+        record
+      end
+
+      # Default fetcher added to the model on inclusion, it behaves like
+      # ActiveRecord::Base.find, will raise ActiveRecord::RecordNotFound exception
+      # if id is not in the cache or the db.
+      def fetch(id, includes: nil)
+        fetch_by_id(id, includes: includes) || raise(
+          ActiveRecord::RecordNotFound, "Couldn't find #{name} with ID=#{id}"
+        )
+      end
+
+      # Default fetcher added to the model on inclusion, if behaves like
+      # ActiveRecord::Base.find_all_by_id
+      def fetch_multi(*ids, includes: nil)
+        ensure_base_model
+        raise_if_scoped
+        ids.flatten!(1)
+        id_type = type_for_attribute(primary_key)
+        ids.map! { |id| id_type.cast(id) }.compact!
+        records = if should_use_cache?
+          cache_keys = ids.map { |id| rails_cache_key(id) }
+          key_to_id_map = Hash[cache_keys.zip(ids)]
+          key_to_record_map = {}
+
+          coders_by_key = IdentityCache.fetch_multi(cache_keys) do |unresolved_keys|
+            ids = unresolved_keys.map { |key| key_to_id_map[key] }
+            records = find_batch(ids)
+            key_to_record_map = records.compact.index_by { |record| rails_cache_key(record.id) }
+            records.map { |record| Encoder.encode(record) }
+          end
+
+          cache_keys.map do |key|
+            key_to_record_map[key] || Encoder.decode(coders_by_key[key], self)
+          end
+        else
+          find_batch(ids)
+        end
+        records.compact!
+        prefetch_associations(includes, records) if includes
+        records
+      end
+
+      # Invalidates the primary cache index for the associated record. Will not invalidate cached attributes.
+      def expire_primary_key_cache_index(id)
+        id = type_for_attribute(primary_key).cast(id)
+        IdentityCache.cache.delete(rails_cache_key(id))
+      end
+
+      # @api private
+      def rails_cache_key(id)
+        "#{prefixed_rails_cache_key}#{id}"
+      end
+
+      private
+
+      def rails_cache_key_prefix
+        @rails_cache_key_prefix ||= IdentityCache::CacheKeyGeneration.denormalized_schema_hash(self)
+      end
+
+      def prefixed_rails_cache_key
+        "#{rails_cache_key_namespace}blob:#{base_class.name}:#{rails_cache_key_prefix}:"
+      end
+
+      def resolve_cache_miss(id)
+        record = includes(cache_fetch_includes).where(primary_key => id).take
+        setup_embedded_associations_on_miss([record]) if record
+        record
+      end
+
+      def find_batch(ids)
+        return [] if ids.empty?
+
+        @id_column ||= columns.detect { |c| c.name == primary_key }
+        ids = ids.map { |id| connection.type_cast(id, @id_column) }
+        records = where(primary_key => ids).includes(cache_fetch_includes).to_a
+        setup_embedded_associations_on_miss(records)
+        records_by_id = records.index_by(&:id)
+        ids.map { |id| records_by_id[id] }
+      end
+    end
+  end
+end

--- a/lib/identity_cache/without_primary_index.rb
+++ b/lib/identity_cache/without_primary_index.rb
@@ -3,9 +3,29 @@ module IdentityCache
   module WithoutPrimaryIndex
     extend ActiveSupport::Concern
 
-    included do |base|
-      base.send(:include, IdentityCache)
-      base.primary_cache_index_enabled = false
+    include ArTransactionChanges
+    include IdentityCache::BelongsToCaching
+    include IdentityCache::CacheKeyGeneration
+    include IdentityCache::ConfigurationDSL
+    include IdentityCache::QueryAPI
+    include IdentityCache::CacheInvalidation
+    include IdentityCache::ShouldUseCache
+    include ParentModelExpiration
+
+    def self.append_features(base) #:nodoc:
+      raise AlreadyIncludedError if base.include?(WithoutPrimaryIndex)
+      super
+    end
+
+    included do
+      class_attribute(:cached_model)
+      self.cached_model = self
+    end
+
+    module ClassMethods
+      def primary_cache_index_enabled
+        false
+      end
     end
   end
 end

--- a/test/helpers/active_record_objects.rb
+++ b/test/helpers/active_record_objects.rb
@@ -17,9 +17,13 @@ module SwitchNamespace
 end
 
 module ActiveRecordObjects
-
-  def setup_models(_base = ActiveRecord::Base)
+  def setup_models
     Kernel.load(File.expand_path('../../helpers/models.rb', __FILE__))
+    include_idc_into_associated_record
+  end
+
+  def include_idc_into_associated_record
+    AssociatedRecord.include(IdentityCache)
   end
 
   def teardown_models

--- a/test/helpers/models.rb
+++ b/test/helpers/models.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class DeeplyAssociatedRecord < ActiveRecord::Base
   include IdentityCache
   belongs_to :item
@@ -7,7 +8,6 @@ class DeeplyAssociatedRecord < ActiveRecord::Base
 end
 
 class AssociatedRecord < ActiveRecord::Base
-  include IdentityCache
   belongs_to :item, inverse_of: :associated_records
   belongs_to :item_two, inverse_of: :associated_records
   has_many :deeply_associated_records

--- a/test/recursive_denormalized_has_many_test.rb
+++ b/test/recursive_denormalized_has_many_test.rb
@@ -105,8 +105,6 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
     IdentityCache.cache.expects(:delete).with(@record.primary_cache_index_key)
     if AssociatedRecord.primary_cache_index_enabled
       IdentityCache.cache.expects(:delete).with(@associated_record.primary_cache_index_key)
-    else
-      IdentityCache.cache.expects(:delete).with(@associated_record.primary_cache_index_key).never
     end
     @associated_record.name = 'different'
     @associated_record.save!
@@ -116,8 +114,6 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
     IdentityCache.cache.expects(:delete).with(@record.primary_cache_index_key)
     if AssociatedRecord.primary_cache_index_enabled
       IdentityCache.cache.expects(:delete).with(@associated_record.primary_cache_index_key)
-    else
-      IdentityCache.cache.expects(:delete).with(@associated_record.primary_cache_index_key).never
     end
     IdentityCache.cache.expects(:delete).with(@deeply_associated_record.primary_cache_index_key)
     @deeply_associated_record.name = 'different'
@@ -160,8 +156,7 @@ class RecursiveNormalizedHasManyTest < IdentityCache::TestCase
 end
 
 class DisabledPrimaryIndexTest < RecursiveDenormalizedHasManyTest
-  def setup
-    super
-    AssociatedRecord.primary_cache_index_enabled = false
+  def include_idc_into_associated_record
+    AssociatedRecord.include(IdentityCache::WithoutPrimaryIndex)
   end
 end


### PR DESCRIPTION
## Problem

IdentityCache::WithoutPrimaryIndex was including the `IdentityCache` module then disabling some of its functionality by setting a `primary_cache_index_enabled` to false to cause methods to raise.  This is the opposite of how inheritance is normally done, where a module or derived class should extend the ancestors while preserving its behaviour.  We also can't use an `is_a?` check to see if functionality exists since `primary_cache_index_enabled` could be changed to not reflect the modules that are included.

## Solution

I moved methods that depend on the primary cache index to a `IdentityCache::WithPrimaryIndex` module, which includes `IdentityCache::WithoutPrimaryIndex` instead of the reverse.  The `IdentityCache` module includes `WithPrimaryIndex`.