### PR TITLE
Lazily query the primary key for cache_index again

### DIFF
--- a/lib/identity_cache/cached/attribute.rb
+++ b/lib/identity_cache/cached/attribute.rb
@@ -5,12 +5,20 @@ module IdentityCache
     class Attribute
       attr_reader :model, :attribute, :alias_name, :key_fields, :unique
 
-      def initialize(model, attribute, alias_name, key_fields, unique)
+      def initialize(model, attribute_or_proc, alias_name, key_fields, unique)
         @model = model
-        @attribute = attribute.to_sym
+        if attribute_or_proc.is_a?(Proc)
+          @attribute_proc = attribute_or_proc
+        else
+          @attribute = attribute_or_proc.to_sym
+        end
         @alias_name = alias_name.to_sym
         @key_fields = key_fields.map(&:to_sym)
         @unique = !!unique
+      end
+
+      def attribute
+        @attribute ||= @attribute_proc.call.to_sym
       end
 
       def build

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -122,16 +122,16 @@ module IdentityCache
       # * by: Other attribute or attributes in the model to keep values indexed. Default is :id
       # * unique: if the index would only have unique values. Default is true
       def cache_attribute(attribute, by: :id, unique: true)
-        cache_attribute_by_alias(attribute, attribute, by: by, unique: unique)
+        cache_attribute_by_alias(attribute, alias_name: attribute, by: by, unique: unique)
       end
 
       private
 
-      def cache_attribute_by_alias(attribute, alias_name, by:, unique:)
+      def cache_attribute_by_alias(attribute_or_proc, alias_name:, by:, unique:)
         ensure_base_model
         fields = Array(by)
 
-        cached_attribute = Cached::Attribute.new(self, attribute, alias_name, fields, unique)
+        cached_attribute = Cached::Attribute.new(self, attribute_or_proc, alias_name, fields, unique)
         cached_attribute.build
         cache_indexes.push(cached_attribute)
       end

--- a/lib/identity_cache/with_primary_index.rb
+++ b/lib/identity_cache/with_primary_index.rb
@@ -53,7 +53,8 @@ module IdentityCache
       # * unique: if the index would only have unique values. Default is false
       #
       def cache_index(*fields, unique: false)
-        cache_attribute_by_alias(primary_key, 'id', by: fields, unique: unique)
+        attribute_proc = -> { primary_key }
+        cache_attribute_by_alias(attribute_proc, alias_name: :id, by: fields, unique: unique)
 
         field_list = fields.join("_and_")
         arg_list = (0...fields.size).collect { |i| "arg#{i}" }.join(',')

--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -4,6 +4,17 @@ require "test_helper"
 class IndexCacheTest < IdentityCache::TestCase
   NAMESPACE = IdentityCache::CacheKeyGeneration::DEFAULT_NAMESPACE
 
+  class WithoutSetup < IdentityCache::TestCase
+    def test_no_queries_on_definition
+      # should not do schema queries eagerly
+      assert_no_queries { Item.cache_index(:title, :id) }
+
+      # make sure schema wasn't cached
+      schema_queries = count_queries { Item.primary_key }
+      assert(schema_queries > 0)
+    end
+  end
+
   def setup
     super
     @record = Item.new

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,7 @@ class IdentityCache::TestCase < Minitest::Test
   attr_reader :backend
 
   def setup
+    ActiveRecord::Base.connection.schema_cache.clear!
     DatabaseConnection.drop_tables
     DatabaseConnection.create_tables
 
@@ -60,6 +61,13 @@ class IdentityCache::TestCase < Minitest::Test
 
   def assert_not_nil(*args)
     assert(*args)
+  end
+
+  def count_queries
+    counter = SQLCounter.new
+    subscriber = ActiveSupport::Notifications.subscribe('sql.active_record', counter)
+    yield
+    counter.log.size
   end
 
   def assert_queries(num = 1)


### PR DESCRIPTION
## Problem

The refactor of the cache_attribute implementation into IdentityCache::Cached::Attribute caused the primary key to start being eagerly requested when `cache_index` is called on a model.  This causes problems when a connection isn't available and we shouldn't fail to boot the app when a connection to the database isn't available.

## Solution

Specify the attribute using a proc for the primary key, which IdentityCache::Cached::Attribute will call when its attribute method is first called.