### PR TITLE
Fix method redefinition error on IdentityCache::Cached::Attribute#attribute

### DIFF
--- a/lib/identity_cache/cached/attribute.rb
+++ b/lib/identity_cache/cached/attribute.rb
@@ -3,7 +3,7 @@
 module IdentityCache
   module Cached
     class Attribute
-      attr_reader :model, :attribute, :alias_name, :key_fields, :unique
+      attr_reader :model, :alias_name, :key_fields, :unique
 
       def initialize(model, attribute_or_proc, alias_name, key_fields, unique)
         @model = model


### PR DESCRIPTION
Fixes `identity_cache/lib/identity_cache/cached/attribute.rb:20: warning: method redefined; discarding old attribute`