### PR TITLE
Add CacheKeyLoader.batch_load to batch cache loading across cache fetchers

### DIFF
--- a/lib/identity_cache/cache_key_loader.rb
+++ b/lib/identity_cache/cache_key_loader.rb
@@ -70,6 +70,53 @@ module IdentityCache
         load_result
       end
 
+      # Load multiple keys for multiple cache fetchers
+      def batch_load(cache_fetcher_to_db_keys_hash)
+        cache_key_to_db_key_hash = {}
+        cache_key_to_cache_fetcher_hash = {}
+
+        batch_load_result = {}
+
+        cache_fetcher_to_db_keys_hash.each do |cache_fetcher, db_keys|
+          if db_keys.empty?
+            batch_load_result[cache_fetcher] = {}
+            next
+          end
+          db_keys.each do |db_key|
+            cache_key = cache_fetcher.cache_key(db_key)
+            cache_key_to_db_key_hash[cache_key] = db_key
+            cache_key_to_cache_fetcher_hash[cache_key] = cache_fetcher
+          end
+        end
+
+        cache_keys = cache_key_to_db_key_hash.keys
+        cache_result = cache_fetch_multi(cache_keys) do |unresolved_cache_keys|
+          cache_fetcher_to_unresolved_keys_hash = unresolved_cache_keys.group_by do |cache_key|
+            cache_key_to_cache_fetcher_hash.fetch(cache_key)
+          end
+
+          resolve_miss_result = {}
+
+          db_keys_buffer = []
+          cache_fetcher_to_unresolved_keys_hash.each do |cache_fetcher, unresolved_cache_fetcher_keys|
+            batch_load_result[cache_fetcher] = resolve_multi_on_miss(cache_fetcher, unresolved_cache_fetcher_keys,
+              cache_key_to_db_key_hash, resolve_miss_result, db_keys_buffer: db_keys_buffer)
+          end
+
+          resolve_miss_result
+        end
+
+        cache_result.each do |cache_key, cache_value|
+          cache_fetcher = cache_key_to_cache_fetcher_hash.fetch(cache_key)
+          load_result = (batch_load_result[cache_fetcher] ||= {})
+
+          db_key = cache_key_to_db_key_hash.fetch(cache_key)
+          load_result[db_key] ||= cache_fetcher.cache_decode(cache_value)
+        end
+
+        batch_load_result
+      end
+
       private
 
       def cache_fetch_multi(cache_keys)
@@ -79,12 +126,13 @@ module IdentityCache
         end
       end
 
-      def resolve_multi_on_miss(cache_fetcher, unresolved_cache_keys, cache_key_to_db_key_hash, resolve_miss_result)
-        db_keys = unresolved_cache_keys.map do |cache_key|
-          cache_key_to_db_key_hash.fetch(cache_key)
+      def resolve_multi_on_miss(cache_fetcher, unresolved_cache_keys, cache_key_to_db_key_hash, resolve_miss_result, db_keys_buffer: [])
+        db_keys_buffer.clear
+        unresolved_cache_keys.each do |cache_key|
+          db_keys_buffer << cache_key_to_db_key_hash.fetch(cache_key)
         end
 
-        load_result = cache_fetcher.load_multi_from_db(db_keys)
+        load_result = cache_fetcher.load_multi_from_db(db_keys_buffer)
 
         unresolved_cache_keys.each do |cache_key|
           db_key = cache_key_to_db_key_hash.fetch(cache_key)

--- a/lib/identity_cache/cache_key_loader.rb
+++ b/lib/identity_cache/cache_key_loader.rb
@@ -44,30 +44,7 @@ module IdentityCache
       # @param db_key [Array] Reference to what to load from the database.
       # @return [Hash] A hash mapping each database key to its corresponding value
       def load_multi(cache_fetcher, db_keys)
-        cache_key_to_db_key_hash = {}
-
-        db_keys.each do |db_key|
-          cache_key = cache_fetcher.cache_key(db_key)
-          cache_key_to_db_key_hash[cache_key] = db_key
-        end
-
-        load_result = nil
-
-        cache_keys = cache_key_to_db_key_hash.keys
-        cache_result = cache_fetch_multi(cache_keys) do |unresolved_cache_keys|
-          resolve_miss_result = {}
-          load_result = resolve_multi_on_miss(cache_fetcher, unresolved_cache_keys,
-            cache_key_to_db_key_hash, resolve_miss_result)
-          resolve_miss_result
-        end
-
-        load_result ||= {}
-        cache_result.each do |cache_key, cache_value|
-          db_key = cache_key_to_db_key_hash.fetch(cache_key)
-          load_result[db_key] ||= cache_fetcher.cache_decode(cache_value)
-        end
-
-        load_result
+        batch_load(cache_fetcher => db_keys).fetch(cache_fetcher)
       end
 
       # Load multiple keys for multiple cache fetchers


### PR DESCRIPTION
@gmcgibbon Here is the CacheKeyLoader.batch_load implementation I mentioned https://github.com/Shopify/identity_cache/pull/420

It can be used to replace load_multi, which I have done temporarily for testing, however, we can keep the load_multi implementation from https://github.com/Shopify/identity_cache/pull/420 as an optimization for the case where we are loading for a single cache fetcher.