### PR TITLE
Use IdentityCache::RecordNotFound in place of ActiveRecord::RecordNotFound

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/module/attribute_accessors'
 require 'ar_transaction_changes'
 
 require "identity_cache/version"
+require "identity_cache/record_not_found"
 require "identity_cache/encoder"
 require "identity_cache/prefetch"
 require "identity_cache/prefetch/batch"

--- a/lib/identity_cache/record_not_found.rb
+++ b/lib/identity_cache/record_not_found.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module IdentityCache
+  class RecordNotFound < ActiveRecord::RecordNotFound
+  end
+end

--- a/lib/identity_cache/with_primary_index.rb
+++ b/lib/identity_cache/with_primary_index.rb
@@ -68,7 +68,7 @@ module IdentityCache
 
             # exception throwing variant
             def fetch_by_#{field_list}!(#{arg_list}, includes: nil)
-              fetch_by_#{field_list}(#{arg_list}, includes: includes) or raise ActiveRecord::RecordNotFound
+              fetch_by_#{field_list}(#{arg_list}, includes: includes) or raise IdentityCache::RecordNotFound
             end
           CODE
         else
@@ -108,11 +108,11 @@ module IdentityCache
       end
 
       # Default fetcher added to the model on inclusion, it behaves like
-      # ActiveRecord::Base.find, will raise ActiveRecord::RecordNotFound exception
+      # ActiveRecord::Base.find, will raise IdentityCache::RecordNotFound exception
       # if id is not in the cache or the db.
       def fetch(id, includes: nil)
         fetch_by_id(id, includes: includes) || raise(
-          ActiveRecord::RecordNotFound, "Couldn't find #{name} with ID=#{id}"
+          IdentityCache::RecordNotFound, "Couldn't find #{name} with ID=#{id}"
         )
       end
 

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -197,7 +197,7 @@ class FetchTest < IdentityCache::TestCase
     nonexistent_record_id = 10
     fetcher.expects(:add).with(@blob_key + '0', IdentityCache::CACHED_NIL)
 
-    assert_raises(ActiveRecord::RecordNotFound) { Item.fetch(nonexistent_record_id) }
+    assert_raises(IdentityCache::RecordNotFound) { Item.fetch(nonexistent_record_id) }
   end
 
   def test_cached_nil_expiry_on_record_creation
@@ -260,7 +260,7 @@ class FetchTest < IdentityCache::TestCase
 
   def test_fetch_by_bang_method
     Item.connection.expects(:exec_query).returns(ActiveRecord::Result.new([], []))
-    assert_raises ActiveRecord::RecordNotFound do
+    assert_raises IdentityCache::RecordNotFound do
       Item.fetch_by_title!('bob')
     end
   end
@@ -268,7 +268,7 @@ class FetchTest < IdentityCache::TestCase
   def test_fetch_does_not_communicate_to_cache_with_nil_id
     fetcher.expects(:fetch).never
     fetcher.expects(:add).never
-    assert_raises(ActiveRecord::RecordNotFound) { Item.fetch(nil) }
+    assert_raises(IdentityCache::RecordNotFound) { Item.fetch(nil) }
   end
 
   def test_fetch_cache_hit_does_not_checkout_database_connection


### PR DESCRIPTION
Closes https://github.com/Shopify/identity_cache/issues/422.

Uses `IdentityCache::RecordNotFound` where we were previously using `ActiveRecord::RecordNotFound`.