### PR TITLE
Lint and naming fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-Lint/ShadowingOuterLocalVariable:
-  Exclude:
-    - 'performance/profile.rb'
-
 # Offense count: 2
 Lint/UselessAssignment:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 3
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: snake_case, camelCase
-Naming/VariableName:
-  Exclude:
-    - 'test/helpers/serialization_format.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 2
-Lint/UselessAssignment:
-  Exclude:
-    - 'test/schema_change_test.rb'
-
 # Offense count: 1
 Naming/ConstantName:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-Naming/ConstantName:
-  Exclude:
-    - 'test/schema_change_test.rb'
-
 # Offense count: 3
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: snake_case, camelCase

--- a/performance/profile.rb
+++ b/performance/profile.rb
@@ -30,7 +30,7 @@ if (runner_name = ENV['RUNNER'])
     exit(1)
   end
 else
-  CACHE_RUNNERS.each do |runner|
-    run(runner.new(RUNS))
+  CACHE_RUNNERS.each do |cache_runner|
+    run(cache_runner.new(RUNS))
   end
 end

--- a/test/helpers/serialization_format.rb
+++ b/test/helpers/serialization_format.rb
@@ -37,14 +37,14 @@ module SerializationFormat
     File.expand_path("../../fixtures/serialized_record.#{DatabaseConnection.db_name}", __FILE__)
   end
 
-  def serialize(record, anIO = nil)
+  def serialize(record, io = nil)
     hash = {
       version: IdentityCache::CACHE_VERSION,
       record: record
     }
 
-    if anIO
-      Marshal.dump(hash, anIO)
+    if io
+      Marshal.dump(hash, io)
     else
       Marshal.dump(hash)
     end

--- a/test/prefetch_associations_test.rb
+++ b/test/prefetch_associations_test.rb
@@ -327,7 +327,7 @@ module IdentityCache
       end
     end
 
-    def test_fetch_multi_batch_fetches_non_embedded_second_level_associations_through_embedded_first_level_has_many_associations # rubocop:disable Metrics/LineLength
+    def test_fetch_multi_batch_fetches_non_embedded_second_level_associations_through_embedded_first_level_has_many_associations # rubocop:disable Layout/LineLength
       Item.send(:cache_has_many, :associated_records, embed: true)
       AssociatedRecord.send(:cache_has_many, :deeply_associated_records, embed: :ids)
 
@@ -349,7 +349,7 @@ module IdentityCache
       end
     end
 
-    def test_fetch_multi_batch_fetches_non_embedded_second_level_associations_through_embedded_first_level_has_one_associations # rubocop:disable Metrics/LineLength
+    def test_fetch_multi_batch_fetches_non_embedded_second_level_associations_through_embedded_first_level_has_one_associations # rubocop:disable Layout/LineLength
       Item.send(:cache_has_one, :associated, embed: true)
       AssociatedRecord.send(:cache_has_many, :deeply_associated_records, embed: :ids)
 

--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -60,7 +60,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     read_new_schema
 
     Item.cached_primary_index.expects(:load_one_from_db).returns(@record)
-    record = Item.fetch(@record.id)
+    Item.fetch(@record.id)
   end
 
   def test_schema_changes_on_deeply_embedded_association_should_cause_cache_miss_for_old_cached_objects
@@ -72,7 +72,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     read_new_schema
 
     Item.cached_primary_index.expects(:load_one_from_db).returns(@record)
-    record = Item.fetch(@record.id)
+    Item.fetch(@record.id)
   end
 
   def test_schema_changes_on_new_cached_child_association

--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -2,7 +2,7 @@
 require "test_helper"
 
 class SchemaChangeTest < IdentityCache::TestCase
-  Migration = ActiveRecord::Migration.try(:[], 4.2) || ActiveRecord::Migration
+  Migration = ActiveRecord::Migration[5.0]
 
   class AddColumnToChild < Migration
     def up


### PR DESCRIPTION
More rubocop fixes. This time for `Lint` and `Naming` type violations. There are only `Style` ones left!