### PR TITLE
Add rubocop task and include it in the default rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ before_script:
   - mysql -e 'create database identity_cache_test'
   - psql -c 'create database identity_cache_test;' -U postgres
 
+script:
+  - bundle exec rake test
+
 cache: bundler
 
 matrix:

--- a/Rakefile
+++ b/Rakefile
@@ -5,8 +5,8 @@ require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rdoc/task'
 
-desc('Default: run unit tests.')
-task(default: :test)
+desc('Default: run tests and style checks.')
+task(default: [:test, :rubocop])
 
 desc('Test the identity_cache plugin.')
 Rake::TestTask.new(:test) do |t|
@@ -14,6 +14,11 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.pattern = 'test/**/*_test.rb'
   t.verbose = true
+end
+
+task :rubocop do
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
 end
 
 desc('Update serialization format test fixture.')

--- a/dev.yml
+++ b/dev.yml
@@ -27,6 +27,14 @@ commands:
         bundle exec ruby -I test "$@"
       fi
 
+  style:
+    desc: 'Run rubocop checks'
+    run: bundle exec rubocop "$@"
+
+  check:
+    desc: 'Run tests and style checks'
+    run: bundle exec rake test && bundle exec rubocop
+
   benchmark-cpu:
     desc: 'Run the identity cache CPU benchmark'
     run: bundle exec rake benchmark:cpu


### PR DESCRIPTION
## Problem

It can be easy to miss rubocop errors until getting CI results, since using `rake` or `dev test` won't run the same tests as in CI.  It would be better to get this feedback earlier, when the tests are run locally.

## Solution

Add a rubocop rake task and add it to the default rake task.

I've also added a `dev check` task so it can be used in a similar way as the default rake task when using `dev`.