### PR TITLE
Add pg to bundle so format dumps work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'mysql2', '~> 0.5.2'
+gem 'mysql2', '~> 0.5.3'
+gem 'pg', '~> 0.21.0'
 gem 'rubocop'
 gem 'byebug', platform: :mri


### PR DESCRIPTION
Adds `pg` to Gemfile, bumps version constraint on `mysql2`.