### PR TITLE
Help make error reported in issue #428 clearer

### DIFF
--- a/lib/identity_cache/encoder.rb
+++ b/lib/identity_cache/encoder.rb
@@ -76,12 +76,12 @@ module IdentityCache
         end
         if coder.key?(:association_ids)
           coder[:association_ids].each do |name, ids|
-            record.instance_variable_set(record.class.cached_has_manys[name].ids_variable_name, ids)
+            record.instance_variable_set(klass.cached_has_manys.fetch(name).ids_variable_name, ids)
           end
         end
         if coder.key?(:association_id)
           coder[:association_id].each do |name, id|
-            record.instance_variable_set(record.class.cached_has_ones[name].id_variable_name, id)
+            record.instance_variable_set(klass.cached_has_ones.fetch(name).id_variable_name, id)
           end
         end
 


### PR DESCRIPTION
cc @saiqulhaq

The exception reported in issue #428 was ```NoMethodError: undefined method `ids_variable_name' for nil:NilClass``` on line [lib/identity_cache/encoder.rb:79](https://github.com/Shopify/identity_cache/blob/c4799ac93b489312d9685dd674750c93a4729b02/lib/identity_cache/encoder.rb#L79).  That exception indicates that `Hash#[]` returned `nil` instead of the cached association.  Using Hash#fetch instead provides a better error message by also providing the association name, which could help in debugging this possible exception.

I'm not actually sure how the exception could be reproduced, but I did notice that the code was trying to get the cached association from the instantiated record class rather than from the cached model that `fetch_by_id` was called on.  These classes aren't the same when single table inheritance is used, so it would be better to avoid this indirection to any possible effects of this single table inheritance edge case.  However, `cached_has_manys` is a `class_attribute` so it should have been inherited by the child class, so I don't actually have a reason to believe that this caused the exception.