### PR TITLE
Remove the default embed option value from cache_has_one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 1.0.0 Unreleased
 
+- Remove the default embed option value from cache_has_one (#437)
 - Type cast values using attribute types before using in cache key (#354)
 - Remove support for rails 4.2 (#355)
 - Set inverse cached association for cache_has_one on cache hit (#345)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ class Product < ActiveRecord::Base
   has_one   :featured_image
 
   cache_has_many :images
-  cache_has_one :featured_image
+  cache_has_one :featured_image, embed: :id
 end
 
 @product.fetch_featured_image
@@ -191,7 +191,7 @@ Example:
 #### cache_has_many
 
 Options:
-_[:embed]_ When true, specifies that the association should be included with the parent when caching. This means the associated objects will be loaded already when the parent is loaded from the cache and will not need to be fetched on their own. When :ids, only the id of the associated records will be included with the parent when caching.
+_[:embed]_ When true, specifies that the association should be included with the parent when caching. This means the associated objects will be loaded already when the parent is loaded from the cache and will not need to be fetched on their own. When :ids, only the id of the associated records will be included with the parent when caching. Defaults to `:ids`.
 
 _[:inverse_name]_ Specifies the name of parent object used by the association. This is useful for polymorphic associations when the association is often named something different between the parent and child objects.
 
@@ -201,12 +201,12 @@ Example:
 #### cache_has_one
 
 Options:
-_[:embed]_ When true, specifies that the association should be included with the parent when caching. This means the associated objects will be loaded already when the parent is loaded from the cache and will not need to be fetched on their own. No other values are currently implemented.
+_[:embed]_ When true, specifies that the association should be included with the parent when caching. This means the associated objects will be loaded already when the parent is loaded from the cache and will not need to be fetched on their own. No other values are currently implemented. When :id, only the id of the associated record will be included with the parent when caching.
 
 _[:inverse_name]_ Specifies the name of parent object used by the association. This is useful for polymorphic associations when the association is often named something different between the parent and child objects.
 
 Example:
-`cache_has_one :configuration, :embed => true`
+`cache_has_one :configuration, embed: :id`
 
 #### cache_belongs_to
 

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -38,9 +38,11 @@ module IdentityCache
       #
       # == Options
       #
-      # * embed: If set to true, will cause IdentityCache to keep the
-      #   values for this association in the same cache entry as the parent,
-      #   instead of its own.
+      # * embed: If `true`, IdentityCache will embed the associated records
+      #   in the cache entries for this model, as well as all the embedded
+      #   associations for the associated record recursively.
+      #   If `:ids` (the default), it will only embed the ids for the associated
+      #   records.
       # * inverse_name: The name of the parent in the association if the name is
       #   not the lowercase pluralization of the parent object's class
       def cache_has_many(association, embed: :ids, inverse_name: nil)
@@ -70,7 +72,7 @@ module IdentityCache
       # == Example:
       #   class Product
       #     cache_has_one :store, embed: true
-      #     cache_has_one :vendor
+      #     cache_has_one :vendor, embed: :id
       #   end
       #
       # == Parameters
@@ -78,13 +80,14 @@ module IdentityCache
       #
       # == Options
       #
-      # * embed: Only true is supported, which is also the default, so
-      #   IdentityCache will keep the values for this association in the same
-      #   cache entry as the parent, instead of its own.
+      # * embed: If `true`, IdentityCache will embed the associated record
+      #   in the cache entries for this model, as well as all the embedded
+      #   associations for the associated record recursively.
+      #   If `:id`, it will only embed the id for the associated record.
       # * inverse_name: The name of the parent in the association ( only
       #   necessary if the name is not the lowercase pluralization of the
       #   parent object's class)
-      def cache_has_one(association, embed: true, inverse_name: nil)
+      def cache_has_one(association, embed:, inverse_name: nil)
         ensure_base_model
         check_association_for_caching(association)
         reflection = reflect_on_association(association)

--- a/performance/cache_runner.rb
+++ b/performance/cache_runner.rb
@@ -53,7 +53,7 @@ ensure
 end
 
 def setup_embedded_associations
-  Item.cache_has_one(:associated)
+  Item.cache_has_one(:associated, embed: true)
   Item.cache_has_many(:associated_records, embed: true)
   AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
 end
@@ -132,7 +132,7 @@ end
 class EmbedRunner < CacheRunner
   def setup_models
     super
-    Item.cache_has_one(:associated)
+    Item.cache_has_one(:associated, embed: true)
     Item.cache_has_many(:associated_records, embed: true)
     AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
   end
@@ -174,7 +174,7 @@ CACHE_RUNNERS << FetchEmbedDeletedConflictRunner
 class NormalizedRunner < CacheRunner
   def setup_models
     super
-    Item.cache_has_one(:associated) # :embed => false isn't supported
+    Item.cache_has_one(:associated, embed: :id)
     Item.cache_has_many(:associated_records, embed: :ids)
     AssociatedRecord.cache_has_many(:deeply_associated_records, embed: :ids)
   end

--- a/test/cache_fetch_includes_test.rb
+++ b/test/cache_fetch_includes_test.rb
@@ -17,7 +17,7 @@ class CacheFetchIncludesTest < IdentityCache::TestCase
   end
 
   def test_cached_has_ones_are_included_in_includes
-    Item.send(:cache_has_one, :associated)
+    Item.send(:cache_has_one, :associated, embed: true)
     assert_equal([:associated], Item.send(:cache_fetch_includes))
   end
 

--- a/test/deeply_nested_associated_record_test.rb
+++ b/test/deeply_nested_associated_record_test.rb
@@ -6,7 +6,7 @@ class DeeplyNestedAssociatedRecordHasOneTest < IdentityCache::TestCase
     assert_nothing_raised do
       PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
       Deeply::Nested::AssociatedRecord.has_one(:polymorphic_record, as: 'owner')
-      Deeply::Nested::AssociatedRecord.cache_has_one(:polymorphic_record, inverse_name: :owner)
+      Deeply::Nested::AssociatedRecord.cache_has_one(:polymorphic_record, inverse_name: :owner, embed: true)
     end
   end
 

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -5,7 +5,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
   def setup
     super
     PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
-    Item.cache_has_one(:associated)
+    Item.cache_has_one(:associated, embed: true)
     Item.cache_index(:title, unique: true)
     @cached_attribute = Item.cache_indexes.last
     @record = Item.new(title: 'foo')

--- a/test/helpers/serialization_format.rb
+++ b/test/helpers/serialization_format.rb
@@ -4,7 +4,7 @@ module SerializationFormat
     AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
     AssociatedRecord.cache_belongs_to(:item)
     Item.cache_has_many(:associated_records, embed: true)
-    Item.cache_has_one(:associated)
+    Item.cache_has_one(:associated, embed: true)
     time = Time.parse('1970-01-01T00:00:00 UTC')
 
     record = Item.new(title: 'foo')

--- a/test/lazy_load_associated_classes_test.rb
+++ b/test/lazy_load_associated_classes_test.rb
@@ -14,7 +14,7 @@ class LazyLoadAssociatedClassesTest < IdentityCache::TestCase
 
   def test_cache_has_one_does_not_load_associated_class
     Item.has_one(:missing_model)
-    Item.cache_has_one(:missing_model)
+    Item.cache_has_one(:missing_model, embed: true)
   end
 
   def test_cache_invalidation

--- a/test/recursive_denormalized_has_many_test.rb
+++ b/test/recursive_denormalized_has_many_test.rb
@@ -6,7 +6,7 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
     super
     AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
     Item.cache_has_many(:associated_records, embed: true)
-    Item.cache_has_one(:associated)
+    Item.cache_has_one(:associated, embed: true)
 
     @record = Item.new(title: 'foo')
 


### PR DESCRIPTION
## Problem

`cache_has_many` and `cache_has_one` have different default values for the `embed` option.  `cache_has_many` defaults to `embed: :ids` and `cache_has_one` defaults to `embed: true`.

We have also run into performance problems from relying too much on embedding, since it can result in a lot of over-fetching from the cache which can cause performance problems for the cache.  It also makes it very easy for other code to rely on the association to be prefetched, which is coupling in the code that can be harder to remove later.

## Solution

Just changing the default to be consistent would significantly change the application and add performance problems that would be annoying to debug.  Just removing the default for `embed` option value for `cache_has_one` is much safer, forcing the application to specify the value explicitly and will allow us to safely add a new default in a later release.