### PR TITLE
Bump the minimum Active Record version to 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.6
 
 gemfile:
-  - gemfiles/Gemfile.rails50
+  - gemfiles/Gemfile.rails52
   - gemfiles/Gemfile.latest-release
   - gemfiles/Gemfile.rails-edge
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 1.0.0 Unreleased
 
+- Bump the minimum Active Record version to 5.2 (#438)
 - Remove the default embed option value from cache_has_one (#437)
 - Type cast values using attribute types before using in cache key (#354)
 - Remove support for rails 4.2 (#355)

--- a/gemfiles/Gemfile.latest-release
+++ b/gemfiles/Gemfile.latest-release
@@ -3,4 +3,4 @@ gemspec path: '..'
 
 gem 'activerecord'
 gem 'activesupport'
-gem "mysql2", ">= 0.4.4", "< 0.6.0"
+gem "mysql2", ">= 0.4.4"

--- a/gemfiles/Gemfile.rails50
+++ b/gemfiles/Gemfile.rails50
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-gemspec path: '..'
-
-gem 'activerecord', '~> 5.0.0'
-gem 'activesupport', '~> 5.0.0'
-gem 'mysql2', '>= 0.3.18', '< 0.5'

--- a/gemfiles/Gemfile.rails52
+++ b/gemfiles/Gemfile.rails52
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+gemspec path: '..'
+
+gem 'activerecord', '~> 5.2'
+gem 'activesupport', '~> 5.2'
+gem 'mysql2', '>= 0.4.4', '< 0.6.0'

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.4.0'
 
   gem.add_dependency('ar_transaction_changes', '~> 1.0')
-  gem.add_dependency('activerecord', '>= 5.0')
+  gem.add_dependency('activerecord', '>= 5.2')
 
   gem.add_development_dependency('memcached', '~> 1.8.0')
   gem.add_development_dependency('memcached_store', '~> 1.0.0')

--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -2,7 +2,7 @@
 require "test_helper"
 
 class SchemaChangeTest < IdentityCache::TestCase
-  Migration = ActiveRecord::Migration[5.0]
+  Migration = ActiveRecord::Migration[5.2]
 
   class AddColumnToChild < Migration
     def up

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,6 @@ require File.dirname(__FILE__) + '/../lib/identity_cache'
 
 DatabaseConnection.setup
 CacheConnection.setup
-ActiveSupport::Cache::Store.instrument = true if ActiveSupport.version < Gem::Version.new("4.2.0")
 
 # This patches AR::MemcacheStore to notify AS::Notifications upon read_multis like the rest of rails does
 module MemcachedStoreInstrumentation


### PR DESCRIPTION
## Problem

Identity Cache was specifying the minimum supported Active Record version to be 5.0, but that is [no longer supported upstream](https://guides.rubyonrails.org/maintenance_policy.html).

## Solution

Bump the minimum supported Active Record version to 5.2, since that is still receiving security fixes.  I've updated travis CI accordingly.  I've also removed a code path that was only relevant for an unsupported version of Active Support.