### PR TITLE
Remove inverse_name option. Specify inverse_of on the Active Record association instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 1.0.0 Unreleased
 
+- Remove inverse_name option. Specify inverse_of on the Active Record association instead. (#439)
 - Bump the minimum Active Record version to 5.2 (#438)
 - Remove the default embed option value from cache_has_one (#437)
 - Type cast values using attribute types before using in cache key (#354)

--- a/README.md
+++ b/README.md
@@ -144,24 +144,21 @@ With this code, on cache miss, the product and its associated images will be loa
 
 ### Caching Polymorphic Associations
 
-IdentityCache tries to figure out both sides of an association whenever it can so it can set those up when rebuilding the object from the cache. In some cases this is hard to determine so you can tell IdentityCache what the association should be. This is most often the case when embedding polymorphic associations. The `inverse_name` option on `cache_has_many` and `cache_has_one` lets you specify the inverse name of the association.
+IdentityCache tries to figure out both sides of an association whenever it can so it can set those up when rebuilding the object from the cache. In some cases this is hard to determine so you can tell IdentityCache what the association should be. This is most often the case when embedding polymorphic associations.
 
 ``` ruby
 class Metafield < ActiveRecord::Base
   include IdentityCache
-  belongs_to :owner, :polymorphic => true
+  belongs_to :owner, polymorphic: true
   cache_belongs_to :owner
 end
 
 class Product < ActiveRecord::Base
   include IdentityCache
-  has_many :metafields, :as => 'owner'
-  cache_has_many :metafields, :inverse_name => :owner
+  has_many :metafields, as: 'owner'
+  cache_has_many :metafields
 end
 ```
-
-The `:inverse_name => :owner` option tells IdentityCache what the association on the other side is named so that it can correctly set the assocation when loading the metafields from the cache.
-
 
 ### Caching Attributes
 
@@ -193,17 +190,13 @@ Example:
 Options:
 _[:embed]_ When true, specifies that the association should be included with the parent when caching. This means the associated objects will be loaded already when the parent is loaded from the cache and will not need to be fetched on their own. When :ids, only the id of the associated records will be included with the parent when caching. Defaults to `:ids`.
 
-_[:inverse_name]_ Specifies the name of parent object used by the association. This is useful for polymorphic associations when the association is often named something different between the parent and child objects.
-
 Example:
-`cache_has_many :metafields, :inverse_name => :owner, :embed => true`
+`cache_has_many :metafields, embed: true`
 
 #### cache_has_one
 
 Options:
 _[:embed]_ When true, specifies that the association should be included with the parent when caching. This means the associated objects will be loaded already when the parent is loaded from the cache and will not need to be fetched on their own. No other values are currently implemented. When :id, only the id of the associated record will be included with the parent when caching.
-
-_[:inverse_name]_ Specifies the name of parent object used by the association. This is useful for polymorphic associations when the association is often named something different between the parent and child objects.
 
 Example:
 `cache_has_one :configuration, embed: :id`

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ end
 
 class Product < ActiveRecord::Base
   include IdentityCache
-  has_many :metafields, as: 'owner'
+  has_many :metafields, as: :owner
   cache_has_many :metafields
 end
 ```

--- a/lib/identity_cache/cached/association.rb
+++ b/lib/identity_cache/cached/association.rb
@@ -76,10 +76,9 @@ module IdentityCache
         end
 
         unless child_class.reflect_on_association(inverse_name)
-          raise InverseAssociationError, <<~MSG.squish
-            Inverse name for association #{parent_class}\##{reflection.name} could
-            not be determined. Please use the :inverse_of option on the Active Record
-            association to specify the inverse association name.
+          raise InverseAssociationError, <<~MSG
+            Inverse name for association #{parent_class}\##{reflection.name} could not be determined.
+            Use the :inverse_of option on the Active Record association to specify the inverse association name.
           MSG
         end
       end

--- a/lib/identity_cache/cached/association.rb
+++ b/lib/identity_cache/cached/association.rb
@@ -4,10 +4,9 @@ module IdentityCache
     class Association # :nodoc:
       include EmbeddedFetching
 
-      def initialize(name, inverse_name:, reflection:)
+      def initialize(name, reflection:)
         @name = name
         @reflection = reflection
-        @inverse_name = inverse_name
         @cached_accessor_name = :"fetch_#{name}"
         @records_variable_name = :"@cached_#{name}"
       end
@@ -79,8 +78,8 @@ module IdentityCache
         unless child_class.reflect_on_association(inverse_name)
           raise InverseAssociationError, <<~MSG.squish
             Inverse name for association #{parent_class}\##{reflection.name} could
-            not be determined. Please use the :inverse_name option to specify
-            the inverse association name for this cache.
+            not be determined. Please use the :inverse_of option on the Active Record
+            association to specify the inverse association name.
           MSG
         end
       end

--- a/lib/identity_cache/cached/belongs_to.rb
+++ b/lib/identity_cache/cached/belongs_to.rb
@@ -2,10 +2,6 @@
 module IdentityCache
   module Cached
     class BelongsTo < Association # :nodoc:
-      def initialize(name, reflection:)
-        super(name, inverse_name: nil, reflection: reflection)
-      end
-
       attr_reader :records_variable_name
 
       def build

--- a/lib/identity_cache/cached/recursive/association.rb
+++ b/lib/identity_cache/cached/recursive/association.rb
@@ -3,7 +3,7 @@ module IdentityCache
   module Cached
     module Recursive
       class Association < Cached::Association # :nodoc:
-        def initialize(name, inverse_name:, reflection:)
+        def initialize(name, reflection:)
           super
           @dehydrated_variable_name = :"@dehydrated_#{name}"
         end

--- a/lib/identity_cache/cached/reference/has_many.rb
+++ b/lib/identity_cache/cached/reference/has_many.rb
@@ -3,7 +3,7 @@ module IdentityCache
   module Cached
     module Reference
       class HasMany < Association # :nodoc:
-        def initialize(name, inverse_name:, reflection:)
+        def initialize(name, reflection:)
           super
           @cached_ids_name = "fetch_#{ids_name}"
           @ids_variable_name = :"@#{ids_cached_reader_name}"

--- a/lib/identity_cache/cached/reference/has_one.rb
+++ b/lib/identity_cache/cached/reference/has_one.rb
@@ -3,7 +3,7 @@ module IdentityCache
   module Cached
     module Reference
       class HasOne < Association # :nodoc:
-        def initialize(name, inverse_name:, reflection:)
+        def initialize(name, reflection:)
           super
           @cached_id_name = "fetch_#{id_name}"
           @id_variable_name = :"@#{id_cached_reader_name}"

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -27,10 +27,8 @@ module IdentityCache
       #     include IdentityCache
       #     has_many :options
       #     has_many :orders
-      #     has_many :buyers
       #     cache_has_many :options, embed: :ids
       #     cache_has_many :orders
-      #     cache_has_many :buyers, inverse_name: 'line_item'
       #   end
       #
       # == Parameters
@@ -43,9 +41,7 @@ module IdentityCache
       #   associations for the associated record recursively.
       #   If `:ids` (the default), it will only embed the ids for the associated
       #   records.
-      # * inverse_name: The name of the parent in the association if the name is
-      #   not the lowercase pluralization of the parent object's class
-      def cache_has_many(association, embed: :ids, inverse_name: nil)
+      def cache_has_many(association, embed: :ids)
         ensure_base_model
         check_association_for_caching(association)
         reflection = reflect_on_association(association)
@@ -61,7 +57,6 @@ module IdentityCache
         cached_has_manys[association] = association_class.new(
           association,
           reflection: reflection,
-          inverse_name: inverse_name,
         ).tap(&:build)
       end
 
@@ -84,10 +79,7 @@ module IdentityCache
       #   in the cache entries for this model, as well as all the embedded
       #   associations for the associated record recursively.
       #   If `:id`, it will only embed the id for the associated record.
-      # * inverse_name: The name of the parent in the association ( only
-      #   necessary if the name is not the lowercase pluralization of the
-      #   parent object's class)
-      def cache_has_one(association, embed:, inverse_name: nil)
+      def cache_has_one(association, embed:)
         ensure_base_model
         check_association_for_caching(association)
         reflection = reflect_on_association(association)
@@ -103,7 +95,6 @@ module IdentityCache
         cached_has_ones[association] = association_class.new(
           association,
           reflection: reflection,
-          inverse_name: inverse_name,
         ).tap(&:build)
       end
 

--- a/test/cache_fetch_includes_test.rb
+++ b/test/cache_fetch_includes_test.rb
@@ -35,7 +35,7 @@ class CacheFetchIncludesTest < IdentityCache::TestCase
   def test_multiple_cached_associations_and_child_associations_are_included_in_includes
     Item.send(:cache_has_many, :associated_records, embed: true)
     PolymorphicRecord.send(:include, IdentityCache::WithoutPrimaryIndex)
-    Item.send(:cache_has_many, :polymorphic_records, inverse_name: :owner, embed: true)
+    Item.send(:cache_has_many, :polymorphic_records, embed: true)
     Item.send(:cache_has_one, :associated, embed: true)
     AssociatedRecord.send(:cache_has_many, :deeply_associated_records, embed: true)
     assert_equal([

--- a/test/cached/association_test.rb
+++ b/test/cached/association_test.rb
@@ -7,11 +7,7 @@ module IdentityCache
       def setup
         super
         @reflection = reflect(AssociatedRecord, :item)
-        @association = Association.new(
-          :item,
-          inverse_name: :associated_record,
-          reflection: @reflection
-        )
+        @association = Association.new(:item, reflection: @reflection)
       end
 
       attr_reader :reflection, :association
@@ -21,7 +17,10 @@ module IdentityCache
       end
 
       def test_inverse_name
-        assert_equal(:associated_record, association.inverse_name)
+        reflection = reflect(Item, :associated_records)
+        association = Association.new(:associated_records, reflection: reflection)
+
+        assert_equal(:item, association.inverse_name)
       end
 
       def test_reflection

--- a/test/cached/recursive/has_many_test.rb
+++ b/test/cached/recursive/has_many_test.rb
@@ -8,11 +8,7 @@ module IdentityCache
         def setup
           super
           @reflection = reflect(AssociatedRecord, :deeply_associated_records)
-          @has_many = HasMany.new(
-            :deeply_associated_records,
-            inverse_name: :associated_record,
-            reflection: @reflection
-          )
+          @has_many = HasMany.new(:deeply_associated_records, reflection: @reflection)
         end
 
         attr_reader :reflection, :has_many

--- a/test/cached/recursive/has_one_test.rb
+++ b/test/cached/recursive/has_one_test.rb
@@ -8,11 +8,7 @@ module IdentityCache
         def setup
           super
           @reflection = reflect(AssociatedRecord, :deeply_associated)
-          @has_one = HasMany.new(
-            :deeply_associated,
-            inverse_name: :associated_record,
-            reflection: @reflection
-          )
+          @has_one = HasMany.new(:deeply_associated, reflection: @reflection)
         end
 
         attr_reader :reflection, :has_one

--- a/test/cached/reference/has_many_test.rb
+++ b/test/cached/reference/has_many_test.rb
@@ -8,11 +8,7 @@ module IdentityCache
         def setup
           super
           @reflection = reflect(AssociatedRecord, :deeply_associated_records)
-          @has_many = HasMany.new(
-            :deeply_associated_records,
-            inverse_name: :associated_record,
-            reflection: @reflection
-          )
+          @has_many = HasMany.new(:deeply_associated_records, reflection: @reflection)
         end
 
         attr_reader :reflection, :has_many

--- a/test/cached/reference/has_one_test.rb
+++ b/test/cached/reference/has_one_test.rb
@@ -8,11 +8,7 @@ module IdentityCache
         def setup
           super
           @reflection = reflect(AssociatedRecord, :deeply_associated)
-          @has_one = HasOne.new(
-            :deeply_associated,
-            inverse_name: :associated_record,
-            reflection: @reflection
-          )
+          @has_one = HasOne.new(:deeply_associated, reflection: @reflection)
         end
 
         attr_reader :reflection, :has_one

--- a/test/deeply_nested_associated_record_test.rb
+++ b/test/deeply_nested_associated_record_test.rb
@@ -6,7 +6,7 @@ class DeeplyNestedAssociatedRecordHasOneTest < IdentityCache::TestCase
     assert_nothing_raised do
       PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
       Deeply::Nested::AssociatedRecord.has_one(:polymorphic_record, as: 'owner')
-      Deeply::Nested::AssociatedRecord.cache_has_one(:polymorphic_record, inverse_name: :owner, embed: true)
+      Deeply::Nested::AssociatedRecord.cache_has_one(:polymorphic_record, embed: true)
     end
   end
 
@@ -14,7 +14,7 @@ class DeeplyNestedAssociatedRecordHasOneTest < IdentityCache::TestCase
     assert_nothing_raised do
       PolymorphicRecord.include(IdentityCache)
       Deeply::Nested::AssociatedRecord.has_many(:polymorphic_records, as: 'owner')
-      Deeply::Nested::AssociatedRecord.cache_has_many(:polymorphic_records, inverse_name: :owner)
+      Deeply::Nested::AssociatedRecord.cache_has_many(:polymorphic_records)
     end
   end
 end

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -100,10 +100,11 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
   end
 
   def test_cache_association_known_inverse_raises
-    assert_raises IdentityCache::InverseAssociationError do
+    exc = assert_raises IdentityCache::InverseAssociationError do
       Item.cache_has_many(:no_inverse_of_records, embed: true)
       IdentityCache.eager_load!
     end
+    assert_match(/\AInverse name for association Item#no_inverse_of_records could not be determined./, exc.message)
   end
 
   def test_cache_uses_inverse_of_on_association

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -99,16 +99,9 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     assert_nothing_raised { ar.expire_parent_caches }
   end
 
-  def test_cache_without_guessable_inverse_name_raises
+  def test_cache_association_known_inverse_raises
     assert_raises IdentityCache::InverseAssociationError do
       Item.cache_has_many(:no_inverse_of_records, embed: true)
-      IdentityCache.eager_load!
-    end
-  end
-
-  def test_cache_without_guessable_inverse_name_does_not_raise_when_inverse_name_specified
-    assert_nothing_raised do
-      Item.cache_has_many(:no_inverse_of_records, inverse_name: :owner, embed: true)
       IdentityCache.eager_load!
     end
   end
@@ -213,7 +206,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
 
     def test_cache_has_many_on_derived_model_raises
       assert_raises(IdentityCache::DerivedModelError) do
-        StiRecordTypeA.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: true)
+        StiRecordTypeA.cache_has_many(:polymorphic_records, embed: true)
       end
     end
   end

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -146,16 +146,9 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     end
   end
 
-  def test_cache_without_guessable_inverse_name_raises
+  def test_cache_association_known_inverse_raises
     assert_raises IdentityCache::InverseAssociationError do
       Item.cache_has_one(:no_inverse_of_record, embed: true)
-      IdentityCache.eager_load!
-    end
-  end
-
-  def test_cache_without_guessable_inverse_name_does_not_raise_when_inverse_name_specified
-    assert_nothing_raised do
-      Item.cache_has_one(:no_inverse_of_record, inverse_name: :owner, embed: true)
       IdentityCache.eager_load!
     end
   end
@@ -169,7 +162,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
 
   def test_cache_has_one_on_derived_model_raises
     assert_raises(IdentityCache::DerivedModelError) do
-      StiRecordTypeA.cache_has_one(:polymorphic_record, inverse_name: :owner, embed: true)
+      StiRecordTypeA.cache_has_one(:polymorphic_record, embed: true)
     end
   end
 

--- a/test/expiry_hook_test.rb
+++ b/test/expiry_hook_test.rb
@@ -41,7 +41,6 @@ module IdentityCache
     def reference_cached_association
       @reference_assocaition ||= Cached::Reference::HasMany.new(
         :deeply_associated_records,
-        inverse_name: :associated_record,
         reflection: reflect(AssociatedRecord, :deeply_associated_records),
       )
     end
@@ -49,7 +48,6 @@ module IdentityCache
     def recursive_cached_association
       @recursive_association ||= Cached::Recursive::HasMany.new(
         :deeply_associated_records,
-        inverse_name: :associated_record,
         reflection: reflect(AssociatedRecord, :deeply_associated_records),
       )
     end

--- a/test/helpers/models.rb
+++ b/test/helpers/models.rb
@@ -57,7 +57,7 @@ class Item < ActiveRecord::Base
   has_many :deeply_associated_records, inverse_of: :item
   has_many :normalized_associated_records
   has_many :not_cached_records
-  has_many :polymorphic_records, as: 'owner'
+  has_many :polymorphic_records, as: 'owner', inverse_of: :owner
   has_many :no_inverse_of_records
   has_one :polymorphic_record, as: 'owner'
   has_one :associated, class_name: 'AssociatedRecord'
@@ -68,7 +68,7 @@ end
 class ItemTwo < ActiveRecord::Base
   include IdentityCache
   has_many :associated_records, inverse_of: :item_two, foreign_key: :item_two_id
-  has_many :polymorphic_records, as: 'owner'
+  has_many :polymorphic_records, as: 'owner', inverse_of: :owner
   self.table_name = 'items2'
 end
 
@@ -79,7 +79,7 @@ end
 
 class StiRecord < ActiveRecord::Base
   include IdentityCache
-  has_many :polymorphic_records, as: 'owner'
+  has_many :polymorphic_records, as: 'owner', inverse_of: :owner
 end
 
 class StiRecordTypeA < StiRecord

--- a/test/polymorphic_has_many_test.rb
+++ b/test/polymorphic_has_many_test.rb
@@ -6,8 +6,8 @@ class PolymorphicHasManyTest < IdentityCache::TestCase
     super
     PolymorphicRecord.include(IdentityCache)
 
-    Item.cache_has_many(:polymorphic_records, inverse_name: :owner)
-    ItemTwo.cache_has_many(:polymorphic_records, inverse_name: :owner)
+    Item.cache_has_many(:polymorphic_records)
+    ItemTwo.cache_has_many(:polymorphic_records)
   end
 
   def test_polymorphic_has_many_filters_by_type

--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -79,7 +79,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     Item.fetch(@record.id)
 
     PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
-    Item.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: true)
+    Item.cache_has_many(:polymorphic_records, embed: true)
     read_new_schema
 
     Item.cached_primary_index.expects(:load_one_from_db).returns(@record)
@@ -88,7 +88,7 @@ class SchemaChangeTest < IdentityCache::TestCase
 
   def test_embed_existing_cache_has_many
     PolymorphicRecord.include(IdentityCache)
-    Item.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: :ids)
+    Item.cache_has_many(:polymorphic_records, embed: :ids)
     read_new_schema
 
     Item.fetch(@record.id)
@@ -97,7 +97,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     setup_models
 
     PolymorphicRecord.include(IdentityCache::WithoutPrimaryIndex)
-    Item.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: true)
+    Item.cache_has_many(:polymorphic_records, embed: true)
     read_new_schema
 
     Item.fetch(@record.id)
@@ -148,7 +148,7 @@ class SchemaChangeTest < IdentityCache::TestCase
     PolymorphicRecord.include(IdentityCache)
     Item.fetch(@record.id)
 
-    Item.cache_has_many(:polymorphic_records, inverse_name: :owner, embed: :ids)
+    Item.cache_has_many(:polymorphic_records, embed: :ids)
     read_new_schema
 
     Item.fetch(@record.id)


### PR DESCRIPTION
## Problem

The `inverse_name` option to the `cache_has_*` methods is redundant now that the name can be specified on the active record association.  I think we added it back before that could be done.  After adding the ability to infer the inverse association from the active record association in https://github.com/Shopify/identity_cache/pull/223, I had updated Shopify to remove the use of `inverse_name`, but I think I had only left it in Identity Cache for backwards compatibility reasons.  I probably should have deprecated it at that point.

## Solution

Remove the `inverse_name` cache association option before making the 1.0 release.