### PR TITLE
Prepare version 1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # IdentityCache changelog
 
+#### 1.0.1
+
+- Fix expiry of cache_has_one association with scope and `embed: :id` (#442)
+
 #### 1.0.0
 
 - Remove inverse_name option. Specify inverse_of on the Active Record association instead. (#439)

--- a/lib/identity_cache/version.rb
+++ b/lib/identity_cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module IdentityCache
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
   CACHE_VERSION = 8
 end


### PR DESCRIPTION
I think the fix for https://github.com/Shopify/identity_cache/pull/442 is important enough that we should make a bug fix release.