### PR TITLE
Remove broken conflict benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,5 @@ script:
 
 cache: bundler
 
-matrix:
-  exclude:
-    - rvm: 2.2.6
-      gemfile: gemfiles/Gemfile.rails-edge
-
 notifications:
   email: false


### PR DESCRIPTION
## Problem

I was trying to run our benchmarks, since I wanted to make sure recent refactors didn't cause a performance regression.  However, it looks like they got broken because they were doing some monkey patching of the private `resolve_cache_miss` method that got removed in the refactor.

Running `dev benchmark-cpu` resulted in this error in the output

```
FetchEmbedConflictRunner:             /Users/dylansmith/src/identity_cache/performance/cache_runner.rb:114:in `method': undefined method `resolve_cache_miss' for class `#<Class:0x007fcf86b92460>' (NameError)
	from /Users/dylansmith/src/identity_cache/performance/cache_runner.rb:114:in `prepare'
	from ./performance/cpu.rb:14:in `run'
	from ./performance/cpu.rb:27:in `block in benchmark'
	from ./performance/cpu.rb:25:in `each'
	from ./performance/cpu.rb:25:in `benchmark'
	from ./performance/cpu.rb:36:in `bmbm'
	from ./performance/cpu.rb:44:in `<main>'
```

## Solution

I just removed these conflict benchmarks, since the only difference they have is that they cause the `cas` or `add` memcached operations to fail, but identity cache doesn't have any code conditional on whether or not these operations succeed.  As such, it was only really benchmarking dependencies of identity cache.