### PR TITLE
Fix fetch has_many id embedded association after adding to it

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: identity-cache
 up:
   - homebrew:
     - postgresql
-  - ruby: 2.4.1
+  - ruby: 2.4.10
   - railgun
   - bundler
 

--- a/lib/identity_cache/cached/reference/has_many.rb
+++ b/lib/identity_cache/cached/reference/has_many.rb
@@ -20,8 +20,8 @@ module IdentityCache
             end
 
             def #{cached_accessor_name}
-              association_klass = association(:#{name}).klass
-              if association_klass.should_use_cache? && !#{name}.loaded?
+              assoc = association(:#{name})
+              if assoc.klass.should_use_cache? && !assoc.loaded? && assoc.target.blank?
                 #{records_variable_name} ||= #{reflection.class_name}.fetch_multi(#{cached_ids_name})
               else
                 #{name}.to_a

--- a/lib/identity_cache/cached/reference/has_one.rb
+++ b/lib/identity_cache/cached/reference/has_one.rb
@@ -21,8 +21,8 @@ module IdentityCache
             end
 
             def #{cached_accessor_name}
-              association_klass = association(:#{name}).klass
-              if association_klass.should_use_cache? && !association(:#{name}).loaded?
+              assoc = association(:#{name})
+              if assoc.klass.should_use_cache? && !assoc.loaded?
                 #{records_variable_name} ||= #{reflection.class_name}.fetch(#{cached_id_name}) if #{cached_id_name}
               else
                 #{name}

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -168,7 +168,7 @@ module IdentityCache
     def fetch_recursively_cached_association(ivar_name, dehydrated_ivar_name, association_name) # :nodoc:
       assoc = association(association_name)
 
-      if assoc.klass.should_use_cache? && !assoc.loaded?
+      if assoc.klass.should_use_cache? && !assoc.loaded? && assoc.target.blank?
         if instance_variable_defined?(ivar_name)
           instance_variable_get(ivar_name)
         elsif instance_variable_defined?(dehydrated_ivar_name)

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -180,6 +180,13 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     end
   end
 
+  def test_fetch_association_after_adding_to_it
+    item = Item.fetch(@record.id)
+    item.associated_records.create!(name: 'foo')
+    fetched_associated_records = item.fetch_associated_records
+    assert_equal(item.associated_records.length, fetched_associated_records.length)
+  end
+
   class CheckAssociationTest < IdentityCache::TestCase
     def test_unsupported_through_assocation
       assert_raises IdentityCache::UnsupportedAssociationError, "caching through associations isn't supported" do

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -244,4 +244,11 @@ class NormalizedHasManyTest < IdentityCache::TestCase
       end
     end
   end
+
+  def test_fetch_association_after_adding_to_it
+    item = Item.fetch(@record.id)
+    item.associated_records.create!(name: 'foo')
+    fetched_associated_records = item.fetch_associated_records
+    assert_equal(item.associated_records.length, fetched_associated_records.length)
+  end
 end

--- a/test/prefetch_associations_test.rb
+++ b/test/prefetch_associations_test.rb
@@ -134,7 +134,7 @@ module IdentityCache
 
       setup_has_many_children_and_grandchildren(@bob)
 
-      associated_records = @bob.associated_records
+      associated_records = Item.find(@bob.id).associated_records
 
       assert_queries(1) do
         assert_memcache_operations(1) do


### PR DESCRIPTION
cc @mgingras

## Problem

The problem is shown well from the added regression test on a `cache_has_many` `embed: :ids` association

```ruby
    item.associated_records.create!(name: 'foo')
    fetched_associated_records = item.fetch_associated_records
    assert_equal(item.associated_records.length, fetched_associated_records.length)
```

which results in the failure

```
  1) Failure:
NormalizedHasManyTest#test_fetch_association_after_adding_to_it [test/normalized_has_many_test.rb:252]:
Expected: 3
  Actual: 2
```

without the included fix to the code under test.

## Solution

I looked at how Active Record distinguishes between loaded associations and unloaded associations with records added to it and found it checks for this with [`elsif !target.empty?`](https://github.com/rails/rails/blob/v6.0.2.2/activerecord/lib/active_record/associations/collection_association.rb#L48).  I decided to use a similar check, although used `blank?` so that we don't assume that `target` will continue to be initialized to `[]` for an unloaded association.