### PR TITLE
Fix should_use_cache check to avoid calling it on the wrong class.

### DIFF
--- a/lib/identity_cache/cached/prefetcher.rb
+++ b/lib/identity_cache/cached/prefetcher.rb
@@ -37,7 +37,7 @@ module IdentityCache
         private
 
         def fetch_association(load_strategy, klass, association, records, &block)
-          unless records.first.class.should_use_cache?
+          unless klass.should_use_cache?
             ActiveRecord::Associations::Preloader.new.preload(records, association)
             return yield
           end


### PR DESCRIPTION
## Problem

We should try to avoid making assumptions that all the records are of the same class in the association prefetcher, since that may not be the case with single table inheritance.  However, in one place we were still doing `records.first.class`.

## Solution

Use the class that is already passed into the method that was calling `records.first.class`.  This way we avoid an edge case that could otherwise cause a problem.