### PR TITLE
Move QueryAPI methods to the embedded association class

### DIFF
--- a/lib/identity_cache/cached/belongs_to.rb
+++ b/lib/identity_cache/cached/belongs_to.rb
@@ -27,6 +27,10 @@ module IdentityCache
         end
       end
 
+      def write(owner_record, associated_record)
+        owner_record.instance_variable_set(records_variable_name, associated_record)
+      end
+
       def fetch(records)
         fetch_async(LoadStrategy::Eager, records) { |associated_records| associated_records }
       end
@@ -53,7 +57,7 @@ module IdentityCache
               associated_records.keys.each do |id, associated_record|
                 owner_record = cache_keys_to_associated_ids.fetch(cache_key).fetch(id)
                 batch_records << owner_record
-                owner_record.instance_variable_set(records_variable_name, associated_record)
+                write(owner_record, associated_record)
               end
             end
 
@@ -73,7 +77,7 @@ module IdentityCache
           ) do |associated_records_by_id|
             associated_records_by_id.each do |id, associated_record|
               owner_record = ids_to_owner_record.fetch(id)
-              owner_record.instance_variable_set(records_variable_name, associated_record)
+              write(owner_record, associated_record)
             end
 
             yield associated_records_by_id.values.compact

--- a/lib/identity_cache/cached/recursive/association.rb
+++ b/lib/identity_cache/cached/recursive/association.rb
@@ -15,22 +15,37 @@ module IdentityCache
 
           model = reflection.active_record
           model.send(:define_method, cached_accessor_name) do
-            fetch_recursively_cached_association(
-              cached_association.records_variable_name,
-              cached_association.dehydrated_variable_name,
-              cached_association.name
-            )
+            cached_association.read(self)
           end
 
           ParentModelExpiration.add_parent_expiry_hook(self)
         end
 
         def read(record)
-          record.public_send(cached_accessor_name)
+          assoc = record.association(name)
+
+          if assoc.klass.should_use_cache? && !assoc.loaded? && assoc.target.blank?
+            if record.instance_variable_defined?(records_variable_name)
+              record.instance_variable_get(records_variable_name)
+            elsif record.instance_variable_defined?(dehydrated_variable_name)
+              association_target = hydrate_association_target(assoc.klass, record.instance_variable_get(dehydrated_variable_name))
+              record.remove_instance_variable(dehydrated_variable_name)
+              set_with_inverse(record, association_target)
+            else
+              assoc.load_target
+            end
+          else
+            assoc.load_target
+          end
         end
 
-        def write(record, records)
-          record.instance_variable_set(records_variable_name, records)
+        def write(record, association_target)
+          record.instance_variable_set(records_variable_name, association_target)
+        end
+
+        def set_with_inverse(record, association_target)
+          set_inverse(record, association_target)
+          write(record, association_target)
         end
 
         def clear(record)
@@ -58,6 +73,30 @@ module IdentityCache
         end
 
         private
+
+        def set_inverse(record, association_target)
+          return if association_target.nil?
+          associated_class = reflection.klass
+          inverse_cached_association = associated_class.cached_belongs_tos[inverse_name]
+          return unless inverse_cached_association
+
+          if association_target.is_a?(Array)
+            association_target.each do |child_record|
+              inverse_cached_association.write(child_record, record)
+            end
+          else
+            inverse_cached_association.write(association_target, record)
+          end
+        end
+
+        def hydrate_association_target(associated_class, dehydrated_value)
+          dehydrated_value = IdentityCache.unmap_cached_nil_for(dehydrated_value)
+          if dehydrated_value.is_a?(Array)
+            dehydrated_value.map { |coder| Encoder.decode(coder, associated_class) }
+          else
+            Encoder.decode(dehydrated_value, associated_class)
+          end
+        end
 
         def embedded_fetched?(records)
           record = records.first

--- a/lib/identity_cache/cached/recursive/association.rb
+++ b/lib/identity_cache/cached/recursive/association.rb
@@ -11,15 +11,16 @@ module IdentityCache
         attr_reader :dehydrated_variable_name
 
         def build
-          reflection.active_record.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-            def #{cached_accessor_name}
-              fetch_recursively_cached_association(
-                :#{records_variable_name},
-                :#{dehydrated_variable_name},
-                :#{name}
-              )
-            end
-          RUBY
+          cached_association = self
+
+          model = reflection.active_record
+          model.send(:define_method, cached_accessor_name) do
+            fetch_recursively_cached_association(
+              cached_association.records_variable_name,
+              cached_association.dehydrated_variable_name,
+              cached_association.name
+            )
+          end
 
           ParentModelExpiration.add_parent_expiry_hook(self)
         end

--- a/lib/identity_cache/cached/recursive/association.rb
+++ b/lib/identity_cache/cached/recursive/association.rb
@@ -28,7 +28,8 @@ module IdentityCache
             if record.instance_variable_defined?(records_variable_name)
               record.instance_variable_get(records_variable_name)
             elsif record.instance_variable_defined?(dehydrated_variable_name)
-              association_target = hydrate_association_target(assoc.klass, record.instance_variable_get(dehydrated_variable_name))
+              dehydrated_target = record.instance_variable_get(dehydrated_variable_name)
+              association_target = hydrate_association_target(assoc.klass, dehydrated_target)
               record.remove_instance_variable(dehydrated_variable_name)
               set_with_inverse(record, association_target)
             else


### PR DESCRIPTION
## Problem

IdentityCache::QueryAPI still has a bunch of methods that could be better co-located with the cached association/index classes that we extracted into the IdentityCache::Cached namespace.

## Solution

The following methods were moved to lib/identity_cache/cached/recursive/association.rb:
* fetch_recursively_cached_association (inlined into the `read` method)
* hydrate_association_target
* set_embedded_association (renamed to `set_with_inverse`)
* set_inverse_of_cached_association (renamed to `set_inverse`)

I also replaced some direct instance variable sets to calls to `write`, which I had to add to the belongs_to association so that it set its own instance variable.