### PR TITLE
Stop passing the column to Connection#type_cast

### DIFF
--- a/lib/identity_cache/cached/primary_index.rb
+++ b/lib/identity_cache/cached/primary_index.rb
@@ -60,7 +60,6 @@ module IdentityCache
       def load_multi_from_db(ids)
         return {} if ids.empty?
 
-        ids = ids.map { |id| model.connection.type_cast(id, id_column) }
         records = build_query(ids).to_a
         model.send(:setup_embedded_associations_on_miss, records)
         records.index_by(&:id)

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -211,14 +211,6 @@ class FetchMultiTest < IdentityCache::TestCase
     assert_equal([@joe, @bob, @joe], Item.fetch_multi(@joe.id, @bob.id, @joe.id))
   end
 
-  def test_load_multi_from_db_coerces_ids_to_primary_key_type
-    mock_relation = mock("ActiveRecord::Relation")
-    Item.expects(:where).returns(mock_relation)
-    mock_relation.expects(:includes).returns(stub(to_a: [@bob, @joe, @fred]))
-
-    Item.cached_primary_index.send(:load_multi_from_db, [@bob, @joe, @fred].map(&:id).map(&:to_s))
-  end
-
   def test_fetch_multi_doesnt_freeze_keys
     cache_response = {}
     cache_response[@bob_blob_key] = cache_response_for(@bob)

--- a/test/prefetch_associations_test.rb
+++ b/test/prefetch_associations_test.rb
@@ -372,14 +372,6 @@ module IdentityCache
       end
     end
 
-    def test_load_multi_from_db_coerces_ids_to_primary_key_type
-      mock_relation = mock("ActiveRecord::Relation")
-      Item.expects(:where).returns(mock_relation)
-      mock_relation.expects(:includes).returns(stub(to_a: [@bob, @joe, @fred]))
-
-      Item.cached_primary_index.send(:load_multi_from_db, [@bob, @joe, @fred].map(&:id).map(&:to_s))
-    end
-
     def test_fetch_by_index_with_includes_option
       Item.send(:cache_belongs_to, :item)
       Item.cache_index(:title)


### PR DESCRIPTION
That's deprecated since https://github.com/rails/rails/pull/39106

