### PR TITLE
Fix broken prefetch_associations of a polymorphic cache_belongs_to

### DIFF
--- a/lib/identity_cache/cached/belongs_to.rb
+++ b/lib/identity_cache/cached/belongs_to.rb
@@ -37,28 +37,30 @@ module IdentityCache
 
       def fetch_async(load_strategy, records)
         if reflection.polymorphic?
-          cache_keys_to_associated_ids = {}
+          type_fetcher_to_db_ids_hash = {}
 
           records.each do |owner_record|
             associated_id = owner_record.send(reflection.foreign_key)
             next unless associated_id && !owner_record.instance_variable_defined?(records_variable_name)
-            associated_cache_key = Object.const_get(
+            foreign_type_fetcher = Object.const_get(
               owner_record.send(reflection.foreign_type)
             ).cached_model.cached_primary_index
-            unless cache_keys_to_associated_ids[associated_cache_key]
-              cache_keys_to_associated_ids[associated_cache_key] = {}
-            end
-            cache_keys_to_associated_ids[associated_cache_key][associated_id] = owner_record
+            (type_fetcher_to_db_ids_hash[foreign_type_fetcher] ||= []) << associated_id
           end
 
-          load_strategy.load_batch(cache_keys_to_associated_ids) do |associated_records_by_cache_key|
+          load_strategy.load_batch(type_fetcher_to_db_ids_hash) do |batch_load_result|
             batch_records = []
-            associated_records_by_cache_key.each do |cache_key, associated_records|
-              associated_records.keys.each do |id, associated_record|
-                owner_record = cache_keys_to_associated_ids.fetch(cache_key).fetch(id)
-                batch_records << owner_record
-                write(owner_record, associated_record)
-              end
+
+            records.each do |owner_record|
+              associated_id = owner_record.send(reflection.foreign_key)
+              next unless associated_id && !owner_record.instance_variable_defined?(records_variable_name)
+              foreign_type_fetcher = Object.const_get(
+                owner_record.send(reflection.foreign_type)
+              ).cached_model.cached_primary_index
+
+              associated_record = batch_load_result.fetch(foreign_type_fetcher).fetch(associated_id)
+              batch_records << owner_record
+              write(owner_record, associated_record)
             end
 
             yield batch_records

--- a/lib/identity_cache/cached/belongs_to.rb
+++ b/lib/identity_cache/cached/belongs_to.rb
@@ -45,7 +45,8 @@ module IdentityCache
             foreign_type_fetcher = Object.const_get(
               owner_record.send(reflection.foreign_type)
             ).cached_model.cached_primary_index
-            (type_fetcher_to_db_ids_hash[foreign_type_fetcher] ||= []) << associated_id
+            db_ids = type_fetcher_to_db_ids_hash[foreign_type_fetcher] ||= []
+            db_ids << associated_id
           end
 
           load_strategy.load_batch(type_fetcher_to_db_ids_hash) do |batch_load_result|


### PR DESCRIPTION
cc @casperisfine 

## Problem

We noticed a weird test failure in https://github.com/Shopify/identity_cache/pull/459 which turned out to be a problem with the implementation of `prefetch_associations` for a  polymorphic cache_belongs_to.  It seemed to be making incorrect assumptions of what the `load_batch` load strategy method is supposed to be given as an input, where it was passing a nested hash when it was only supposed to be a single hash.

I changed the failing tests, that were just asserting on the number of queries performed, to actually assert on the result of the prefetch.  This resulted in the following test failures without the corresponding fix:

```
  1) Failure:
FetchMultiTest#test_fetch_multi_with_polymorphic_has_one [test/fetch_multi_test.rb:304]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<Item id: 4, item_id: nil, title: nil, created_at: "2020-05-05 14:35:54", updated_at: "2020-05-05 14:35:54">, #<ItemTwo id: 1, item_id: nil, title: nil, created_at: "2020-05-05 14:35:54", updated_at: "2020-05-05 14:35:54">]
+[#<PolymorphicRecord id: 1, owner_type: "Item", owner_id: 4, created_at: "2020-05-05 14:35:54", updated_at: "2020-05-05 14:35:54">, #<PolymorphicRecord id: 2, owner_type: "ItemTwo", owner_id: 1, created_at: "2020-05-05 14:35:54", updated_at: "2020-05-05 14:35:54">]


  2) Failure:
FetchMultiTest#test_fetch_multi_with_polymorphic_has_many [test/fetch_multi_test.rb:322]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<Item id: 4, item_id: nil, title: nil, created_at: "2020-05-05 14:35:54", updated_at: "2020-05-05 14:35:54">, #<Item id: 4, item_id: nil, title: nil, created_at: "2020-05-05 14:35:54", updated_at: "2020-05-05 14:35:54">, #<ItemTwo id: 1, item_id: nil, title: nil, created_at: "2020-05-05 14:35:54", updated_at: "2020-05-05 14:35:54">]
+[#<Item id: 4, item_id: nil, title: nil, created_at: "2020-05-05 14:35:54", updated_at: "2020-05-05 14:35:54">, #<PolymorphicRecord id: 2, owner_type: "Item", owner_id: 4, created_at: "2020-05-05 14:35:54", updated_at: "2020-05-05 14:35:54">, #<PolymorphicRecord id: 3, owner_type: "ItemTwo", owner_id: 1, created_at: "2020-05-05 14:35:54", updated_at: "2020-05-05 14:35:54">]
```

## Solution

Fix the argument to `load_strategy.load_batch`.  This meant also changing the code handling the result of that call, since it was previously relying on it holding the owner record.  I also changed some variable names, since they seemed confusing (e.g. calling a cache fetching a cache key).