### PR TITLE
Only expire the cache when the record has changed, or it is forced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 .rubocop-http*
+.byebug_history

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -2,6 +2,7 @@
 module IdentityCache
   module QueryAPI
     extend ActiveSupport::Concern
+    include ArTransactionChanges
 
     included do |base|
       base.after_commit(:expire_cache)
@@ -153,8 +154,8 @@ module IdentityCache
     end
 
     # Invalidate the cache data associated with the record.
-    def expire_cache
-      expire_attribute_indexes
+    def expire_cache(force: false)
+      expire_attribute_indexes if force || transaction_changed_attributes.any? || destroyed?
       true
     end
 

--- a/lib/identity_cache/with_primary_index.rb
+++ b/lib/identity_cache/with_primary_index.rb
@@ -5,9 +5,9 @@ module IdentityCache
 
     include WithoutPrimaryIndex
 
-    def expire_cache
-      expire_primary_index
-      super
+    def expire_cache(force: false)
+      expire_primary_index if force || transaction_changed_attributes.any? || destroyed?
+      super(force: force)
     end
 
     # @api private

--- a/test/attribute_cache_test.rb
+++ b/test/attribute_cache_test.rb
@@ -39,13 +39,13 @@ class AttributeCacheTest < IdentityCache::TestCase
     end
   end
 
-  def test_cached_attribute_values_are_expired_from_the_cache_when_an_existing_record_is_saved
+  def test_cached_attribute_values_are_not_expired_from_the_cache_when_an_existing_record_is_saved_with_no_changes
     assert_queries(1) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
     assert_queries(0) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
-
+    
     @record.save!
 
-    assert_queries(1) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
+    assert_queries(0) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
   end
 
   def test_cached_attribute_values_are_expired_from_the_cache_when_an_existing_record_with_changed_attributes_is_saved

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -77,7 +77,10 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
 
     IdentityCache.cache.expects(:delete).with(@record.associated_records.first.primary_cache_index_key)
     IdentityCache.cache.expects(:delete).with(key)
-    @record.associated_records.first.save
+    
+    first_associated = @record.associated_records.first
+    first_associated.name = 'foobar'
+    first_associated.save
   end
 
   def test_changes_in_associated_records_foreign_keys_should_expire_new_parent_and_old_parents_cache
@@ -117,6 +120,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     child = @record.associated_records.first
     IdentityCache.cache.expects(:delete).with(child.primary_cache_index_key).once
     IdentityCache.cache.expects(:delete).with(@record.primary_cache_index_key)
+    child.name = "bar"
     child.save!
   end
 

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -124,7 +124,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
 
     IdentityCache.cache.expects(:delete).at_least(1).with(key)
     IdentityCache.cache.expects(:delete).with(@record.associated.primary_cache_index_key)
-
+    @record.associated.name = 'baz'
     @record.associated.save
   end
 

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -250,7 +250,7 @@ class FetchMultiTest < IdentityCache::TestCase
 
   def test_fetch_multi_after_expiring_a_record
     Item.fetch_multi(@joe.id, @fred.id)
-    @bob.expire_cache
+    @bob.expire_cache(force: true)
     assert_equal(IdentityCache::DELETED, backend.read(@bob.primary_cache_index_key))
 
     add = Spy.on(IdentityCache.cache.cache_fetcher, :add).and_call_through

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -159,7 +159,7 @@ class FetchTest < IdentityCache::TestCase
 
   def test_fetch_conflict
     load_one_from_db = Spy.on(Item.cached_primary_index, :load_one_from_db).and_return do
-      @record.expire_cache
+      @record.expire_cache(force: true)
       @record
     end
     add = Spy.on(fetcher, :add).and_call_through
@@ -171,11 +171,11 @@ class FetchTest < IdentityCache::TestCase
   end
 
   def test_fetch_conflict_after_delete
-    @record.expire_cache
+    @record.expire_cache(force: true)
     assert_equal(IdentityCache::DELETED, backend.read(@record.primary_cache_index_key))
 
     load_one_from_db = Spy.on(Item.cached_primary_index, :load_one_from_db).and_return do
-      @record.expire_cache
+      @record.expire_cache(force: true)
       @record
     end
     add = Spy.on(IdentityCache.cache.cache_fetcher, :add).and_call_through

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -199,6 +199,7 @@ class NormalizedHasManyTest < IdentityCache::TestCase
 
   def test_saving_a_child_record_should_expire_only_itself
     IdentityCache.cache.expects(:delete).with(@baz.primary_cache_index_key).once
+    @baz.name = 'baz2'
     @baz.save!
   end
 

--- a/test/normalized_has_one_test.rb
+++ b/test/normalized_has_one_test.rb
@@ -7,7 +7,7 @@ class NormalizedHasOneTest < IdentityCache::TestCase
     Item.cache_has_one(:associated, embed: :id)
 
     @record = Item.new(title: 'foo')
-    @record.build_associated(name: 'bar')
+    @record.build_associated(name: 'baz')
     @record.save!
     @record.reload
     @baz = @record.associated
@@ -134,6 +134,7 @@ class NormalizedHasOneTest < IdentityCache::TestCase
 
   def test_saving_a_child_record_should_expire_only_itself
     IdentityCache.cache.expects(:delete).with(@baz.primary_cache_index_key).once
+    @baz.name = 'baz2'
     @baz.save!
   end
 


### PR DESCRIPTION
We discovered that `after_commit` is part of the ActiveRecord object lifecycle, not the database, so it's called after the commit method, not after the persistance layer has commited changed data

To accomodate this, I'm using the [`ar_transaction_changes`](https://github.com/dylanahsmith/ar_transaction_changes) gem to see if there are any records, or the object was destroyed to clear the cached attributes.

Additionally, I feel like `expire_cache` should be lazy, and default to this behaviour, but still give the ability to force it for some reason 

I'm willing to bet this is being used in a lot of places, but for no reason, infact, I know it's used with `update_all` batch commits in Shopify as callbacks aren't used, but because the default is `force: false` this should hopefully improve some behaviour here.

A lot of the tests relied on this behaviour, so I broke a fair number and fixed them by changing the values.