### PR TITLE
Drop ruby 2.4 support, since it is no longer supported upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.4
+  - 2.5
   - 2.6
   - 2.7
 
@@ -17,9 +17,9 @@ env:
 
 jobs:
   exclude:
-    - rvm: 2.4
+    - rvm: 2.5
       gemfile: gemfiles/Gemfile.rails-edge
-    - rvm: 2.4
+    - rvm: 2.5
       gemfile: gemfiles/Gemfile.latest-release
 
 services:

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = IdentityCache::VERSION
 
-  gem.required_ruby_version = '>= 2.4.0'
+  gem.required_ruby_version = '>= 2.5.0'
 
   gem.add_dependency('ar_transaction_changes', '~> 1.0')
   gem.add_dependency('activerecord', '>= 5.2')

--- a/lib/identity_cache/cached/recursive/association.rb
+++ b/lib/identity_cache/cached/recursive/association.rb
@@ -14,7 +14,7 @@ module IdentityCache
           cached_association = self
 
           model = reflection.active_record
-          model.send(:define_method, cached_accessor_name) do
+          model.define_method(cached_accessor_name) do
             cached_association.read(self)
           end
 


### PR DESCRIPTION
## Problem

CI started failing due to a ruby 2.4 incompatibility in the latest spy gem's 1.0.1 release (e.g. https://travis-ci.org/github/Shopify/identity_cache/jobs/727394585)

```
  1) Error:
FetchTest#test_exists_with_identity_cache_when_cache_miss_and_not_in_db:
NoMethodError: private method `alias_method' called for #<Class:#<IdentityCache::MemoizedCacheProxy:0x00000000026aacf0>>
    /home/travis/build/Shopify/identity_cache/gemfiles/vendor/bundle/ruby/2.4.0/gems/spy-1.0.1/lib/spy/subroutine.rb:61:in `hook'
    /home/travis/build/Shopify/identity_cache/gemfiles/vendor/bundle/ruby/2.4.0/gems/spy-1.0.1/lib/spy/subroutine.rb:366:in `on'
    /home/travis/build/Shopify/identity_cache/gemfiles/vendor/bundle/ruby/2.4.0/gems/spy-1.0.1/lib/spy.rb:186:in `create_and_hook_spy'
    /home/travis/build/Shopify/identity_cache/gemfiles/vendor/bundle/ruby/2.4.0/gems/spy-1.0.1/lib/spy.rb:22:in `block in on'
    /home/travis/build/Shopify/identity_cache/gemfiles/vendor/bundle/ruby/2.4.0/gems/spy-1.0.1/lib/spy.rb:21:in `map'
    /home/travis/build/Shopify/identity_cache/gemfiles/vendor/bundle/ruby/2.4.0/gems/spy-1.0.1/lib/spy.rb:21:in `on'
    /home/travis/build/Shopify/identity_cache/test/fetch_test.rb:106:in `test_exists_with_identity_cache_when_cache_miss_and_not_in_db'
```

## Solution

I noticed the failure on CI for the spy gem but the failure wasn't there for ruby 2.5 (https://travis-ci.org/github/ryanong/spy/builds/719648100).  Also, I noticed that ruby 2.4 is no longer supported upstream (https://www.ruby-lang.org/en/downloads/branches/).  So I decided to just remove support for ruby 2.4 here too.