### PR TITLE
Fixing CAS for Dalli adapter

### DIFF
--- a/lib/identity_cache/mem_cache_store_cas.rb
+++ b/lib/identity_cache/mem_cache_store_cas.rb
@@ -44,7 +44,7 @@ module IdentityCache
             cas_id = raw_values[key].last
             entry = ActiveSupport::Cache::Entry.new(value, **options)
             payload = options[:raw] ? entry.value.to_s : entry
-            @data.replace_cas(key, payload, options[:expires_in].to_i, cas_id, options)
+            @data.replace_cas(key, payload, cas_id, options[:expires_in].to_i, options)
           end
         end
       end

--- a/test/helpers/cache_connection.rb
+++ b/test/helpers/cache_connection.rb
@@ -19,7 +19,7 @@ module CacheConnection
     @backend ||= case ENV['ADAPTER']
     when nil, 'dalli'
       require 'active_support/cache/mem_cache_store'
-      ActiveSupport::Cache::MemCacheStore.new("#{host}:11211", failover: false)
+      ActiveSupport::Cache::MemCacheStore.new("#{host}:11211", failover: false, expires_in: 6.hours.to_i)
     when 'memcached'
       require 'memcached_store'
       require 'active_support/cache/memcached_store'


### PR DESCRIPTION
When setting up test suite with values from docs (namely TTL option of Dalli client), `fetch_multi` method stops populating cache because params ordering that Dalli client expects is different from ordering that is used when calling `replace_cas`  method:
https://github.com/Shopify/identity_cache/blob/721e1bbd0399fb222f17d6142f9b21e30e2c9307/lib/identity_cache/mem_cache_store_cas.rb#L47
https://github.com/petergoldstein/dalli/blob/e9afa45c5f8a134c4a7ca853530eb0ff8aeb3e01/lib/dalli/client.rb#L295