### PR TITLE
Autocorrect rubocop offenses

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -120,7 +120,7 @@ module IdentityCache
     #
     def fetch(key)
       if should_use_cache?
-        unmap_cached_nil_for(cache.fetch(key) { map_cached_nil_for yield })
+        unmap_cached_nil_for(cache.fetch(key) { map_cached_nil_for(yield) })
       else
         yield
       end
@@ -146,7 +146,7 @@ module IdentityCache
       result = if should_use_cache?
         fetch_in_batches(keys.uniq) do |missed_keys|
           results = yield missed_keys
-          results.map { |e| map_cached_nil_for e }
+          results.map { |e| map_cached_nil_for(e) }
         end
       else
         results = yield keys

--- a/performance/cpu.rb
+++ b/performance/cpu.rb
@@ -23,7 +23,7 @@ end
 def benchmark(runners, label_width = 0)
   IdentityCache.cache.clear
   runners.each do |runner|
-    print "#{runner.name}: ".ljust(label_width)
+    print("#{runner.name}: ".ljust(label_width))
     puts run(runner.new(RUNS))
   end
 end

--- a/test/attribute_cache_test.rb
+++ b/test/attribute_cache_test.rb
@@ -18,7 +18,7 @@ class AttributeCacheTest < IdentityCache::TestCase
     fetch = Spy.on(IdentityCache.cache, :fetch).and_call_through
 
     assert_queries(1) do
-      assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
+      assert_equal('foo', AssociatedRecord.fetch_name_by_id(1))
     end
     assert(fetch.has_been_called_with?(@name_attribute_key))
   end
@@ -27,7 +27,7 @@ class AttributeCacheTest < IdentityCache::TestCase
     assert_equal('foo', AssociatedRecord.fetch_name_by_id(1))
 
     assert_queries(0) do
-      assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
+      assert_equal('foo', AssociatedRecord.fetch_name_by_id(1))
     end
   end
 
@@ -35,63 +35,63 @@ class AttributeCacheTest < IdentityCache::TestCase
     assert_nil(AssociatedRecord.fetch_name_by_id(2))
 
     assert_queries(0) do
-      assert_nil AssociatedRecord.fetch_name_by_id(2)
+      assert_nil(AssociatedRecord.fetch_name_by_id(2))
     end
   end
 
   def test_cached_attribute_values_are_expired_from_the_cache_when_an_existing_record_is_saved
-    assert_queries(1) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
-    assert_queries(0) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
+    assert_queries(1) { assert_equal('foo', AssociatedRecord.fetch_name_by_id(1)) }
+    assert_queries(0) { assert_equal('foo', AssociatedRecord.fetch_name_by_id(1)) }
 
     @record.update!(updated_at: @record.updated_at + 1)
 
-    assert_queries(1) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
+    assert_queries(1) { assert_equal('foo', AssociatedRecord.fetch_name_by_id(1)) }
   end
 
   def test_cached_attribute_values_are_expired_from_the_cache_when_an_existing_record_with_changed_attributes_is_saved
-    assert_queries(1) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
-    assert_queries(0) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
+    assert_queries(1) { assert_equal('foo', AssociatedRecord.fetch_name_by_id(1)) }
+    assert_queries(0) { assert_equal('foo', AssociatedRecord.fetch_name_by_id(1)) }
 
     @record.name = 'bar'
     @record.save!
 
-    assert_queries(1) { assert_equal 'bar', AssociatedRecord.fetch_name_by_id(1) }
+    assert_queries(1) { assert_equal('bar', AssociatedRecord.fetch_name_by_id(1)) }
   end
 
   def test_cached_attribute_values_are_expired_from_the_cache_when_an_existing_record_is_destroyed
-    assert_queries(1) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
-    assert_queries(0) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1) }
+    assert_queries(1) { assert_equal('foo', AssociatedRecord.fetch_name_by_id(1)) }
+    assert_queries(0) { assert_equal('foo', AssociatedRecord.fetch_name_by_id(1)) }
 
     @record.destroy
 
-    assert_queries(1) { assert_nil AssociatedRecord.fetch_name_by_id(1) }
+    assert_queries(1) { assert_nil(AssociatedRecord.fetch_name_by_id(1)) }
   end
 
   def test_cached_attribute_values_are_expired_from_the_cache_when_a_new_record_is_saved
     new_id = 2
-    assert_queries(1) { assert_nil AssociatedRecord.fetch_name_by_id(new_id) }
-    assert_queries(0) { assert_nil AssociatedRecord.fetch_name_by_id(new_id) }
+    assert_queries(1) { assert_nil(AssociatedRecord.fetch_name_by_id(new_id)) }
+    assert_queries(0) { assert_nil(AssociatedRecord.fetch_name_by_id(new_id)) }
 
     @parent.associated_records.create(name: 'bar')
 
-    assert_queries(1) { assert_equal 'bar', AssociatedRecord.fetch_name_by_id(new_id) }
+    assert_queries(1) { assert_equal('bar', AssociatedRecord.fetch_name_by_id(new_id)) }
   end
 
   def test_value_coercion
-    assert_queries(1) { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(@record.id.to_f) }
-    assert_no_queries { assert_equal 'foo', AssociatedRecord.fetch_name_by_id(@record.id) }
+    assert_queries(1) { assert_equal('foo', AssociatedRecord.fetch_name_by_id(@record.id.to_f)) }
+    assert_no_queries { assert_equal('foo', AssociatedRecord.fetch_name_by_id(@record.id)) }
     @record.update!(name: 'bar')
-    assert_queries(1) { assert_equal 'bar', AssociatedRecord.fetch_name_by_id(@record.id.to_f) }
+    assert_queries(1) { assert_equal('bar', AssociatedRecord.fetch_name_by_id(@record.id.to_f)) }
   end
 
   def test_no_nil_empty_string_cache_key_conflict
     Item.cache_attribute(:id, by: [:title])
     @parent.update!(title: "")
-    assert_queries(1) { assert_equal @parent.id, Item.fetch_id_by_title("") }
-    assert_queries(1) { assert_nil Item.fetch_id_by_title(nil) }
+    assert_queries(1) { assert_equal(@parent.id, Item.fetch_id_by_title("")) }
+    assert_queries(1) { assert_nil(Item.fetch_id_by_title(nil)) }
     @parent.update!(title: nil)
-    assert_queries(1) { assert_nil Item.fetch_id_by_title("") }
-    assert_queries(1) { assert_equal @parent.id, Item.fetch_id_by_title(nil) }
+    assert_queries(1) { assert_nil(Item.fetch_id_by_title("")) }
+    assert_queries(1) { assert_equal(@parent.id, Item.fetch_id_by_title(nil)) }
   end
 
   def test_fetching_by_attribute_delegates_to_block_if_transactions_are_open
@@ -99,7 +99,7 @@ class AttributeCacheTest < IdentityCache::TestCase
 
     @record.transaction do
       assert_queries(1) do
-        assert_equal 'foo', AssociatedRecord.fetch_name_by_id(1)
+        assert_equal('foo', AssociatedRecord.fetch_name_by_id(1))
       end
     end
   end

--- a/test/cache_hash_test.rb
+++ b/test/cache_hash_test.rb
@@ -6,9 +6,9 @@ class CacheHashTest < IdentityCache::TestCase
     3.times do
       random_str = Array.new(200) { rand(36).to_s(36) }.join
       hash_val = IdentityCache.memcache_hash(random_str)
-      assert hash_val
-      assert_kind_of Numeric, hash_val
-      assert_equal 0, (hash_val >> 64)
+      assert(hash_val)
+      assert_kind_of(Numeric, hash_val)
+      assert_equal(0, (hash_val >> 64))
     end
   end
 end

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -94,13 +94,13 @@ class CacheInvalidationTest < IdentityCache::TestCase
     ]
 
     expected_keys.each do |expected_key|
-      assert IdentityCache.cache.fetch(expected_key) { nil }
+      assert(IdentityCache.cache.fetch(expected_key) { nil })
     end
 
     baz.update!(updated_at: baz.updated_at + 1)
 
     expected_keys.each do |expected_key|
-      refute IdentityCache.cache.fetch(expected_key) { nil }
+      refute(IdentityCache.cache.fetch(expected_key) { nil })
     end
   end
 
@@ -125,7 +125,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
     ]
 
     expected_keys.each do |expected_key|
-      assert IdentityCache.cache.fetch(expected_key) { nil }
+      assert(IdentityCache.cache.fetch(expected_key) { nil })
     end
 
     baz.item = record1
@@ -133,7 +133,7 @@ class CacheInvalidationTest < IdentityCache::TestCase
     baz.save!
 
     expected_keys.each do |expected_key|
-      refute IdentityCache.cache.fetch(expected_key) { nil }
+      refute(IdentityCache.cache.fetch(expected_key) { nil })
     end
   end
 

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -101,7 +101,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
   end
 
   def test_cache_association_known_inverse_raises
-    exc = assert_raises IdentityCache::InverseAssociationError do
+    exc = assert_raises(IdentityCache::InverseAssociationError) do
       Item.cache_has_many(:no_inverse_of_records, embed: true)
       IdentityCache.eager_load!
     end
@@ -122,7 +122,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
   end
 
   def test_fetch_association_does_not_allow_chaining
-    check = proc { assert_equal false, Item.fetch(@record.id).fetch_associated_records.respond_to?(:where) }
+    check = proc { assert_equal(false, Item.fetch(@record.id).fetch_associated_records.respond_to?(:where)) }
     2.times { check.call } # for miss and hit
     Item.transaction { check.call }
   end
@@ -140,14 +140,14 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     IdentityCache.with_fetch_read_only_records do
       Item.fetch(@record.id) # warm cache
       record_from_cache_hit = Item.fetch(@record.id)
-      assert record_from_cache_hit.fetch_associated_records.all?(&:readonly?)
+      assert(record_from_cache_hit.fetch_associated_records.all?(&:readonly?))
     end
   end
 
   def test_returned_records_should_be_readonly_on_cache_miss
     IdentityCache.with_fetch_read_only_records do
       record_from_cache_miss = Item.fetch(@record.id)
-      assert record_from_cache_miss.fetch_associated_records.all?(&:readonly?)
+      assert(record_from_cache_miss.fetch_associated_records.all?(&:readonly?))
     end
   end
 
@@ -155,17 +155,17 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     IdentityCache.with_fetch_read_only_records do
       record_from_db = Item.find(@record.id)
       uncached_records = record_from_db.associated_records
-      assert uncached_records.none?(&:readonly?)
-      assert record_from_db.fetch_associated_records.none?(&:readonly?)
-      assert record_from_db.associated_records.none?(&:readonly?)
+      assert(uncached_records.none?(&:readonly?))
+      assert(record_from_db.fetch_associated_records.none?(&:readonly?))
+      assert(record_from_db.associated_records.none?(&:readonly?))
     end
   end
 
   def test_returned_records_with_open_transactions_should_not_be_readonly
     IdentityCache.with_fetch_read_only_records do
       Item.transaction do
-        assert_equal IdentityCache.should_use_cache?, false
-        assert Item.fetch(@record.id).fetch_associated_records.none?(&:readonly?)
+        assert_equal(IdentityCache.should_use_cache?, false)
+        assert(Item.fetch(@record.id).fetch_associated_records.none?(&:readonly?))
       end
     end
   end
@@ -190,7 +190,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
 
   class CheckAssociationTest < IdentityCache::TestCase
     def test_unsupported_through_assocation
-      assert_raises IdentityCache::UnsupportedAssociationError, "caching through associations isn't supported" do
+      assert_raises(IdentityCache::UnsupportedAssociationError, "caching through associations isn't supported") do
         Item.has_many(
           :deeply_through_associated_records,
           through: :associated_records,
@@ -208,7 +208,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
       Item.cache_has_many(:deeply_joined_associated_records, embed: true)
 
       message = "caching association Item.deeply_joined_associated_records scoped with a join isn't supported"
-      assert_raises IdentityCache::UnsupportedAssociationError, message do
+      assert_raises(IdentityCache::UnsupportedAssociationError, message) do
         Item.fetch(1)
       end
     end

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -48,7 +48,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
 
     assert_equal(@record, record_from_cache_miss)
     5.times do
-      assert_nil record_from_cache_miss.fetch_associated
+      assert_nil(record_from_cache_miss.fetch_associated)
     end
     assert(
       fetch.has_been_called_with?(
@@ -113,7 +113,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
 
     assert_equal(@record, record_from_cache_hit)
     5.times do
-      assert_nil record_from_cache_hit.fetch_associated
+      assert_nil(record_from_cache_hit.fetch_associated)
     end
   end
 
@@ -147,14 +147,14 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
   end
 
   def test_cache_association_known_inverse_raises
-    assert_raises IdentityCache::InverseAssociationError do
+    assert_raises(IdentityCache::InverseAssociationError) do
       Item.cache_has_one(:no_inverse_of_record, embed: true)
       IdentityCache.eager_load!
     end
   end
 
   def test_unsupported_through_assocation
-    assert_raises IdentityCache::UnsupportedAssociationError, "caching through associations isn't supported" do
+    assert_raises(IdentityCache::UnsupportedAssociationError, "caching through associations isn't supported") do
       Item.has_one(:deeply_associated, through: :associated, class_name: 'DeeplyAssociatedRecord')
       Item.cache_has_one(:deeply_associated, embed: true)
     end
@@ -170,16 +170,16 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     IdentityCache.with_fetch_read_only_records do
       Item.fetch_by_title('foo')
       record_from_cache_hit = Item.fetch_by_title('foo')
-      assert record_from_cache_hit.fetch_associated.readonly?
-      refute record_from_cache_hit.associated.readonly?
+      assert(record_from_cache_hit.fetch_associated.readonly?)
+      refute(record_from_cache_hit.associated.readonly?)
     end
   end
 
   def test_returned_record_should_be_readonly_on_cache_miss
     IdentityCache.with_fetch_read_only_records do
-      assert IdentityCache.should_use_cache?
+      assert(IdentityCache.should_use_cache?)
       record_from_cache_miss = Item.fetch_by_title('foo')
-      assert record_from_cache_miss.fetch_associated.readonly?
+      assert(record_from_cache_miss.fetch_associated.readonly?)
     end
   end
 
@@ -187,17 +187,17 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     IdentityCache.with_fetch_read_only_records do
       record_from_db = Item.find_by_title('foo')
       uncached_record = record_from_db.associated
-      refute uncached_record.readonly?
+      refute(uncached_record.readonly?)
       record_from_db.fetch_associated
-      refute uncached_record.readonly?
+      refute(uncached_record.readonly?)
     end
   end
 
   def test_returned_record_with_open_transactions_should_not_be_readonly
     IdentityCache.with_fetch_read_only_records do
       Item.transaction do
-        refute IdentityCache.should_use_cache?
-        refute Item.fetch_by_title('foo').fetch_associated.readonly?
+        refute(IdentityCache.should_use_cache?)
+        refute(Item.fetch_by_title('foo').fetch_associated.readonly?)
       end
     end
   end

--- a/test/fetch_multi_test.rb
+++ b/test/fetch_multi_test.rb
@@ -50,7 +50,7 @@ class FetchMultiTest < IdentityCache::TestCase
     events = 0
     subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
       events += 1
-      assert_equal "Item", payload[:class]
+      assert_equal("Item", payload[:class])
     end
     Item.fetch_multi(@bob.id, @joe.id, @fred.id)
     assert_equal(3, events)
@@ -78,7 +78,7 @@ class FetchMultiTest < IdentityCache::TestCase
     events = 0
     subscriber = ActiveSupport::Notifications.subscribe('dehydration.identity_cache') do |_, _, _, _, payload|
       events += 1
-      assert_equal "Item", payload[:class]
+      assert_equal("Item", payload[:class])
     end
     Item.fetch_multi(@bob.id, @joe.id, @fred.id)
     assert_equal(3, events)
@@ -106,11 +106,11 @@ class FetchMultiTest < IdentityCache::TestCase
       events = 0
       subscriber = ActiveSupport::Notifications.subscribe('cache_fetch_multi.identity_cache') do |_, _, _, _, payload|
         events += 1
-        assert payload.delete(:resolve_miss_time) > 0
-        assert_equal expected, payload
+        assert(payload.delete(:resolve_miss_time) > 0)
+        assert_equal(expected, payload)
       end
       Item.fetch_multi(@bob.id, @joe.id, @fred.id)
-      assert_equal 1, events
+      assert_equal(1, events)
     end
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
@@ -156,7 +156,7 @@ class FetchMultiTest < IdentityCache::TestCase
     assert_equal(fetch_result, results)
 
     results = IdentityCache.fetch_multi(1, 2) do |_keys|
-      flunk "Contents should have been fetched from cache successfully"
+      flunk("Contents should have been fetched from cache successfully")
     end
 
     assert_equal(fetch_result, results)
@@ -168,7 +168,7 @@ class FetchMultiTest < IdentityCache::TestCase
     fetcher.expects(:fetch_multi).with([1, 2]).returns(cache_result)
 
     results = IdentityCache.fetch_multi(1, 2) do |_keys|
-      flunk "Contents should have been fetched from cache successfully"
+      flunk("Contents should have been fetched from cache successfully")
     end
 
     assert_equal(cache_result, results)
@@ -230,10 +230,10 @@ class FetchMultiTest < IdentityCache::TestCase
     cache_response[@bob_blob_key] = cache_response_for(@bob)
     cache_response[@joe_blob_key] = cache_response_for(@joe)
 
-    with_batch_size 1 do
+    with_batch_size(1) do
       fetcher.expects(:fetch_multi).with([@bob_blob_key]).returns(cache_response).once
       fetcher.expects(:fetch_multi).with([@joe_blob_key]).returns(cache_response).once
-      assert_equal [@bob, @joe], Item.fetch_multi(@bob.id, @joe.id)
+      assert_equal([@bob, @joe], Item.fetch_multi(@bob.id, @joe.id))
     end
   end
 
@@ -334,10 +334,10 @@ class FetchMultiTest < IdentityCache::TestCase
       fetch_multi = fetch_multi_stub(cache_response)
 
       response = Item.fetch_multi(@bob.id, @joe.id, @fred.id)
-      assert fetch_multi.has_been_called_with?(@bob_blob_key, @joe_blob_key, @fred_blob_key)
-      assert_equal [@bob, @joe, @fred], response
+      assert(fetch_multi.has_been_called_with?(@bob_blob_key, @joe_blob_key, @fred_blob_key))
+      assert_equal([@bob, @joe, @fred], response)
 
-      assert response.all?(&:readonly?)
+      assert(response.all?(&:readonly?))
     end
   end
 
@@ -350,19 +350,19 @@ class FetchMultiTest < IdentityCache::TestCase
       fetch_multi = fetch_multi_stub(cache_response)
 
       response = Item.fetch_multi(@bob.id, @joe.id, @fred.id)
-      assert fetch_multi.has_been_called_with?(@bob_blob_key, @joe_blob_key, @fred_blob_key)
-      assert_equal [@bob, @joe, @fred], response
+      assert(fetch_multi.has_been_called_with?(@bob_blob_key, @joe_blob_key, @fred_blob_key))
+      assert_equal([@bob, @joe, @fred], response)
 
-      assert response.all?(&:readonly?)
+      assert(response.all?(&:readonly?))
     end
   end
 
   def test_fetch_multi_with_open_transactions_returns_non_readonly_records
     IdentityCache.with_fetch_read_only_records do
       Item.transaction do
-        assert_equal IdentityCache.should_use_cache?, false
+        assert_equal(IdentityCache.should_use_cache?, false)
         IdentityCache.cache.expects(:fetch_multi).never
-        assert Item.fetch_multi(@bob.id, @joe.id, @fred.id).none?(&:readonly?)
+        assert(Item.fetch_multi(@bob.id, @joe.id, @fred.id).none?(&:readonly?))
       end
     end
   end

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -34,7 +34,7 @@ class FetchTest < IdentityCache::TestCase
     events = 0
     subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
       events += 1
-      assert_equal "Item", payload[:class]
+      assert_equal("Item", payload[:class])
     end
     Item.fetch(1)
     assert_equal(1, events)
@@ -49,7 +49,7 @@ class FetchTest < IdentityCache::TestCase
     events = 0
     subscriber = ActiveSupport::Notifications.subscribe('cache_fetch.identity_cache') do |_, _, _, _, payload|
       events += 1
-      assert_equal expected, payload
+      assert_equal(expected, payload)
     end
     Item.fetch(1)
     assert_equal(1, events)
@@ -67,10 +67,10 @@ class FetchTest < IdentityCache::TestCase
       events = 0
       subscriber = ActiveSupport::Notifications.subscribe('cache_fetch.identity_cache') do |_, _, _, _, payload|
         events += 1
-        assert_equal expected, payload
+        assert_equal(expected, payload)
       end
       Item.fetch(1)
-      assert_equal 1, events
+      assert_equal(1, events)
     end
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
@@ -116,7 +116,7 @@ class FetchTest < IdentityCache::TestCase
     events = 0
     subscriber = ActiveSupport::Notifications.subscribe('dehydration.identity_cache') do |_, _, _, _, payload|
       events += 1
-      assert_equal "Item", payload[:class]
+      assert_equal("Item", payload[:class])
     end
     Item.fetch(1)
     assert_equal(1, events)
@@ -131,8 +131,8 @@ class FetchTest < IdentityCache::TestCase
     events = 0
     subscriber = ActiveSupport::Notifications.subscribe('cache_fetch.identity_cache') do |_, _, _, _, payload|
       events += 1
-      assert payload.delete(:resolve_miss_time) > 0
-      assert_equal expected, payload
+      assert(payload.delete(:resolve_miss_time) > 0)
+      assert_equal(expected, payload)
     end
     Item.fetch(1)
     assert_equal(1, events)
@@ -260,7 +260,7 @@ class FetchTest < IdentityCache::TestCase
 
   def test_fetch_by_bang_method
     Item.connection.expects(:exec_query).returns(ActiveRecord::Result.new([], []))
-    assert_raises IdentityCache::RecordNotFound do
+    assert_raises(IdentityCache::RecordNotFound) do
       Item.fetch_by_title!('bob')
     end
   end
@@ -307,7 +307,7 @@ class FetchTest < IdentityCache::TestCase
   def test_returned_records_are_readonly_on_cache_hit
     IdentityCache.with_fetch_read_only_records do
       IdentityCache.cache.expects(:fetch).with(@blob_key).returns(@cached_value)
-      assert Item.fetch(1).readonly?
+      assert(Item.fetch(1).readonly?)
     end
   end
 
@@ -316,9 +316,9 @@ class FetchTest < IdentityCache::TestCase
       fetch = Spy.on(IdentityCache.cache, :fetch).and_call_through
       Item.cached_primary_index.expects(:load_one_from_db).with(1).once.returns(@record)
 
-      assert Item.exists_with_identity_cache?(1)
-      assert fetch.has_been_called_with?(@blob_key)
-      assert Item.fetch(1).readonly?
+      assert(Item.exists_with_identity_cache?(1))
+      assert(fetch.has_been_called_with?(@blob_key))
+      assert(Item.fetch(1).readonly?)
     end
   end
 
@@ -328,9 +328,9 @@ class FetchTest < IdentityCache::TestCase
         fetch = Spy.on(IdentityCache.cache, :fetch).and_call_through
         Item.cached_primary_index.expects(:load_one_from_db).with(1).once.returns(@record)
 
-        refute IdentityCache.should_use_cache?
-        refute fetch.has_been_called_with?(@blob_key)
-        refute Item.fetch(1).readonly?, "Fetched item was read-only"
+        refute(IdentityCache.should_use_cache?)
+        refute(fetch.has_been_called_with?(@blob_key))
+        refute(Item.fetch(1).readonly?, "Fetched item was read-only")
       end
     end
   end

--- a/test/helpers/active_record_objects.rb
+++ b/test/helpers/active_record_objects.rb
@@ -9,7 +9,7 @@ module SwitchNamespace
   def self.included(base)
     base.extend(ClassMethods)
     base.class_eval do
-      class_attribute :namespace
+      class_attribute(:namespace)
       self.namespace = 'ns'
     end
   end

--- a/test/identity_cache_test.rb
+++ b/test/identity_cache_test.rb
@@ -12,7 +12,7 @@ class IdentityCacheTest < IdentityCache::TestCase
   def test_identity_cache_raises_if_loaded_twice
     assert_raises(IdentityCache::AlreadyIncludedError) do
       BadModel.class_eval do
-        include IdentityCache
+        include(IdentityCache)
       end
     end
   end
@@ -23,7 +23,7 @@ class IdentityCacheTest < IdentityCache::TestCase
 
   def test_should_use_cache_in_transaction
     ActiveRecord::Base.transaction do
-      assert_equal false, IdentityCache.should_use_cache?
+      assert_equal(false, IdentityCache.should_use_cache?)
     end
   end
 end

--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -26,7 +26,7 @@ class IndexCacheTest < IdentityCache::TestCase
     Item.cache_index(:title, :id)
 
     assert_queries(1) do
-      assert_equal [], Item.fetch_by_title_and_id('garbage_title', 'garbage_id')
+      assert_equal([], Item.fetch_by_title_and_id('garbage_title', 'garbage_id'))
     end
   end
 

--- a/test/lazy_load_associated_classes_test.rb
+++ b/test/lazy_load_associated_classes_test.rb
@@ -26,11 +26,11 @@ class LazyLoadAssociatedClassesTest < IdentityCache::TestCase
     Item.fetch(item.id)
 
     assert_queries(0) do
-      assert_equal 'baz', Item.fetch(item.id).fetch_associated_records.first.name
+      assert_equal('baz', Item.fetch(item.id).fetch_associated_records.first.name)
     end
     associated_record.update!(name: 'buzz')
     assert_queries(2) do
-      assert_equal 'buzz', Item.fetch(item.id).fetch_associated_records.first.name
+      assert_equal('buzz', Item.fetch(item.id).fetch_associated_records.first.name)
     end
   end
 
@@ -50,7 +50,7 @@ class LazyLoadAssociatedClassesTest < IdentityCache::TestCase
       err2 = assert_raises(IdentityCache::UnsupportedAssociationError) do
         Item.fetch_multi([1])
       end
-      assert_equal err1.message, err2.message
+      assert_equal(err1.message, err2.message)
     end
   end
 
@@ -69,7 +69,7 @@ class LazyLoadAssociatedClassesTest < IdentityCache::TestCase
       err2 = assert_raises(IdentityCache::UnsupportedAssociationError) do
         Item.fetch_multi([1])
       end
-      assert_equal err1.message, err2.message
+      assert_equal(err1.message, err2.message)
     end
   end
 end

--- a/test/load_strategy/eager_test.rb
+++ b/test/load_strategy/eager_test.rb
@@ -7,7 +7,7 @@ module IdentityCache
       def test_load
         record = AssociatedRecord.create!
         Eager.load(AssociatedRecord.cached_primary_index, record.id) do |loaded_record|
-          assert_equal record, loaded_record
+          assert_equal(record, loaded_record)
         end
       end
 
@@ -15,7 +15,7 @@ module IdentityCache
         records = create_list(:associated_record, 3)
         records_by_id = records.map { |record| [record.id, record] }.to_h
         Eager.load_multi(AssociatedRecord.cached_primary_index, records.map(&:id)) do |loaded_records_by_id|
-          assert_equal records_by_id, loaded_records_by_id
+          assert_equal(records_by_id, loaded_records_by_id)
         end
       end
 
@@ -31,8 +31,8 @@ module IdentityCache
         Eager.load_batch(ids_by_cache_fetcher) do |loaded_records_by_id_by_cache_fetcher|
           ids_by_cache_fetcher.each do |cache_fetcher, ids|
             loaded_records_by_id = loaded_records_by_id_by_cache_fetcher.fetch(cache_fetcher)
-            assert_equal ids, loaded_records_by_id.keys.sort
-            assert_equal ids, loaded_records_by_id.values.map(&:id).sort
+            assert_equal(ids, loaded_records_by_id.keys.sort)
+            assert_equal(ids, loaded_records_by_id.values.map(&:id).sort)
           end
         end
       end

--- a/test/load_strategy/lazy_test.rb
+++ b/test/load_strategy/lazy_test.rb
@@ -14,7 +14,7 @@ module IdentityCache
       def test_load
         record = AssociatedRecord.create!
         lazy.load(AssociatedRecord.cached_primary_index, record.id) do |loaded_record|
-          assert_equal record, loaded_record
+          assert_equal(record, loaded_record)
         end
 
         lazy.load_now
@@ -24,7 +24,7 @@ module IdentityCache
         records = create_list(:associated_record, 3)
         records_by_id = records.map { |record| [record.id, record] }.to_h
         lazy.load_multi(AssociatedRecord.cached_primary_index, records.map(&:id)) do |loaded_records_by_id|
-          assert_equal records_by_id, loaded_records_by_id
+          assert_equal(records_by_id, loaded_records_by_id)
         end
 
         lazy.load_now
@@ -42,8 +42,8 @@ module IdentityCache
         lazy.load_batch(ids_by_cache_fetcher) do |loaded_records_by_id_by_cache_fetcher|
           ids_by_cache_fetcher.each do |cache_fetcher, ids|
             loaded_records_by_id = loaded_records_by_id_by_cache_fetcher.fetch(cache_fetcher)
-            assert_equal ids, loaded_records_by_id.keys.sort
-            assert_equal ids, loaded_records_by_id.values.map(&:id).sort
+            assert_equal(ids, loaded_records_by_id.keys.sort)
+            assert_equal(ids, loaded_records_by_id.values.map(&:id).sort)
           end
         end
 
@@ -52,7 +52,7 @@ module IdentityCache
 
       def test_lazy_load
         lazy.lazy_load do |yielded_lazy_loader|
-          assert_same lazy, yielded_lazy_loader
+          assert_same(lazy, yielded_lazy_loader)
         end
       end
 

--- a/test/memoized_cache_proxy_test.rb
+++ b/test/memoized_cache_proxy_test.rb
@@ -25,7 +25,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
 
     IdentityCache.cache.with_memoization do
       IdentityCache.cache.write('foo', 'bar')
-      assert_equal 'bar', IdentityCache.cache.fetch('foo')
+      assert_equal('bar', IdentityCache.cache.fetch('foo'))
     end
   end
 
@@ -34,9 +34,9 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
 
     IdentityCache.cache.with_memoization do
       IdentityCache.cache.write('foo', nil)
-      assert_nil IdentityCache.cache.fetch('foo')
+      assert_nil(IdentityCache.cache.fetch('foo'))
       IdentityCache.cache.write('bar', false)
-      assert_equal false, IdentityCache.cache.fetch('bar')
+      assert_equal(false, IdentityCache.cache.fetch('bar'))
     end
   end
 
@@ -44,7 +44,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
     fetcher.expects(:fetch).with('foo').returns('bar')
 
     IdentityCache.cache.with_memoization do
-      assert_equal 'bar', IdentityCache.cache.fetch('foo')
+      assert_equal('bar', IdentityCache.cache.fetch('foo'))
     end
   end
 
@@ -54,7 +54,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
 
     IdentityCache.cache.with_memoization do
       IdentityCache.cache.write('foo', 'bar')
-      assert_equal 'bar', IdentityCache.cache.fetch('foo')
+      assert_equal('bar', IdentityCache.cache.fetch('foo'))
     end
   end
 
@@ -62,9 +62,9 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
     backend.write('foo', 'bar')
 
     IdentityCache.cache.with_memoization do
-      assert_equal 'bar', IdentityCache.cache.fetch('foo')
+      assert_equal('bar', IdentityCache.cache.fetch('foo'))
       backend.delete('foo')
-      assert_equal 'bar', IdentityCache.cache.fetch('foo')
+      assert_equal('bar', IdentityCache.cache.fetch('foo'))
     end
   end
 
@@ -114,7 +114,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
     expected = { memoizing: false }
     subscriber = ActiveSupport::Notifications.subscribe('cache_write.identity_cache') do |_, _, _, _, payload|
       events += 1
-      assert_equal expected, payload
+      assert_equal(expected, payload)
     end
     IdentityCache.cache.write('foo', 'bar')
     assert_equal(1, events)
@@ -127,7 +127,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
     expected = { memoizing: false }
     subscriber = ActiveSupport::Notifications.subscribe('cache_delete.identity_cache') do |_, _, _, _, payload|
       events += 1
-      assert_equal expected, payload
+      assert_equal(expected, payload)
     end
     IdentityCache.cache.delete('foo')
     assert_equal(1, events)
@@ -139,7 +139,7 @@ class MemoizedCacheProxyTest < IdentityCache::TestCase
     events = 0
     subscriber = ActiveSupport::Notifications.subscribe('cache_clear.identity_cache') do |_, _, _, _, payload|
       events += 1
-      assert payload.empty?
+      assert(payload.empty?)
     end
     IdentityCache.cache.clear
     assert_equal(1, events)

--- a/test/normalized_belongs_to_test.rb
+++ b/test/normalized_belongs_to_test.rb
@@ -18,7 +18,7 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
   def test_fetching_the_association_should_delegate_to_the_normal_association_fetcher_if_any_transactions_are_open
     Item.expects(:fetch_by_id).never
     @record.transaction do
-      assert_equal @parent_record, @record.fetch_item
+      assert_equal(@parent_record, @record.fetch_item)
     end
   end
 
@@ -65,32 +65,32 @@ class NormalizedBelongsToTest < IdentityCache::TestCase
   def test_returned_record_should_be_readonly_on_cache_hit
     IdentityCache.with_fetch_read_only_records do
       @record.fetch_item # warm cache
-      assert @record.fetch_item.readonly?
-      refute @record.item.readonly?
+      assert(@record.fetch_item.readonly?)
+      refute(@record.item.readonly?)
     end
   end
 
   def test_returned_record_should_be_readonly_on_cache_miss
     IdentityCache.with_fetch_read_only_records do
-      assert @record.fetch_item.readonly?
-      refute @record.item.readonly?
+      assert(@record.fetch_item.readonly?)
+      refute(@record.item.readonly?)
     end
   end
 
   def test_db_returned_record_should_never_be_readonly
     IdentityCache.with_fetch_read_only_records do
       uncached_record = @record.item
-      refute uncached_record.readonly?
+      refute(uncached_record.readonly?)
       @record.fetch_item
-      refute uncached_record.readonly?
+      refute(uncached_record.readonly?)
     end
   end
 
   def test_returned_record_with_open_transactions_should_not_be_readonly
     IdentityCache.with_fetch_read_only_records do
       Item.transaction do
-        refute IdentityCache.should_use_cache?
-        refute @record.fetch_item.readonly?
+        refute(IdentityCache.should_use_cache?)
+        refute(@record.fetch_item.readonly?)
       end
     end
   end

--- a/test/normalized_has_many_test.rb
+++ b/test/normalized_has_many_test.rb
@@ -85,8 +85,8 @@ class NormalizedHasManyTest < IdentityCache::TestCase
       Item.fetch(@record.id)
     end
     assert_no_queries do
-      assert_equal @record, fetched_records
-      assert_nil fetched_records.fetch_associated
+      assert_equal(@record, fetched_records)
+      assert_nil(fetched_records.fetch_associated)
     end
   end
 
@@ -97,7 +97,7 @@ class NormalizedHasManyTest < IdentityCache::TestCase
   def test_fetching_associated_ids_will_use_the_cached_value_if_the_record_is_from_the_cache
     @record = Item.fetch(@record.id)
     assert_queries(0) do
-      assert_equal [2, 1], @record.fetch_associated_record_ids
+      assert_equal([2, 1], @record.fetch_associated_record_ids)
     end
   end
 
@@ -115,7 +115,7 @@ class NormalizedHasManyTest < IdentityCache::TestCase
     @record.fetch_associated_records
     assert_queries(0) do
       @record = Item.fetch(@record.id)
-      assert_equal [@baz, @bar], @record.fetch_associated_records
+      assert_equal([@baz, @bar], @record.fetch_associated_records)
     end
   end
 
@@ -130,7 +130,7 @@ class NormalizedHasManyTest < IdentityCache::TestCase
 
     assert_memcache_operations(0) do
       @record.transaction do
-        assert_equal [@baz, @bar], @record.fetch_associated_records
+        assert_equal([@baz, @bar], @record.fetch_associated_records)
       end
     end
   end
@@ -140,7 +140,7 @@ class NormalizedHasManyTest < IdentityCache::TestCase
     @record.associated_records.to_a
 
     assert_memcache_operations(0) do
-      assert_equal [@baz, @bar], @record.fetch_associated_records
+      assert_equal([@baz, @bar], @record.fetch_associated_records)
     end
   end
 
@@ -215,7 +215,7 @@ class NormalizedHasManyTest < IdentityCache::TestCase
   end
 
   def test_fetch_association_does_not_allow_chaining
-    check = proc { assert_equal false, Item.fetch(@record.id).fetch_associated_records.respond_to?(:where) }
+    check = proc { assert_equal(false, Item.fetch(@record.id).fetch_associated_records.respond_to?(:where)) }
     2.times { check.call } # for miss and hit
     Item.transaction { check.call }
   end
@@ -231,7 +231,7 @@ class NormalizedHasManyTest < IdentityCache::TestCase
   def test_returned_records_should_be_readonly_on_cache_miss
     IdentityCache.with_fetch_read_only_records do
       record_from_cache_miss = Item.fetch(@record.id)
-      assert record_from_cache_miss.fetch_associated_records.all?(&:readonly?)
+      assert(record_from_cache_miss.fetch_associated_records.all?(&:readonly?))
     end
   end
 

--- a/test/normalized_has_one_test.rb
+++ b/test/normalized_has_one_test.rb
@@ -36,7 +36,7 @@ class NormalizedHasOneTest < IdentityCache::TestCase
     assert_equal([1, 2], fetched_records.map(&:cached_associated_id))
 
     fetched_records.each do |record|
-      refute_predicate record.association(:associated), :loaded?
+      refute_predicate(record.association(:associated), :loaded?)
     end
   end
 
@@ -53,8 +53,8 @@ class NormalizedHasOneTest < IdentityCache::TestCase
     end
 
     assert_no_queries do
-      assert_equal 1, fetched_record.fetch_denormalized_associated.cached_deeply_associated_id
-      refute_predicate fetched_record.fetch_denormalized_associated.association(:deeply_associated), :loaded?
+      assert_equal(1, fetched_record.fetch_denormalized_associated.cached_deeply_associated_id)
+      refute_predicate(fetched_record.fetch_denormalized_associated.association(:deeply_associated), :loaded?)
     end
   end
 
@@ -65,7 +65,7 @@ class NormalizedHasOneTest < IdentityCache::TestCase
   def test_fetching_associated_id_will_use_the_cached_value_if_the_record_is_from_the_cache
     @record = Item.fetch(@record.id)
     assert_queries(0) do
-      assert_equal 1, @record.fetch_associated_id
+      assert_equal(1, @record.fetch_associated_id)
     end
   end
 
@@ -83,7 +83,7 @@ class NormalizedHasOneTest < IdentityCache::TestCase
     @record.fetch_associated
     assert_queries(0) do
       @record = Item.fetch(@record.id)
-      assert_equal @baz, @record.fetch_associated
+      assert_equal(@baz, @record.fetch_associated)
     end
   end
 
@@ -92,7 +92,7 @@ class NormalizedHasOneTest < IdentityCache::TestCase
 
     assert_memcache_operations(0) do
       @record.transaction do
-        assert_equal @baz, @record.fetch_associated
+        assert_equal(@baz, @record.fetch_associated)
       end
     end
   end
@@ -102,7 +102,7 @@ class NormalizedHasOneTest < IdentityCache::TestCase
     @record.associated
 
     assert_memcache_operations(0) do
-      assert_equal @baz, @record.fetch_associated
+      assert_equal(@baz, @record.fetch_associated)
     end
   end
 
@@ -148,7 +148,7 @@ class NormalizedHasOneTest < IdentityCache::TestCase
   def test_returned_record_should_be_readonly_on_cache_miss
     IdentityCache.with_fetch_read_only_records do
       record_from_cache_miss = Item.fetch(@record.id)
-      assert record_from_cache_miss.fetch_associated.readonly?
+      assert(record_from_cache_miss.fetch_associated.readonly?)
     end
   end
 

--- a/test/prefetch_associations_test.rb
+++ b/test/prefetch_associations_test.rb
@@ -72,7 +72,7 @@ module IdentityCache
             prefetch(Item, :associated_records, items)
           end
           assert_no_queries do
-            assert_equal [[associated1], [associated2]], items.map(&:fetch_associated_records)
+            assert_equal([[associated1], [associated2]], items.map(&:fetch_associated_records))
           end
         end
       end
@@ -109,7 +109,7 @@ module IdentityCache
       events = 0
       subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
         events += 1
-        assert_equal "Item", payload[:class]
+        assert_equal("Item", payload[:class])
       end
       prefetch(Item, :item, items)
       assert_equal(2, events)
@@ -160,8 +160,8 @@ module IdentityCache
         cached_bob, cached_joe = Item.fetch_multi(
           @bob.id, @joe.id, includes: { associated: :deeply_associated_records }
         )
-        assert_nil cached_joe.fetch_associated
-        assert_equal 'deep child', cached_bob.fetch_associated.fetch_deeply_associated_records.first.name
+        assert_nil(cached_joe.fetch_associated)
+        assert_equal('deep child', cached_bob.fetch_associated.fetch_deeply_associated_records.first.name)
       end
     end
 
@@ -212,8 +212,8 @@ module IdentityCache
 
       assert_memcache_operations(2) do
         @cached_bob, @cached_joe = Item.fetch_multi(@bob.id, @joe.id, includes: :associated_records)
-        assert_equal child_records[0..2].sort, @cached_bob.fetch_associated_records.sort
-        assert_equal child_records[3..5].sort, @cached_joe.fetch_associated_records.sort
+        assert_equal(child_records[0..2].sort, @cached_bob.fetch_associated_records.sort)
+        assert_equal(child_records[3..5].sort, @cached_joe.fetch_associated_records.sort)
       end
     end
 
@@ -230,8 +230,8 @@ module IdentityCache
 
       assert_memcache_operations(2) do
         @cached_bob, @cached_joe = Item.fetch_multi(@bob.id, @joe.id, includes: :associated)
-        assert_equal child_records.first, @cached_bob.fetch_associated
-        assert_equal child_records.second, @cached_joe.fetch_associated
+        assert_equal(child_records.first, @cached_bob.fetch_associated)
+        assert_equal(child_records.second, @cached_joe.fetch_associated)
       end
     end
 
@@ -249,8 +249,8 @@ module IdentityCache
         @cached_bob_child, @cached_fred_child = AssociatedRecord.fetch_multi(
           @bob_child.id, @fred_child.id, includes: :item
         )
-        assert_equal @bob,  @cached_bob_child.fetch_item
-        assert_equal @fred, @cached_fred_child.fetch_item
+        assert_equal(@bob,  @cached_bob_child.fetch_item)
+        assert_equal(@fred, @cached_fred_child.fetch_item)
       end
     end
 
@@ -282,12 +282,12 @@ module IdentityCache
         bob_children = @cached_bob.fetch_associated_records.sort
         joe_children = @cached_joe.fetch_associated_records.sort
 
-        assert_equal grandchildren[0..2].sort,   bob_children[0].fetch_deeply_associated_records.sort
-        assert_equal grandchildren[3..5].sort,   bob_children[1].fetch_deeply_associated_records.sort
-        assert_equal grandchildren[6..8].sort,   bob_children[2].fetch_deeply_associated_records.sort
-        assert_equal grandchildren[9..11].sort,  joe_children[0].fetch_deeply_associated_records.sort
-        assert_equal grandchildren[12..14].sort, joe_children[1].fetch_deeply_associated_records.sort
-        assert_equal grandchildren[15..17].sort, joe_children[2].fetch_deeply_associated_records.sort
+        assert_equal(grandchildren[0..2].sort,   bob_children[0].fetch_deeply_associated_records.sort)
+        assert_equal(grandchildren[3..5].sort,   bob_children[1].fetch_deeply_associated_records.sort)
+        assert_equal(grandchildren[6..8].sort,   bob_children[2].fetch_deeply_associated_records.sort)
+        assert_equal(grandchildren[9..11].sort,  joe_children[0].fetch_deeply_associated_records.sort)
+        assert_equal(grandchildren[12..14].sort, joe_children[1].fetch_deeply_associated_records.sort)
+        assert_equal(grandchildren[15..17].sort, joe_children[2].fetch_deeply_associated_records.sort)
       end
     end
 
@@ -311,8 +311,8 @@ module IdentityCache
 
         @cached_bob_parent  = @cached_bob_child.fetch_item
         @cached_fred_parent = @cached_fred_child.fetch_item
-        assert_equal @bob,  @cached_bob_parent.fetch_item
-        assert_equal @fred, @cached_fred_parent.fetch_item
+        assert_equal(@bob,  @cached_bob_parent.fetch_item)
+        assert_equal(@fred, @cached_fred_parent.fetch_item)
       end
     end
 
@@ -340,12 +340,12 @@ module IdentityCache
         bob_children = @cached_bob.fetch_associated_records.sort
         joe_children = @cached_joe.fetch_associated_records.sort
 
-        assert_equal grandchildren[0..2].sort,   bob_children[0].fetch_deeply_associated_records.sort
-        assert_equal grandchildren[3..5].sort,   bob_children[1].fetch_deeply_associated_records.sort
-        assert_equal grandchildren[6..8].sort,   bob_children[2].fetch_deeply_associated_records.sort
-        assert_equal grandchildren[9..11].sort,  joe_children[0].fetch_deeply_associated_records.sort
-        assert_equal grandchildren[12..14].sort, joe_children[1].fetch_deeply_associated_records.sort
-        assert_equal grandchildren[15..17].sort, joe_children[2].fetch_deeply_associated_records.sort
+        assert_equal(grandchildren[0..2].sort,   bob_children[0].fetch_deeply_associated_records.sort)
+        assert_equal(grandchildren[3..5].sort,   bob_children[1].fetch_deeply_associated_records.sort)
+        assert_equal(grandchildren[6..8].sort,   bob_children[2].fetch_deeply_associated_records.sort)
+        assert_equal(grandchildren[9..11].sort,  joe_children[0].fetch_deeply_associated_records.sort)
+        assert_equal(grandchildren[12..14].sort, joe_children[1].fetch_deeply_associated_records.sort)
+        assert_equal(grandchildren[15..17].sort, joe_children[2].fetch_deeply_associated_records.sort)
       end
     end
 
@@ -367,8 +367,8 @@ module IdentityCache
         bob_child = @cached_bob.fetch_associated
         joe_child = @cached_joe.fetch_associated
 
-        assert_equal grandchildren[0..2].sort,   bob_child.fetch_deeply_associated_records.sort
-        assert_equal grandchildren[3..5].sort,   joe_child.fetch_deeply_associated_records.sort
+        assert_equal(grandchildren[0..2].sort,   bob_child.fetch_deeply_associated_records.sort)
+        assert_equal(grandchildren[3..5].sort,   joe_child.fetch_deeply_associated_records.sort)
       end
     end
 

--- a/test/readonly_test.rb
+++ b/test/readonly_test.rb
@@ -45,7 +45,7 @@ class ReadonlyTest < IdentityCache::TestCase
     Item.cached_primary_index.expects(:load_one_from_db).with(1).once.returns(@record)
 
     assert_readonly_fetch do
-      assert_equal @record, Item.fetch(1)
+      assert_equal(@record, Item.fetch(1))
     end
     assert_nil(backend.read(@record.primary_cache_index_key))
     assert(fetch.has_been_called_with?(@record.primary_cache_index_key))
@@ -55,7 +55,7 @@ class ReadonlyTest < IdentityCache::TestCase
     fetch_multi = Spy.on(IdentityCache.cache, :fetch_multi).and_call_through
 
     assert_readonly_fetch_multi do
-      assert_equal [@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id)
+      assert_equal([@bob, @joe, @fred], Item.fetch_multi(@bob.id, @joe.id, @fred.id))
     end
     keys = [@bob, @joe, @fred].map(&:primary_cache_index_key)
     assert_empty(backend.read_multi(*keys))

--- a/test/recursive_denormalized_has_many_test.rb
+++ b/test/recursive_denormalized_has_many_test.rb
@@ -65,7 +65,7 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
     events = 0
     subscriber = ActiveSupport::Notifications.subscribe('dehydration.identity_cache') do |_, _, _, _, payload|
       events += 1
-      assert_equal "Item", payload[:class]
+      assert_equal("Item", payload[:class])
     end
     Item.fetch(@record.id)
     assert_equal(1, events)
@@ -82,7 +82,7 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
     events = 0
     subscriber = ActiveSupport::Notifications.subscribe('hydration.identity_cache') do |_, _, _, _, payload|
       events += 1
-      assert_equal "Item", payload[:class]
+      assert_equal("Item", payload[:class])
     end
     Item.fetch(@record.id)
     assert_equal(1, events)
@@ -131,7 +131,7 @@ class RecursiveDenormalizedHasManyTest < IdentityCache::TestCase
       assert_memcache_operations(0) do
         associated_record = item.fetch_associated_records.to_a.first
         deeply_associated_record = associated_record.fetch_deeply_associated_records.first
-        assert_equal item.id, deeply_associated_record.fetch_associated_record.fetch_item.id
+        assert_equal(item.id, deeply_associated_record.fetch_associated_record.fetch_item.id)
       end
     end
   end

--- a/test/schema_change_test.rb
+++ b/test/schema_change_test.rb
@@ -111,15 +111,15 @@ class SchemaChangeTest < IdentityCache::TestCase
 
         associated_class.class_eval do
           self.table_name = 'associated_records'
-          include IdentityCache::WithoutPrimaryIndex
-          belongs_to :item, class_name: item_class.name
+          include(IdentityCache::WithoutPrimaryIndex)
+          belongs_to(:item, class_name: item_class.name)
         end
 
         item_class.class_eval do
           self.table_name = 'items'
-          include IdentityCache
-          has_many :associated_records, class_name: associated_class_name
-          cache_has_many :associated_records, embed: true
+          include(IdentityCache)
+          has_many(:associated_records, class_name: associated_class_name)
+          cache_has_many(:associated_records, embed: true)
         end
       end
     end
@@ -135,7 +135,7 @@ class SchemaChangeTest < IdentityCache::TestCase
 
     assert_no_queries do
       record = self.class::Item.fetch(@record.id)
-      assert_equal ['bar'], record.fetch_associated_records.map(&:name)
+      assert_equal(['bar'], record.fetch_associated_records.map(&:name))
     end
   ensure
     self.class.send(:remove_const, :Item) if self.class.const_defined?(:Item, false)


### PR DESCRIPTION
## Problem

I was going to open another pull request, but noticed that I got rubocop errors on CI (which I didn't see locally).  It looks like these got introduced in a newer rubocop version.

## Solution

Use rubocop autocorrect