### PR TITLE
Expire caches before other after_commit callbacks

### DIFF
--- a/lib/identity_cache/parent_model_expiration.rb
+++ b/lib/identity_cache/parent_model_expiration.rb
@@ -37,9 +37,6 @@ module IdentityCache
     included do
       class_attribute(:parent_expiration_entries)
       self.parent_expiration_entries = Hash.new { |hash, key| hash[key] = [] }
-      after_commit do
-        expire_parent_caches if destroyed? || transaction_changed_attributes.present?
-      end
     end
 
     def expire_parent_caches

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -148,10 +148,11 @@ module IdentityCache
       end
     end
 
+    no_op_callback = proc {}
     included do |base|
       # Make sure there is at least once after_commit callback so that _run_commit_callbacks
       # is called, which is overridden to do an early after_commit callback
-      base.after_commit {}
+      base.after_commit(&no_op_callback)
     end
 
     # Override the method that is used to call after_commit callbacks so that we can

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -182,4 +182,17 @@ class CacheInvalidationTest < IdentityCache::TestCase
       @record.class.fetch(@record.id)
     end
   end
+
+  def test_cache_expiry_before_other_after_commit_callbacks
+    Item.fetch(@record.id) # fill cache
+
+    record_id = @record.id
+    after_commit_fetched = nil
+    Item.after_commit do
+      after_commit_fetched = Item.fetch(record_id)
+    end
+    @record.update!(updated_at: @record.updated_at + 1)
+
+    assert_equal(after_commit_fetched.updated_at, @record.updated_at)
+  end
 end

--- a/test/cache_invalidation_test.rb
+++ b/test/cache_invalidation_test.rb
@@ -195,4 +195,19 @@ class CacheInvalidationTest < IdentityCache::TestCase
 
     assert_equal(after_commit_fetched.updated_at, @record.updated_at)
   end
+
+  def test_cache_not_expired_until_after_transaction
+    log = []
+    subscribe_to_sql_queries(->(sql) { log << [:sql, sql] }) do
+      subscribe_to_cache_operations(->(op) { log << [:cache, op] }) do
+        @record.update!(title: 'foo2')
+      end
+    end
+    assert_equal([:sql, :sql, :sql, :cache], log.map(&:first))
+    sql_queries = log.first(3).map(&:last)
+    assert_match(/^BEGIN\b/, sql_queries[0])
+    assert_match(/^UPDATE\b/, sql_queries[1])
+    assert_match(/^COMMIT\b/, sql_queries[2])
+    assert_match(/^cache_write.active_support /, log.last.last)
+  end
 end


### PR DESCRIPTION
Green CI depends on rubocop autocorrections in https://github.com/Shopify/identity_cache/pull/470 

## Problem

We noticed a race condition between identity cache's cache expiration after_commit callback and background jobs enqueued form another after_commit callback for the same record.  This can result in stale data being loaded from the cache if the after_commit callback that enqueues the job is called after the identity cache's cache expiration after_commit callback.

The order that after_commit callbacks are called is the opposite order from when they are defined by calling `after_commit`.  By convention we normally include modules near the top of a model and Identity Cache's `after_commit` callback is defined when the `IdentityCache`/`IdentityCache::WithoutPrimaryIndex` is included, so typically identity cache's cache expiration is done after application defined after_commit callbacks.

## Solution

The ar_transaction_changes had a similar concern with ordering of callbacks (although it wanted to do something **after** all other after_commit callbacks), which it solved by [wrapping the _run_commit_callbacks method](https://github.com/dylanahsmith/ar_transaction_changes/blob/v1.1.7/lib/ar_transaction_changes.rb) that is used to call the after_commit callbacks.  This is a method defined by ActiveSupport::Callbacks's `define_callbacks` class method.

I took a similar approach here, wrapping `_run_commit_callbacks` and expiring caches before calling `super` in that override.

I've also included a regression test that tries to fetch the updated record in another after_commit callback and fails without the corresponding fix.