### PR TITLE
Refactor test helpers for capturing externals to help test external ordering

### DIFF
--- a/test/attribute_cache_test.rb
+++ b/test/attribute_cache_test.rb
@@ -98,8 +98,10 @@ class AttributeCacheTest < IdentityCache::TestCase
     IdentityCache.cache.expects(:read).never
 
     @record.transaction do
-      assert_queries(1) do
-        assert_equal('foo', AssociatedRecord.fetch_name_by_id(1))
+      assert_queries(HAVE_LAZY_BEGIN ? 2 : 1) do
+        assert_memcache_operations(0) do
+          assert_equal('foo', AssociatedRecord.fetch_name_by_id(1))
+        end
       end
     end
   end

--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -7,10 +7,10 @@ class IndexCacheTest < IdentityCache::TestCase
   class WithoutSetup < IdentityCache::TestCase
     def test_no_queries_on_definition
       # should not do schema queries eagerly
-      assert_no_queries { Item.cache_index(:title, :id) }
+      assert_no_queries(all: true) { Item.cache_index(:title, :id) }
 
       # make sure schema wasn't cached
-      schema_queries = count_queries { Item.primary_key }
+      schema_queries = count_queries(all: true) { Item.primary_key }
       assert(schema_queries > 0)
     end
   end

--- a/test/prefetch_associations_test.rb
+++ b/test/prefetch_associations_test.rb
@@ -68,7 +68,7 @@ module IdentityCache
 
       Item.transaction do
         assert_memcache_operations(0) do
-          assert_queries(1) do
+          assert_queries(HAVE_LAZY_BEGIN ? 2 : 1) do
             prefetch(Item, :associated_records, items)
           end
           assert_no_queries do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -148,11 +148,9 @@ class SQLCounter
   end
 
   def call(_name, _start, _finish, _message_id, values)
+    return if values[:cached]
     sql = values[:sql]
-
-    # FIXME: this seems bad. we should probably have a better way to indicate
-    # the query was cached
-    return if 'CACHE' == values[:name] || IGNORED_SQL.any? { |x| x.match?(sql) }
+    return if IGNORED_SQL.any? { |p| p.match?(sql) }
     log << sql
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -118,9 +118,9 @@ module IdentityCache
   end
 end
 
+# Based on SQLCounter in the active record test suite
 class SQLCounter
-  cattr_accessor :ignored_sql
-  self.ignored_sql = [
+  IGNORED_SQL = [
     /^PRAGMA (?!(table_info))/,
     /^SELECT currval/,
     /^SELECT CAST/,
@@ -133,22 +133,17 @@ class SQLCounter
     /^BEGIN/,
     /^COMMIT/,
     /^SHOW /,
-  ]
 
-  # FIXME: this needs to be refactored so specific database can add their own
-  # ignored SQL.  This ignored SQL is for Oracle.
-  ignored_sql.concat([
+    # Oracle ignored SQL
     /^select .*nextval/i,
     /^SAVEPOINT/,
     /^ROLLBACK TO/,
     /^\s*select .* from all_triggers/im,
-  ])
+  ]
 
-  attr_reader :ignore
   attr_accessor :log
 
-  def initialize(ignore = self.class.ignored_sql)
-    @ignore = ignore
+  def initialize
     @log = []
   end
 
@@ -157,7 +152,7 @@ class SQLCounter
 
     # FIXME: this seems bad. we should probably have a better way to indicate
     # the query was cached
-    return if 'CACHE' == values[:name] || ignore.any? { |x| x =~ sql }
+    return if 'CACHE' == values[:name] || IGNORED_SQL.any? { |x| x.match?(sql) }
     log << sql
   end
 end


### PR DESCRIPTION
## Problem

For https://github.com/Shopify/identity_cache/pull/471, I want to test the ordering of the `COMMIT` database query and the cache expiry.  However, there are a number of problems with the test helpers to capture external requests:
* they ignore transaction queries (e.g. `BEGIN` and `COMMIT`)
* they only count the number of queries and don't expose the list of queries from the underlying counter classes
* the logs for the query counter classes are separate, so even if we had the logs, we wouldn't know the order of the events between those logs

I also noticed that we aren't actually properly ignoring schema queries, which is actually partially relied on by a test (IndexCacheTest::WithoutSetup#test_no_queries_on_definition) that is asserting on the number of schema queries being made, which means that it could pass even when unexpected schema queries are made.

The test helpers for counting database queries is based on an old version of SQLCounter from the Active Record test suite, which is what made it fragile to ignoring schema queries, so should be updated to make it more resilient to upstream changes in Active Record.

## Solution

I've added subscribe_to_sql_queries and subscribe_to_cache_operations test helpers, which are now used to implement the existing test helpers for counting externals.  These are more flexible in that they take a proc to call when an external call is made.  This way they can be combined as follows

```ruby
    log = []
    subscribe_to_sql_queries(->(sql) { log << [:sql, sql] }) do
      subscribe_to_cache_operations(->(op) { log << [:cache, op] }) do
        @record.update!(title: 'foo2')
      end
    end
```

so that they can test the ordering of externals across datastores.

I've also added support for an `all: true` keyword argument to be passed to these methods so that IndexCacheTest::WithoutSetup#test_no_queries_on_definition can assert on the number of schema queries being made.

I've used a couple of ideas from the [upstream SQLCounter](https://github.com/rails/rails/blob/2042865c5f467d987c1abb2ed6c42043fbfcf1d6/activerecord/test/cases/test_case.rb#L124-L139):
* use `values[:cached]` to see if the query was cached
* use `values[:name] == 'SCHEMA'` to determine if it was a schema query

I've stopped ignoring transaction queries and instead just updated a couple of assertions to incorporate them into the expected query count.

I found the exception conditional assertions in `ensure` blocks to be confusing, so I got rid of them.

Also, I find it easier to debug `assert_no_queries` if it raises when a query is made, so I get a backtrace showing me where exactly the query was made.

I've broken these changes into multiple commits if they are hard to review together.  Let me know if it would help to further break this up into multiple pull requests.