### PR TITLE
Reduce the number of travis CI jobs by using explicit named jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,27 @@
 language: ruby
 
-rvm:
-  - 2.5
-  - 2.6
-  - 2.7
-
-gemfile:
-  - gemfiles/Gemfile.rails52
-  - gemfiles/Gemfile.latest-release
-  - gemfiles/Gemfile.rails-edge
-
-env:
-  - DB=mysql2
-  - DB=postgresql
-  - DB=mysql2 ADAPTER=memcached
-
 jobs:
-  exclude:
-    - rvm: 2.5
-      gemfile: gemfiles/Gemfile.rails-edge
-    - rvm: 2.5
-      gemfile: gemfiles/Gemfile.latest-release
+  include:
+  - name: "Minimum supported with mysql & dalli"
+    ruby: 2.5
+    gemfile: gemfiles/Gemfile.min-supported
+    env: DB=mysql2
+  - name: "Minimum supported with pg & memcached_store"
+    ruby: 2.5
+    gemfile: gemfiles/Gemfile.min-supported
+    env: DB=postgresql ADAPTER=memcached
+  - name: "Latest released with mysql & dalli"
+    ruby: 2.7
+    gemfile: gemfiles/Gemfile.latest-release
+    env: DB=mysql2
+  - name: "Latest released with pg & memcached_store"
+    ruby: 2.7
+    gemfile: gemfiles/Gemfile.latest-release
+    env: DB=postgresql ADAPTER=memcached
+  - name: "Rails master"
+    ruby: 2.7
+    gemfile: gemfiles/Gemfile.rails-edge
+    env: DB=mysql2
 
 services:
   - memcache

--- a/gemfiles/Gemfile.min-supported
+++ b/gemfiles/Gemfile.min-supported
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+gemspec path: '..'
+
+gem 'ar_transaction_changes', '~> 1.1.0'
+gem 'activerecord', '~> 5.2.0'
+gem 'mysql2', '~> 0.4.4'
+gem 'pg', '~> 0.18.0'

--- a/gemfiles/Gemfile.rails52
+++ b/gemfiles/Gemfile.rails52
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-gemspec path: '..'
-
-gem 'activerecord', '~> 5.2'
-gem 'activesupport', '~> 5.2'
-gem 'mysql2', '>= 0.4.4', '< 0.6.0'
-gem "pg", ">= 0.18", "< 2.0"

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5.0'
 
-  gem.add_dependency('ar_transaction_changes', '~> 1.0')
+  gem.add_dependency('ar_transaction_changes', '~> 1.1')
   gem.add_dependency('activerecord', '>= 5.2')
 
   gem.add_development_dependency('memcached', '~> 1.8.0')


### PR DESCRIPTION
## Problem

I rebased https://github.com/Shopify/identity_cache/pull/471 after https://github.com/Shopify/identity_cache/pull/472 was merged pushed the change about 2 hours ago and the CI build for that push (https://travis-ci.org/github/Shopify/identity_cache/builds/733400585) is still waiting for CI workers.

I think this may be because there are 21 CI jobs that are needed for each CI run, since the build matrix can grow quickly from adding to any dimension.

I also noticed we aren't even doing a good job of testing our minimum version requirements.  For instance, I tried testing the minimum supported ar_transaction_changes version and got bundle version incompatibility error.

```
Bundler could not find compatible versions for gem "activerecord":
  In Gemfile.min-supported:
    ar_transaction_changes (~> 1.0.0) was resolved to 1.0.3, which depends on
      activerecord (>= 3.0, < 5.0)

    identity_cache was resolved to 1.0.1, which depends on
      activerecord (>= 5.2)
```

## Solution

Reduce the number of CI jobs to 5, so we can test the minimum and maximum supported versions of different dependencies as well as rails edge, without having to test all the combinations of these.

Testing the minimum supported version works well across multiple dimensions, because its main purpose is to make sure we aren't depending on a feature added in a later version.  We don't need all combinations for that purpose.  Although, we might need to add more jobs if we wanted to test version specific code.

Testing the maximum supported version works well across multiple dimension, because its main purpose is to make sure we aren't using a feature that was deprecated or removed within the supported versions.