### PR TITLE
[DEV] Fixing double logging of cache hits and misses

### DIFF
--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -195,15 +195,15 @@ module IdentityCache
     end
 
     def log_multi_result(keys, memo_miss_keys, cache_miss_keys)
-      IdentityCache.logger.debug do
-        memoized_keys = keys - memo_miss_keys
-        cache_hit_keys = memo_miss_keys - cache_miss_keys
-        missed_keys = cache_miss_keys
+      return unless IdentityCache.logger.level == Logger::DEBUG
 
-        memoized_keys.each { |k| IdentityCache.logger.debug("[IdentityCache] (memoized) cache hit for #{k} (multi)") }
-        cache_hit_keys.each { |k| IdentityCache.logger.debug("[IdentityCache] (backend) cache hit for #{k} (multi)") }
-        missed_keys.each { |k| IdentityCache.logger.debug("[IdentityCache] cache miss for #{k} (multi)") }
-      end
+      memoized_keys = keys - memo_miss_keys
+      cache_hit_keys = memo_miss_keys - cache_miss_keys
+      missed_keys = cache_miss_keys
+
+      memoized_keys.each { |k| IdentityCache.logger.debug("[IdentityCache] (memoized) cache hit for #{k} (multi)") }
+      cache_hit_keys.each { |k| IdentityCache.logger.debug("[IdentityCache] (backend) cache hit for #{k} (multi)") }
+      missed_keys.each { |k| IdentityCache.logger.debug("[IdentityCache] cache miss for #{k} (multi)") }
     end
   end
 end

--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -195,7 +195,7 @@ module IdentityCache
     end
 
     def log_multi_result(keys, memo_miss_keys, cache_miss_keys)
-      return unless IdentityCache.logger.level == Logger::DEBUG
+      return unless IdentityCache.logger.debug?
 
       memoized_keys = keys - memo_miss_keys
       cache_hit_keys = memo_miss_keys - cache_miss_keys


### PR DESCRIPTION
Due to the fact that in Rails logger is extended to output to console and server respectively
https://github.com/rails/rails/blob/4cf7559/activerecord/lib/active_record/railtie.rb#L64
https://github.com/rails/rails/blob/4cf7559/railties/lib/rails/commands/server/server_command.rb#L85
there is a downside of using `IdentityCache.logger.debug` and calling it once again inside that block that results in duplication of logs:
![image](https://user-images.githubusercontent.com/6929378/95684360-d304c700-0bf9-11eb-97a4-76528ef58e92.png) 
This pull request fixes the problem by using guard-clause instead of wrapping the code in `logger.debug` call making it log only once:
![image](https://user-images.githubusercontent.com/6929378/95684543-1ca1e180-0bfb-11eb-8552-31bc1c86d8c3.png)

