### PR TITLE
Rubocop autocorrect new violations on master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gemspec
 
 gem 'mysql2', '~> 0.5.3'
 gem 'pg', ">= 0.18", "< 2.0"
-gem 'rubocop'
+gem 'rubocop', '~> 1.5'
 gem 'byebug', platform: :mri

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -54,10 +54,15 @@ module IdentityCache
   DELETED_TTL = 1000
 
   class AlreadyIncludedError < StandardError; end
+
   class AssociationError < StandardError; end
+
   class InverseAssociationError < StandardError; end
+
   class UnsupportedScopeError < StandardError; end
+
   class UnsupportedAssociationError < StandardError; end
+
   class DerivedModelError < StandardError; end
 
   mattr_accessor :cache_namespace

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -92,7 +92,7 @@ module IdentityCache
 
     def subscribe_to_cache_operations(subscriber)
       formatting_subscriber = lambda do |name, _start, _finish, _message_id, values|
-        operation = "#{name} #{(values[:keys].try(:join, ', ') || values[:key])}"
+        operation = "#{name} #{values[:keys].try(:join, ', ') || values[:key]}"
         subscriber.call(operation)
       end
       subscription = ActiveSupport::Notifications.subscribe(/cache_.*\.active_support/, formatting_subscriber)


### PR DESCRIPTION
## Problem

I pushed another branch and got the following rubocop offenses for code on master

```
Offenses:

lib/identity_cache.rb:57:3: C: Layout/EmptyLineBetweenDefs: Use empty lines between class definitions.
  class AssociationError < StandardError; end
  ^^^^^^^^^^^^^^^^^^^^^^
lib/identity_cache.rb:58:3: C: Layout/EmptyLineBetweenDefs: Use empty lines between class definitions.
  class InverseAssociationError < StandardError; end
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/identity_cache.rb:59:3: C: Layout/EmptyLineBetweenDefs: Use empty lines between class definitions.
  class UnsupportedScopeError < StandardError; end
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/identity_cache.rb:60:3: C: Layout/EmptyLineBetweenDefs: Use empty lines between class definitions.
  class UnsupportedAssociationError < StandardError; end
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/identity_cache.rb:61:3: C: Layout/EmptyLineBetweenDefs: Use empty lines between class definitions.
  class DerivedModelError < StandardError; end
  ^^^^^^^^^^^^^^^^^^^^^^^
test/test_helper.rb:95:32: C: Style/RedundantParentheses: Don't use parentheses around an interpolated expression.
        operation = "#{name} #{(values[:keys].try(:join, ', ') || values[:key])}"
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

92 files inspected, 6 offenses detected, 6 offenses auto-correctable
Error: Process completed with exit code 1.
```

I'm guessing this was caused by the major 1.0 release of rubocop.

## Solution

`bundle exec rubocop -a` fixed all these offenses

Add a major version constraint to the rubocop dev dependency.