### PR TITLE
Recursively install parent expiry hooks when expirying parent caches

### DIFF
--- a/lib/identity_cache/parent_model_expiration.rb
+++ b/lib/identity_cache/parent_model_expiration.rb
@@ -21,6 +21,7 @@ module IdentityCache
       end
 
       def install_pending_parent_expiry_hooks(model)
+        return if lazy_hooks.empty?
         name = model.name.demodulize
         if (hooks = lazy_hooks.delete(name))
           hooks.each(&:install)
@@ -40,7 +41,6 @@ module IdentityCache
     end
 
     def expire_parent_caches
-      ParentModelExpiration.install_pending_parent_expiry_hooks(cached_model)
       parents_to_expire = Set.new
       add_parents_to_cache_expiry_set(parents_to_expire)
       parents_to_expire.each do |parent|
@@ -49,6 +49,7 @@ module IdentityCache
     end
 
     def add_parents_to_cache_expiry_set(parents_to_expire)
+      ParentModelExpiration.install_pending_parent_expiry_hooks(cached_model)
       self.class.parent_expiration_entries.each do |association_name, cached_associations|
         parents_to_expire_on_changes(parents_to_expire, association_name, cached_associations)
       end

--- a/test/parent_model_expiration_test.rb
+++ b/test/parent_model_expiration_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class ParentModelExpirationTest < IdentityCache::TestCase
+  def test_recursively_expire_parent_caches
+    define_cache_indexes = lambda do
+      AssociatedRecord.cache_has_many(:deeply_associated_records, embed: true)
+      Item.cache_has_many(:associated_records, embed: true)
+    end
+    define_cache_indexes.call
+
+    # setup fixtures
+    item = Item.new(title: 'grandparent')
+
+    associated_record = AssociatedRecord.new(name: 'parent')
+    item.associated_records << associated_record
+
+    deeply_associated_record = DeeplyAssociatedRecord.new(name: "child")
+    associated_record.deeply_associated_records << deeply_associated_record
+
+    item.save!
+
+    Item.fetch(item.id) # fill cache
+
+    # reset models to test lazy parent expiration hooks
+    teardown_models
+    setup_models
+    define_cache_indexes.call
+
+    DeeplyAssociatedRecord.find(deeply_associated_record.id).update(name: 'updated child')
+
+    fetched_name = Item.fetch(item.id).fetch_associated_records.first.fetch_deeply_associated_records.first.name
+    assert_equal('updated child', fetched_name)
+  end
+end


### PR DESCRIPTION
## Problem

We had a problem in development with records not being expired when they were saved.  @andrewhassan helped me track down this problem, where we found the record was a deeply embedded association and the debug logs showed that the record along with its parent was being expired, but not the grandparent record.  So it looked like the cache expiration didn't happen when fetching the grandparent record from the cache.

I realized this is because we lazily install parent expiration hooks, in order to reduce eager loading of models for boot time performance.  On cache expiration, we install the pending parent expiration hooks, but we weren't doing this recursively.

## Solution

This PR moves the call to `ParentModelExpiration.install_pending_parent_expiry_hooks` just before the call to `parent_expiration_entries` that it affects, in a method that gets called recursively during parent expiration.

Since `ParentModelExpiration.install_pending_parent_expiry_hooks` will be called more often, I reduced the `model.name.demodulize` overhead from calling this method using a fast path for when all hooks have been installed.

I've also included a regression test which fails without the corresponding fix.  This situation wasn't well tested because it requires inserting fixtures and filling the cache before setting up the models, which I simulated by tearing down and setting up the models again in the test, similar to what we do in SchemaChangeTest#test_embed_existing_cache_has_many