### PR TITLE
changelog: Add entries for unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,16 @@
 
 ### Fixes
 - Recursively install parent expiry hooks when expiring parent caches (#476)
-- Expire caches before other after_commit callbacks (#471)
+- Expire caches before other `after_commit` callbacks (#471)
 - Avoid unnecessary record cache expiry on save with no DB update (#464)
-- Fix an Active Record deprecation warning by not using Connection#type_cast (#459)
-- Fix broken prefetch_associations of a polymorphic cache_belongs_to (#461)
-- Fix should_use_cache check to avoid calling it on the wrong class (#454)
-- Fix fetch has_many embedded association on record after adding to it (#449)
+- Fix an Active Record deprecation warning by not using `Connection#type_cast` (#459)
+- Fix broken `prefetch_associations` of a polymorphic `cache_belongs_to` (#461)
+- Fix `should_use_cache?` check to avoid calling it on the wrong class (#454)
+- Fix fetch `has_many` embedded association on record after adding to it (#449)
 
 ### Features
-- Support multiple databases and transactional tests in IdentityCache.should_use_cache? (#293)
-- Add support for the default MemCacheStore from ActiveSupport (#465)
+- Support multiple databases and transactional tests in `IdentityCache.should_use_cache?` (#293)
+- Add support for the default `MemCacheStore` from `ActiveSupport` (#465)
 
 ### Breaking Changes
 - Drop ruby 2.4 support, since it is no longer supported upstream (#468)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # IdentityCache changelog
 
+## Unreleased
+
+### Fixes
+- Recursively install parent expiry hooks when expiring parent caches (#476)
+- Expire caches before other after_commit callbacks (#471)
+- Avoid unnecessary record cache expiry on save with no DB update (#464)
+- Fix an Active Record deprecation warning by not using Connection#type_cast (#459)
+- Fix broken prefetch_associations of a polymorphic cache_belongs_to (#461)
+- Fix should_use_cache check to avoid calling it on the wrong class (#454)
+- Fix fetch has_many embedded association on record after adding to it (#449)
+
+### Features
+- Support multiple databases and transactional tests in IdentityCache.should_use_cache? (#293)
+- Add support for the default MemCacheStore from ActiveSupport (#465)
+
+### Breaking Changes
+- Drop ruby 2.4 support, since it is no longer supported upstream (#468)
+
 ## 1.0.1
 
 - Fix expiry of cache_has_one association with scope and `embed: :id` (#442)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # IdentityCache changelog
 
-#### 1.0.1
+## 1.0.1
 
 - Fix expiry of cache_has_one association with scope and `embed: :id` (#442)
 
-#### 1.0.0
+## 1.0.0
 
 - Remove inverse_name option. Specify inverse_of on the Active Record association instead. (#439)
 - Bump the minimum Active Record version to 5.2 (#438)
@@ -25,16 +25,16 @@
 - Remove deprecated `never_set_inverse_association` option (#319)
 - Lazy load associated classes (#306)
 
-#### 0.5.1
+## 0.5.1
 
 - Fix bug in prefetch_associations for cache_has_one associations that may be nil
 
-#### 0.5.0
+## 0.5.0
 
 - `never_set_inverse_association` and `fetch_read_only_records` are now `true` by default (#315)
 - Store the class name instead of the class itself (#311)
 
-#### 0.4.1
+## 0.4.1
 
 - Deprecated embedded associations on models that don't use IDC (#305)
 - Remove a respond_to? check that hides mistakes in includes hash (#307)
@@ -45,11 +45,11 @@
 - Clone instead of dup record when readonlyifying fetched records (#292)
 - Consistently store the array for cached has many associations (#288)
 
-#### 0.4.0
+## 0.4.0
 
 - Return an array from fetched association to prevent chaining. Up to now, a relation was returned by default. (#287)
 
-#### 0.3.2
+## 0.3.2
 
 - Deprecate returning non read-only records when cache is used. Set IdentityCache.fetch_readonly_records to true to avoid this. (#282)
 - Use loaded association first when fetching a cache_has_many id embedded association (#280)
@@ -57,11 +57,11 @@
 - Fetch association returns relation or array depending on the configuration. It was only returning a relation for cache_has_many fetch association methods. (#276)
 - Stop sharing the same attributes hash between the fetched record and the memoized cache, which could interfere with dirty tracking (#267)
 
-#### 0.3.1
+## 0.3.1
 
 - Fix cache_index for non-id primary key
 
-#### 0.3.0
+## 0.3.0
 
 - Add support for includes option on cache_index and fetch_by_id
 - Use ActiveRecord instantiate
@@ -74,37 +74,37 @@
 - Fix cache_belongs_to on polymorphic assocations.
 - Fetching a cache_belongs_to association no longer loads the belongs_to association
 
-#### 0.2.5
+## 0.2.5
 
 - Fixed support for namespaced model classes
 - Added some deduplication for parent cache expiry
 - Fixed some deprecation warnings in rails 4.2
 
-#### 0.2.4
+## 0.2.4
 
 - Refactoring, documentation and test changes
 
-#### 0.2.3
+## 0.2.3
 
 - PostgreSQL support
 - Rails 4.2 compatibility
 - Fix: Don't connect to database when calling `IdentityCache.should_use_cache?`
 - Fix: Fix invalid parent cache invalidation if object is embedded in different parents
 
-#### 0.2.2
+## 0.2.2
 
 - Change: memcached is no longer a runtime dependency
 - Use cache for read-only models.
 
-#### 0.2.1
+## 0.2.1
 
 - Add a fallback backend using local memory.
 
-#### 0.2.0
+## 0.2.0
 
 - Memcache CAS support
 
-#### 0.1.0
+## 0.1.0
 
 - Backwards incompatible change: Stop expiring cache on after_touch callback.
 - Change: fetch_multi accepts an array of keys as argument
@@ -115,29 +115,29 @@
 - Fix: Avoid unused preload on fetch_multi with :includes option for cache miss
 - Fix: reload will invalidate the local instance cache
 
-#### 0.0.7
+## 0.0.7
 
 - Add support for non-integer primary keys
 - Fix: Not implemented error for cache_has_one with embed: false
 - Fix: cache key to change when adding a cache_has_many association with :embed => false
 - Fix: Compatibility rails 4.1 for `quote_value`, which needs default column.
 
-#### 0.0.6
+## 0.0.6
 
 - Fix: bug where previously nil-cached attribute caches weren't expired on record creation
 - Fix: cache key to not change when adding a non-embedded association.
 - Perf: Rails 4 Only create `CollectionProxy` when using it
 
-#### 0.0.5
+## 0.0.5
 
 
-#### 0.0.4
+## 0.0.4
 
 - Fix: only marshal attributes, embedded associations and normalized association IDs
 - Add cache version number to cache keys
 - Add test case to ensure version number is updated when the marshalled format changes
 
-#### 0.0.3
+## 0.0.3
 
 - Fix: memoization for multi hits actually work
 - Fix: quotes `SELECT` projection elements on cache misses
@@ -145,7 +145,7 @@
 - Fix: table names are not hardcoded anymore
 - Logger now differentiates memoized vs non memoized hits
 
-#### 0.0.2
+## 0.0.2
 
 - Fix: Existent embedded entries will no longer raise when `ActiveModel::MissingAttributeError` when accessing a newly created attribute.
 - Fix: Do not marshal raw ActiveRecord associations


### PR DESCRIPTION
I've also started to group the changes by whether they are fixes, features or breaking changes.  This should make it easier to make a release and decide what the new release number should be.  Note that I listed dropping an EOL version or ruby as a breaking change, although, I don't think we should bother with a major release just for that.

I've also updated previous release headers so that they don't skip header depths.  That way we don't need to nest the change grouping headers so deeply.