### PR TITLE
Fix ActiveRecord::Associations::Preloader#preload call on rails edge

### DIFF
--- a/lib/identity_cache/cached/prefetcher.rb
+++ b/lib/identity_cache/cached/prefetcher.rb
@@ -38,7 +38,8 @@ module IdentityCache
 
         def fetch_association(load_strategy, klass, association, records, &block)
           unless klass.should_use_cache?
-            ActiveRecord::Associations::Preloader.new.preload(records, association)
+            preload_scope = nil
+            ActiveRecord::Associations::Preloader.new.preload(records, association, preload_scope)
             return yield
           end
 


### PR DESCRIPTION
## Problem

I noticed in my changelog update PR that CI is failing with rails edge (https://travis-ci.org/github/Shopify/identity_cache/jobs/749702526) with the following error

```
  1) Error:
IdentityCache::PrefetchAssociationsTest#test_prefetch_associations_without_using_cache:
ArgumentError: wrong number of arguments (given 2, expected 3)
    /home/travis/build/Shopify/identity_cache/gemfiles/vendor/bundle/ruby/2.7.0/bundler/gems/rails-25c3eab0dcf0/activerecord/lib/active_record/associations/preloader.rb:106:in `preload'
    /home/travis/build/Shopify/identity_cache/lib/identity_cache/cached/prefetcher.rb:41:in `fetch_association'
```
...

because the ActiveRecord::Associations::Preloader#preload method removed the default value from the 3rd parameter.

## Solution

Looks like ActiveRecord::Associations::Preloader#preload will handle the old default value of `nil` the same way, so just pass it explicitly.