### PR TITLE
Support Rails 7.0 without deprecation

### DIFF
--- a/test/identity_cache_test.rb
+++ b/test/identity_cache_test.rb
@@ -23,7 +23,11 @@ class IdentityCacheWithTransactionalFixturesTest < ActiveSupport::TestCase
   self.use_transactional_tests = true
 
   class ModelWithConnection < ActiveRecord::Base
-    establish_connection ActiveRecord::Base.connection_config
+    if ActiveRecord.gem_version < Gem::Version.new('6.1.0.alpha')
+      establish_connection ActiveRecord::Base.connection_config
+    else
+      establish_connection ActiveRecord::Base.connection_db_config
+    end
   end
 
   def test_should_use_cache_outside_transaction
@@ -48,7 +52,11 @@ class IdentityCacheWithoutTransactionalFixturesTest < ActiveSupport::TestCase
   self.use_transactional_tests = false
 
   class ModelWithConnection < ActiveRecord::Base
-    establish_connection ActiveRecord::Base.connection_config
+    if ActiveRecord.gem_version < Gem::Version.new('6.1.0.alpha')
+      establish_connection ActiveRecord::Base.connection_config
+    else
+      establish_connection ActiveRecord::Base.connection_db_config
+    end
   end
 
   def test_should_use_cache_outside_transaction


### PR DESCRIPTION
`ActiveRecord::Associations::Preloader` old API is deprecated and call insides this gem were causing applications to print deprecations.

I defined the `preload_records` method conditionally based on the Active Record version so we don't have the runtime penalty to check which API we should call.

There is an extra commit to remove a deprecation on Rails 6.1.