### PR TITLE
Run tests against ruby 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         sudo apt-get -y install libmemcached-dev libmysqlclient-dev libpq-dev libsasl2-dev
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.entry.ruby }}
     - name: Install bundler and gems

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
             ruby: 2.7
             gemfile: "Gemfile.rails-edge"
             edge: true
+          - name: 'Ruby 3 - Rails edge'
+            ruby: 3.0
+            gemfile: "Gemfile.rails-edge"
+            edge: true
 
     name: ${{ matrix.entry.name }}
 

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('activerecord', '>= 5.2')
 
   gem.add_development_dependency('memcached', '~> 1.8.0')
-  gem.add_development_dependency('memcached_store', '~> 1.0.0')
+  gem.add_development_dependency('memcached_store', '>= 2.1.5')
   gem.add_development_dependency('dalli')
   gem.add_development_dependency('rake')
   gem.add_development_dependency('mocha', '0.14.0')


### PR DESCRIPTION
Add CI entry for Ruby 3.0 - Rails edge
Versions of `memcached_store` prior to `2.1.5` are incompatible with Ruby 3. The fix for using the last argument as keyword parameters was fixed in memcached_store in Shopify/memcached_store#56