### PR TITLE
Update dependencies used in development and on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
             ruby: 2.5
             gemfile: "Gemfile.min-supported"
           - name: 'Latest released & run rubocop'
-            ruby: 2.7
+            ruby: 3.0
             gemfile: "Gemfile.latest-release"
             rubocop: true
           - name: 'Rails edge'
-            ruby: 2.7
+            ruby: 3.0
             gemfile: "Gemfile.rails-edge"
             edge: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,9 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'rubocop', '~> 1.5'
 gem 'mysql2', '~> 0.5.3'
 gem 'pg', ">= 0.18", "< 2.0"
-gem 'rubocop', '~> 1.5'
+
 gem 'byebug', platform: :mri
+gem 'stackprof', platform: :mri

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,13 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rubocop', '~> 1.5'
-gem 'mysql2', '~> 0.5.3'
-gem 'pg', ">= 0.18", "< 2.0"
+
+gem 'mysql2', '~> 0.5.3', platform: :mri
+gem 'pg', ">= 0.18", "< 2.0", platform: :mri
+gem 'memcached', '~> 1.8.0', platform: :mri
+gem 'memcached_store', '~> 1.0.0', platform: :mri
+gem 'dalli', '~> 2.7.11'
+gem 'cityhash', '~> 0.6.0', platform: :mri
 
 gem 'byebug', platform: :mri
 gem 'stackprof', platform: :mri

--- a/gemfiles/Gemfile.latest-release
+++ b/gemfiles/Gemfile.latest-release
@@ -1,8 +1,12 @@
 source 'https://rubygems.org'
 gemspec path: '..'
 
+gem 'rubocop', '~> 1.5'
+
 gem 'activerecord'
 gem 'activesupport'
-gem "mysql2", ">= 0.4.4"
-gem "pg", ">= 0.18", "< 2.0"
-gem 'rubocop', '~> 1.5'
+gem "mysql2", "~> 0.5"
+gem "pg", "~> 1.1"
+gem 'memcached_store'
+gem 'dalli'
+gem 'cityhash'

--- a/gemfiles/Gemfile.min-supported
+++ b/gemfiles/Gemfile.min-supported
@@ -2,6 +2,11 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'ar_transaction_changes', '~> 1.1.0'
+
 gem 'activerecord', '~> 5.2.0'
 gem 'mysql2', '~> 0.4.4'
 gem 'pg', '~> 0.18.0'
+gem 'memcached', '~> 1.8.0'
+gem 'memcached_store', '~> 1.0.0'
+gem 'dalli', '~> 2.7.11'
+gem 'cityhash', '~> 0.6.0'

--- a/gemfiles/Gemfile.rails-edge
+++ b/gemfiles/Gemfile.rails-edge
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gemspec path: '..'
 
-gem 'activerecord', github: 'rails/rails'
+gem 'activerecord', github: 'rails/rails', branch: 'main'
 gem 'activesupport', github: 'rails/rails'
 gem "mysql2", "~> 0.5"
 gem "pg", "~> 1.1"

--- a/gemfiles/Gemfile.rails-edge
+++ b/gemfiles/Gemfile.rails-edge
@@ -3,5 +3,8 @@ gemspec path: '..'
 
 gem 'activerecord', github: 'rails/rails'
 gem 'activesupport', github: 'rails/rails'
-gem "mysql2", ">= 0.4.4"
+gem "mysql2", "~> 0.5"
 gem "pg", "~> 1.1"
+gem 'memcached_store'
+gem 'dalli'
+gem 'cityhash'

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -42,16 +42,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('mocha', '~> 1.12')
   gem.add_development_dependency('spy', '~> 1.0')
   gem.add_development_dependency('minitest', '~> 5.14')
-
-  gem.add_development_dependency('memcached', '~> 1.8.0')
-  gem.add_development_dependency('memcached_store', '~> 1.0.0')
-  gem.add_development_dependency('dalli')
-
-  if RUBY_PLATFORM == 'java'
-    raise NotImplementedError
-  else
-    gem.add_development_dependency('cityhash', '0.6.0')
-    gem.add_development_dependency('mysql2')
-    gem.add_development_dependency('pg')
-  end
 end

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -38,13 +38,14 @@ Gem::Specification.new do |gem|
   gem.add_dependency('ar_transaction_changes', '~> 1.1')
   gem.add_dependency('activerecord', '>= 5.2')
 
+  gem.add_development_dependency('rake', '~> 13.0')
+  gem.add_development_dependency('mocha', '~> 1.12')
+  gem.add_development_dependency('spy', '~> 1.0')
+  gem.add_development_dependency('minitest', '~> 5.14')
+
   gem.add_development_dependency('memcached', '~> 1.8.0')
   gem.add_development_dependency('memcached_store', '~> 1.0.0')
   gem.add_development_dependency('dalli')
-  gem.add_development_dependency('rake')
-  gem.add_development_dependency('mocha', '0.14.0')
-  gem.add_development_dependency('spy')
-  gem.add_development_dependency('minitest', '>= 2.11.0')
 
   if RUBY_PLATFORM == 'java'
     raise NotImplementedError
@@ -52,6 +53,5 @@ Gem::Specification.new do |gem|
     gem.add_development_dependency('cityhash', '0.6.0')
     gem.add_development_dependency('mysql2')
     gem.add_development_dependency('pg')
-    gem.add_development_dependency('stackprof')
   end
 end


### PR DESCRIPTION
## Problem

I noticed that we were using some old development dependencies (e.g. mocha 0.14.0 is from 2013), weren't actually testing the latest version of optional runtime dependencies (e.g. memcached_store) and weren't testing the latest version of ruby (3) on CI.

## Solution

I used the gemspec to specify the common development and CI dependencies and pinned these dependencies to a major version.

I've added a version constraint for optional runtime dependencies in gemfiles/Gemfile.min-supported and removed these constraints from gemfiles/Gemfile.latest-release so that we can test old and new versions of these gems.

The above allowed ruby 3 to be tested without issues, so I updated CI to use ruby 3 as the latest ruby version.