### PR TITLE
CI: Revert back to testing ruby 2.7 as the latest version for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ jobs:
       matrix:
         entry:
           - name: 'Minimum supported'
-            ruby: 2.5
+            ruby: '2.5'
             gemfile: "Gemfile.min-supported"
           - name: 'Latest released & run rubocop'
-            ruby: 3.0
+            ruby: '2.7'
             gemfile: "Gemfile.latest-release"
             rubocop: true
           - name: 'Rails edge'
-            ruby: 3.0
+            ruby: '2.7'
             gemfile: "Gemfile.rails-edge"
             edge: true
 


### PR DESCRIPTION
## Problem

CI on master failed (https://github.com/Shopify/identity_cache/runs/1749428232) after merging https://github.com/Shopify/identity_cache/pull/485 which starts testing with ruby 3, even though CI passed with ruby 3 on the branch (https://github.com/Shopify/identity_cache/runs/1710455356).

I found that the CI ruby version is provided by the [Virtual Environment](https://github.com/actions/virtual-environments) and that the CI run links to the used virtual environment.  The [passing virtual environment included ruby 3](https://github.com/actions/virtual-environments/blob/ubuntu18/20210111.1/images/linux/Ubuntu1804-README.md#ruby) and the [failing version didn't include ruby 3](https://github.com/actions/virtual-environments/blob/ubuntu18/20201210.0/images/linux/Ubuntu1804-README.md#ruby).  https://github.com/actions/virtual-environments/pull/2514 is the revert of the ruby 3 support.

## Solution

Revert back to using ruby 2.7 in CI as the latest ruby version until ruby 3 support is added again to the virtual environment.

I also used strings for the versions, since I noticed in the error message that `ruby: 3.0` in the matrix entry resulted in `ruby-version: 3` being used after variable substitution.