### PR TITLE
CI: Use ruby/setup-ruby since actions/setup-ruby is deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ jobs:
       matrix:
         entry:
           - name: 'Minimum supported'
-            ruby: 2.5
+            ruby: '2.5'
             gemfile: "Gemfile.min-supported"
           - name: 'Latest released & run rubocop'
-            ruby: 3.0
+            ruby: '3.0'
             gemfile: "Gemfile.latest-release"
             rubocop: true
           - name: 'Rails edge'
-            ruby: 3.0
+            ruby: '3.0'
             gemfile: "Gemfile.rails-edge"
             edge: true
 
@@ -70,7 +70,7 @@ jobs:
         sudo apt-get -y install libmemcached-dev libmysqlclient-dev libpq-dev libsasl2-dev
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.entry.ruby }}
     - name: Install bundler and gems


### PR DESCRIPTION
Closes #484

## Problem

As explained on https://github.com/Shopify/identity_cache/pull/486

> CI on master failed (https://github.com/Shopify/identity_cache/runs/1749428232) after merging #485 which starts testing with ruby 3, even though CI passed with ruby 3 on the branch (https://github.com/Shopify/identity_cache/runs/1710455356).
> 
> I found that the CI ruby version is provided by the [Virtual Environment](https://github.com/actions/virtual-environments) and that the CI run links to the used virtual environment. The [passing virtual environment included ruby 3](https://github.com/actions/virtual-environments/blob/ubuntu18/20210111.1/images/linux/Ubuntu1804-README.md#ruby) and the [failing version didn't include ruby 3](https://github.com/actions/virtual-environments/blob/ubuntu18/20201210.0/images/linux/Ubuntu1804-README.md#ruby). [actions/virtual-environments#2514](https://github.com/actions/virtual-environments/pull/2514) is the revert of the ruby 3 support.

although that problem has now been fixed, https://github.com/actions/setup-ruby has now been deprecated

## Solution

Use https://github.com/ruby/setup-ruby which supports ruby 3.0 and is the recommended replacement for https://github.com/actions/setup-ruby.

Also from https://github.com/Shopify/identity_cache/pull/486:

> I also used strings for the versions, since I noticed in the error message that `ruby: 3.0` in the matrix entry resulted in `ruby-version: 3` being used after variable substitution.