### PR TITLE
README: Fix Build Status badge to references recent CI builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # IdentityCache
-[![Build Status](https://travis-ci.org/Shopify/identity_cache.svg?branch=master)](https://travis-ci.org/Shopify/identity_cache)
+[![Build Status](https://github.com/Shopify/identity_cache/workflows/CI/badge.svg?branch=master)](https://github.com/Shopify/identity_cache/actions?query=branch%3Amaster)
 
 Opt in read through ActiveRecord caching used in production and extracted from Shopify. IdentityCache lets you specify how you want to cache your model objects, at the model level, and adds a number of convenience methods for accessing those objects through the cache. Memcached is used as the backend cache store, and the database is only hit when a copy of the object cannot be found in Memcached.
 


### PR DESCRIPTION
## Problem

The README's build status badge currently says CI is passing on master, but CI master is currently failing, requiring https://github.com/Shopify/identity_cache/pull/487 to fix it.  This is because the build status badge is still referencing travis CI, which we are no longer using for CI

## Solution

Use a github actions badge instead (https://docs.github.com/en/actions/managing-workflow-runs/adding-a-workflow-status-badge)