### PR TITLE
Fix mem_cache_store adapter with connection_pool

### DIFF
--- a/lib/identity_cache/mem_cache_store_cas.rb
+++ b/lib/identity_cache/mem_cache_store_cas.rb
@@ -29,7 +29,7 @@ module IdentityCache
       keys = keys_to_names.keys
       rescue_error_with(false) do
         instrument(:cas_multi, keys, options) do
-          raw_values = @data.get_multi_cas(keys)
+          raw_values = @data.with { |c| c.get_multi_cas(keys) }
 
           values = {}
           raw_values.each do |key, raw_value|
@@ -44,7 +44,7 @@ module IdentityCache
             cas_id = raw_values[key].last
             entry = ActiveSupport::Cache::Entry.new(value, **options)
             payload = options[:raw] ? entry.value.to_s : entry
-            @data.replace_cas(key, payload, cas_id, options[:expires_in].to_i, options)
+            @data.with { |c| c.replace_cas(key, payload, cas_id, options[:expires_in].to_i, options) }
           end
         end
       end


### PR DESCRIPTION
Fixes #483

## Problem

I was able to reproduce the bug by running the tests with the following diff

```
diff --git a/Gemfile b/Gemfile
index 7df2ce3..064343f 100644
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'memcached', '~> 1.8.0', platform: :mri
 gem 'memcached_store', '~> 1.0.0', platform: :mri
 gem 'dalli', '~> 2.7.11'
 gem 'cityhash', '~> 0.6.0', platform: :mri
+gem 'connection_pool'
 
 gem 'byebug', platform: :mri
 gem 'stackprof', platform: :mri
diff --git a/test/helpers/cache_connection.rb b/test/helpers/cache_connection.rb
index ff957b6..d190865 100644
--- a/test/helpers/cache_connection.rb
+++ b/test/helpers/cache_connection.rb
@@ -23,7 +23,7 @@ module CacheConnection
     case ENV['ADAPTER']
     when nil, 'dalli'
       require 'active_support/cache/mem_cache_store'
-      ActiveSupport::Cache::MemCacheStore.new(address, failover: false, expires_in: 6.hours.to_i)
+      ActiveSupport::Cache::MemCacheStore.new(address, failover: false, expires_in: 6.hours.to_i, pool_size: 2)
     when 'memcached'
       require 'memcached_store'
       require 'active_support/cache/memcached_store'

```

## Solution

Avoid calling anything other than `.with` on `@data` so it works with the connection pool.