### PR TITLE
Add expire methods by key values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,4 +90,4 @@ jobs:
       run: bundle exec rake test
     - name: Run rubocop
       if: matrix.entry.rubocop
-      run: bundle exec rubocop
+      run: bundle exec rubocop --debug

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -67,6 +67,8 @@ module IdentityCache
 
   class LockWaitTimeout < StandardError; end
 
+  class MissingKeyName < StandardError; end
+
   mattr_accessor :cache_namespace
   self.cache_namespace = "IDC:#{CACHE_VERSION}:"
 

--- a/test/expire_by_key_values_test.rb
+++ b/test/expire_by_key_values_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class ExpireByKeyValuesTest < IdentityCache::TestCase
+  NAMESPACE = IdentityCache::CacheKeyGeneration::DEFAULT_NAMESPACE
+
+  def setup
+    super
+    AssociatedRecord.cache_attribute(:name)
+    AssociatedRecord.cache_attribute(:name, by: :item_id)
+    AssociatedRecord.cache_attribute(:name, by: [:id, :item_id])
+
+    parent = Item.create!(title: "bob")
+    parent.associated_records.create!(name: "foo")
+    IdentityCache.cache.clear
+  end
+
+  def test_expire_by_key_values
+    assert_queries(3) do
+      assert_equal("foo", AssociatedRecord.fetch_name_by_id(1))
+      assert_equal("foo", AssociatedRecord.fetch_name_by_item_id(1))
+      assert_equal("foo", AssociatedRecord.fetch_name_by_id_and_item_id(1, 1))
+    end
+
+    assert_queries(0) do
+      assert_equal("foo", AssociatedRecord.fetch_name_by_id(1))
+      assert_equal("foo", AssociatedRecord.fetch_name_by_item_id(1))
+      assert_equal("foo", AssociatedRecord.fetch_name_by_id_and_item_id(1, 1))
+    end
+
+    key_values = {
+      id: 1,
+      item_id: 1,
+    }
+
+    AssociatedRecord.cache_indexes.each do |index|
+      index.expire_by_key_value(key_values)
+    end
+
+    assert_queries(3) do
+      assert_equal("foo", AssociatedRecord.fetch_name_by_id(1))
+      assert_equal("foo", AssociatedRecord.fetch_name_by_item_id(1))
+      assert_equal("foo", AssociatedRecord.fetch_name_by_id_and_item_id(1, 1))
+    end
+  end
+
+  def test_expire_by_key_values_raises_exception_on_missing_key
+    by_id_index, by_item_id_index, by_multi_index = AssociatedRecord.cache_indexes
+    missing_id_error_message =
+      "AssociatedRecord attribute name expire_by_key_value - required fields: id. missing: id"
+    missing_item_id_error_message =
+      "AssociatedRecord attribute name expire_by_key_value - required fields: item_id. missing: item_id"
+    missing_id_key_in_multi_error_message =
+      "AssociatedRecord attribute name expire_by_key_value - required fields: id, item_id. missing: id"
+
+    missing_id_error = assert_raises(IdentityCache::MissingKeyName) do
+      by_id_index.expire_by_key_value({ item_id: 1 })
+    end
+    missing_item_id_error = assert_raises(IdentityCache::MissingKeyName) do
+      by_item_id_index.expire_by_key_value({ id: 1 })
+    end
+    missing_id_in_multi_error = assert_raises(IdentityCache::MissingKeyName) do
+      by_multi_index.expire_by_key_value({ item_id: 1 })
+    end
+
+    assert_equal(missing_id_error_message, missing_id_error.message)
+    assert_equal(missing_item_id_error_message, missing_item_id_error.message)
+    assert_equal(missing_id_key_in_multi_error_message, missing_id_in_multi_error.message)
+  end
+end


### PR DESCRIPTION
There are situations where performance is crucial. For those reasons it can be desired to utilize methods that do not instantiate active record objects, for example `pluck` for reading data and `upsert_all` for writing data. Utilizing these gives the developer the flexibility to read or update the needed information without needing to take the time to instantiate a new Active Record instance for each of the objects as this instantiation can really add up on processing time.

Following the `pluck` example utilizing the IDC feature of `cache_attribute` it is super useful in the case that we need just one value of one record. In the case where we need to update these records it might be preferred to utilize `upsert_all` which does not instantiate any ActiveRecords and we don't have a way to expire the cache. A possible way to accomplish this is to fetch the data before doing the update or update them through the ActiveRecord object, although the performance would be very poorly in which `upsert_all` is preferred.

We are proposing on this PR a method to expire the cache when you don't have a direct access to an ActiveRecord instance. The method is attached to the `Attribute` class and we can access it like this:
```ruby
# item.rb
cache_attribute :name, by: :id
```
```ruby
# item_management.rb in the project
NameOfScope::Item.cache_indexes.each do |index|
    index.expire_by_key_value({ id: 1 })
end
```

We decided to pass a hash for the case of when we have an attribute cached by multiple keys:
```ruby
# item.rb
cache_attribute :name, by: [:id, :item_id]
```
```ruby
# item_management.rb in the project
NameOfScope::Item.cache_indexes.each do |index|
    index.expire_by_key_value({ id: 1, item_id:10 })
end
```

This also lets us have this case:
```ruby
# item.rb
cache_attribute :name, by: :id
cache_attribute :name, by: :other_property
cache_attribute :name, by: [:id, :item_id]
```
```ruby
# item_management.rb in the project
NameOfScope::Item.cache_indexes.each do |index|
    index.expire_by_key_value({ id: 1, item_id: 10, other_property: 11 })
end
```
We made this the most flexible possible to be able to handle these different possibilities as well as to avoid expiring the cache and missing one key, the attribute class will raise an exception letting you know that there is a missing field.

If the update changes the value of the key, then pluck should be used to get the current values, and the expiration call should include both the new and old values of the keys.

There is also some discussion about these changes, the main questions that comes out from these changes are:
* Should we also add methods to expire `expire_<attribute>_by_<key>`? In my opinion it could add a possible problem where you only expire one key of the object and not the other one, but we believe it is a good discussion to have.
* Should the gem have a method that does the `NameOfScope::Item.cache_indexes.each`

@Shopify/delivery-platform 