### PR TITLE
Avoid rubocop errors by skipping the version of rubocop with a bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,10 @@
 source "https://rubygems.org"
 gemspec
 
-gem "rubocop", "~> 1.5"
+# Skip rubocop 1.16.1 until the next release which will include the fix:
+# https://github.com/rubocop/rubocop/pull/9862
+gem "rubocop", "~> 1.5", "!= 1.16.1"
+
 gem "rubocop-shopify", "~> 2.0.1", require: false
 
 gem "mysql2", "~> 0.5.3", platform: :mri

--- a/gemfiles/Gemfile.latest-release
+++ b/gemfiles/Gemfile.latest-release
@@ -1,7 +1,9 @@
 source "https://rubygems.org"
 gemspec path: ".."
 
-gem "rubocop", "~> 1.5"
+# Skip rubocop 1.16.1 until the next release which will include the fix:
+# https://github.com/rubocop/rubocop/pull/9862
+gem "rubocop", "~> 1.5", "!= 1.16.1"
 gem "rubocop-shopify", "~> 2.0.1", require: false
 
 gem "activerecord"


### PR DESCRIPTION
## Problem

Rubocop 1.16.1 was released a couple of days ago, which introduced errors in CI (e.g. failing build https://github.com/Shopify/identity_cache/runs/2796385731)

## Solution

I tested on the previous release of rubocop (1.16.0) and it didn't have the problem.  I also tested against rubocop master and it was fixed there (specifically by ttps://github.com/rubocop/rubocop/pull/9862).  So we can just skip the rubocop version with the bug until the next release.