### PR TITLE
Fix mocha deprecation

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "logger"
 require "minitest/autorun"
-require "mocha/setup"
+require "mocha/minitest"
 require "active_record"
 require "helpers/database_connection"
 require "helpers/cache_connection"


### PR DESCRIPTION
Branch is based on https://github.com/Shopify/identity_cache/pull/496 to avoid CI failures

The warning from running the tests was

```Mocha deprecation warning at test/test_helper.rb:4:in `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'```

So I chose to use 'mocha/minitest', the most appropriate of the suggested changes recommended in that error message