### PR TITLE
Do not raise scope error if IdentityCache is disabled

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -22,6 +22,8 @@ module IdentityCache
       private
 
       def raise_if_scoped
+        return unless should_use_cache?
+
         if current_scope
           IdentityCache.logger.error("#{name} has scope: #{current_scope.to_sql} (#{current_scope.values.keys})")
           raise UnsupportedScopeError, "IdentityCache doesn't support rails scopes (#{name})"


### PR DESCRIPTION
## Why

`should_use_cache?` method acts as a guard when the model/DB is in an undesirable state to use the IDC.

We're overriding this method to manipulate when to use model IDC conditionally.
I think raising an Rails scope error when cache is not being used, is misleading.

## Reviews

Is my understanding of `should_use_cache?` correct? Will there be a case we want to raise this error, even when `should_use_cache?` is false?