### PR TITLE
Added new method to safely fetch read only records

### DIFF
--- a/lib/identity_cache/cache_hash.rb
+++ b/lib/identity_cache/cache_hash.rb
@@ -22,12 +22,12 @@ module IdentityCache
   module CacheHash
     if defined?(CityHash)
 
-      def memcache_hash(key) #:nodoc:
+      def memcache_hash(key) # :nodoc:
         CityHash.hash64(key)
       end
     else
 
-      def memcache_hash(key) #:nodoc:
+      def memcache_hash(key) # :nodoc:
         a = Digest::MD5.digest(key).unpack("LL")
         (a[0] << 32) | a[1]
       end

--- a/lib/identity_cache/encoder.rb
+++ b/lib/identity_cache/encoder.rb
@@ -66,7 +66,7 @@ module IdentityCache
         end
       end
 
-      def record_from_coder(coder, klass) #:nodoc:
+      def record_from_coder(coder, klass) # :nodoc:
         record = klass.instantiate(coder[:attributes].dup)
 
         if coder.key?(:associations)

--- a/lib/identity_cache/without_primary_index.rb
+++ b/lib/identity_cache/without_primary_index.rb
@@ -12,7 +12,7 @@ module IdentityCache
     include IdentityCache::ShouldUseCache
     include ParentModelExpiration
 
-    def self.append_features(base) #:nodoc:
+    def self.append_features(base) # :nodoc:
       raise AlreadyIncludedError if base.include?(WithoutPrimaryIndex)
       super
     end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

As `with_fetch_read_only_records` is not thread-safe, the following happens:

1. T1 calls `with_fetch_read_only_records(false)`, value is set to false.
2. T2 calls `with_fetch_read_only_records(false)`, value is set to false
3. T1 loads user.
4. T1 resets `fetch_read_only_records` to the old value (true).
5. T2 loads user (which is set to read only)
6. T3 resets `fetch_read_only_records` to old value (true, so no change).

By not having the `fetch_read_only_records` thread-safed we might have every now and then `ActiveRecord::ReadOnlyRecord` errors.

**How does it do it?**

A new method was created to fetch read only records flag safely:
```ruby
    def fetch_read_only_records
      v = Thread.current[:identity_cache_fetch_read_only_records]
      return v unless v.nil?
      fetch_read_only_records
    end
```

Which will be used in `with_fetch_read_only_records`.

I think we could simply use `IdentityCache.fetch_read_only_records = false` in the initializer but we want to set the IDC fetch strategy granularly. 