### PR TITLE
Fix tests on rails 7 by not trying to clear autoload dependencies

### DIFF
--- a/test/helpers/active_record_objects.rb
+++ b/test/helpers/active_record_objects.rb
@@ -26,8 +26,10 @@ module ActiveRecordObjects
   end
 
   def teardown_models
-    ActiveSupport::DescendantsTracker.clear
-    ActiveSupport::Dependencies.clear
+    if ActiveRecord::VERSION::MAJOR < 7
+      ActiveSupport::DescendantsTracker.clear
+      ActiveSupport::Dependencies.clear
+    end
     Object.send(:remove_const, "DeeplyAssociatedRecord")
     Object.send(:remove_const, "PolymorphicRecord")
     Object.send(:remove_const, "NormalizedAssociatedRecord")


### PR DESCRIPTION
cc @joelpinheiro

Fixes #504

Dependencies used to be tracked by default in Active Support and needed to be cleared to make the tests pass.  However, on rails 7 the autoloader isn't set by default on ActiveSupport::Dependencies so this is resulting in `NoMethodError`s.  ActiveSupport::Dependencies.clear is also documented as being a private API in rails 7, so we should avoid using it anyways.

The Identity Cache tests don't actually need the autoloader, since it uses `Kernel.load` to load the models (such that they can be reloaded) and manually removes the constants manually.  Since there is no Zeitwerk autolaoder to clear state on and because there is no classes tracked without the autoloader set up by railties, there is no state that needs to be cleared now.