### PR TITLE
Add accessor method to see if embedded association is loaded

### DIFF
--- a/test/cached/recursive/has_many_test.rb
+++ b/test/cached/recursive/has_many_test.rb
@@ -22,6 +22,7 @@ module IdentityCache
           record = AssociatedRecord.new
 
           assert_operator(record, :respond_to?, :fetch_deeply_associated_records)
+          assert_operator(record, :respond_to?, :cached_deeply_associated_records_loaded?)
         end
 
         def test_clear

--- a/test/cached/recursive/has_one_test.rb
+++ b/test/cached/recursive/has_one_test.rb
@@ -22,6 +22,7 @@ module IdentityCache
           record = AssociatedRecord.new
 
           assert_operator(record, :respond_to?, :fetch_deeply_associated)
+          assert_operator(record, :respond_to?, :cached_deeply_associated_loaded?)
         end
 
         def test_clear

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -26,6 +26,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     Item.any_instance.expects(:association).with(:associated_records).returns(expected)
 
     assert_equal(@record, record_from_db)
+    assert_equal(false, record_from_db.cached_associated_records_loaded?)
     assert_equal(expected, record_from_db.fetch_associated_records)
   end
 
@@ -42,6 +43,7 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
 
     record_from_cache_hit = Item.fetch(@record.id)
     assert_equal(@record, record_from_cache_hit)
+    assert_equal(true, record_from_cache_hit.cached_associated_records_loaded?)
 
     result = assert_memcache_operations(0) do
       assert_no_queries do

--- a/test/denormalized_has_one_test.rb
+++ b/test/denormalized_has_one_test.rb
@@ -21,6 +21,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     record_from_cache_miss = Item.fetch_by_title("foo")
 
     assert_equal(@record, record_from_cache_miss)
+    assert_equal(true, record_from_cache_miss.cached_associated_loaded?)
     assert_not_nil(@record.fetch_associated)
     assert_equal(@record.associated, record_from_cache_miss.fetch_associated)
     assert(fetch.has_been_called_with?(@cached_attribute.cache_key("foo"), {}))
@@ -50,6 +51,7 @@ class DenormalizedHasOneTest < IdentityCache::TestCase
     record_from_db = Item.find_by_title("foo")
 
     assert_equal(@record, record_from_db)
+    assert_equal(false, record_from_db.cached_associated_loaded?)
     assert_not_nil(record_from_db.fetch_associated)
   end
 


### PR DESCRIPTION
It can be hard to know all flows that read from cache and update them to use the cached embedded associations. Sometimes the same code path can be used in different flows, some that read from cache, some that read from DB.

Since identity cache doesn't mess with the regular Rails / Active Record association, I propose we can add a method like "is the embedded association X loaded from cache"? The code can then be updated to use the cached object (if available), otherwise default to the normal association (and not populate cache).

I've named the method `cached_#{name}_loaded?`. Not sure that's the best name.

Example:

```ruby
class Item < ActiveRecord::Base
  include IdentityCache
  has_one :associated
  cache_has_one :associated, embed: true
end

i1 = Item.fetch_by_id(1)
i1.cached_associated_loaded? # => true

i2 = Item.find(1)
i2.cached_associated_loaded? # => false
```

What do you think?

An alternative I can think of, instead of exposing this boolean accessor, expose a new method like `fetch_#{name}_from_cache_or_association_without_populating_cache` (but with a more succinct name).

Thoughts?