### PR TITLE
Don't require "dalli/cas/client" on Dalli 3

### DIFF
--- a/lib/identity_cache/mem_cache_store_cas.rb
+++ b/lib/identity_cache/mem_cache_store_cas.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require "dalli/cas/client"
+require "dalli/cas/client" unless Dalli::VERSION > "3"
 
 module IdentityCache
   module MemCacheStoreCAS


### PR DESCRIPTION
CAS support was merged into the main client in Dalli 3, and requiring this file now prints a deprecation warning: https://github.com/petergoldstein/dalli/commit/c3e017aff3d2d02163192506baca6038a9d8adcc