### PR TITLE
Fix dev isogun compatibility which doesn't currently support postgresql

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,6 @@ name: identity-cache
 
 up:
   - homebrew:
-    - postgresql
     - mysql-client@5.7:
         or:        [mysql@5.7]
         conflicts: [mysql-connector-c, mysql, mysql-client]
@@ -13,7 +12,6 @@ up:
 env:
   RAILGUN_HOST: identity-cache.railgun
   MYSQL_HOST: identity-cache.railgun
-  POSTGRES_HOST: identity-cache.railgun
   MEMCACHED_HOST: identity-cache.railgun
 
 commands:

--- a/railgun.yml
+++ b/railgun.yml
@@ -12,5 +12,4 @@ volumes:
 
 services:
   - mysql
-  - postgresql
   - memcached


### PR DESCRIPTION
## Problem

`dev up` was failing with an `undefined method `[]' for nil:NilClass (NoMethodError)` error in dev isogun code to wait for a service.  This wasn't a problem in another project just using mysql2, so I found that postgresql was causing the problem and that it currently isn't supported in the move to isogun.

## Solution

Remove `dev.yml`/`railgun.yml` support for postgresql.  It isn't really required to run the tests locally, would probably still be possible by installing postgres directly through homebrew and is still being tested in CI.