### PR TITLE
Fix test for rails edge

### DIFF
--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -35,7 +35,7 @@ class IndexCacheTest < IdentityCache::TestCase
     Item.cache_index(:title, :id, unique: true)
 
     Item.connection.expects(:exec_query)
-      .with(regexp_matches(/ LIMIT 1\Z/i), any_parameters)
+      .with(regexp_matches(/ LIMIT [1?]\Z/i), any_parameters)
       .returns(ActiveRecord::Result.new([], []))
 
     assert_nil(Item.fetch_by_title_and_id("title", "2"))


### PR DESCRIPTION
CI is failing on Rails Edge with the following failure

```
  1) Failure:
IndexCacheTest#test_fetch_with_unique_adds_limit_clause [/opt/hostedtoolcache/Ruby/3.0.4/x64/lib/ruby/gems/3.0.0/bundler/gems/rails-18da7b6ba71c/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:589]:
unexpected invocation: #<ActiveRecord::ConnectionAdapters::Mysql2Adapter:0x2e68>.exec_query("SELECT `items`.`id` FROM `items` WHERE `items`.`title` = ? AND `items`.`id` = ? LIMIT ?", "Item Pluck", [#<ActiveRecord::Relation::QueryAttribute:0x192f8>, #<ActiveRecord::Relation::QueryAttribute:0x19320>, #<ActiveModel::Attribute::WithCastValue:0x19348>], {:prepare => true})
unsatisfied expectations:
- expected exactly once, invoked never: #<ActiveRecord::ConnectionAdapters::Mysql2Adapter:0x2e68>.exec_query(regexp_matches(/ LIMIT 1\Z/i), any_parameters)
```

Since `LIMIT 1` isn't matching `LIMIT ?`, so I fixed the test regex to allow that.