### PR TITLE
Return useful value from 'expire_cache'

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -171,10 +171,10 @@ module IdentityCache
       super
     end
 
-    # Invalidate the cache data associated with the record.
+    # Invalidate the cache data associated with the record. Returns `true` on success,
+    # `false` otherwise.
     def expire_cache
-      expire_attribute_indexes
-      true
+      expire_attribute_indexes.all?
     end
 
     # @api private
@@ -186,7 +186,7 @@ module IdentityCache
     private
 
     def expire_attribute_indexes # :nodoc:
-      cache_indexes.each do |cached_attribute|
+      cache_indexes.map do |cached_attribute|
         cached_attribute.expire(self)
       end
     end

--- a/test/expire_cache_test.rb
+++ b/test/expire_cache_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ExpireCacheTest < IdentityCache::TestCase
+  def setup
+    super
+
+    Item.cache_index(:title, unique: true)
+    Item.cache_index(:id, :title, unique: true)
+
+    @record = Item.new
+    @record.id = 1
+    @record.title = "bob"
+
+    Spy.on(Item.cached_primary_index, :load_one_from_db).and_return do
+      @record
+    end
+  end
+
+  def test_expire_cache_hit
+    assert_equal(@record, Item.fetch(1))
+    refute_equal(IdentityCache::DELETED, backend.read(@record.primary_cache_index_key))
+    assert(@record.expire_cache)
+    assert_equal(IdentityCache::DELETED, backend.read(@record.primary_cache_index_key))
+  end
+
+  def test_expire_cache_on_failure
+    assert_equal(@record, Item.fetch(1))
+    refute_equal(IdentityCache::DELETED, backend.read(@record.primary_cache_index_key))
+
+    Spy.on(backend, :write_entry).and_return { false }
+
+    refute(@record.expire_cache)
+    refute_equal(IdentityCache::DELETED, backend.read(@record.primary_cache_index_key))
+  end
+end


### PR DESCRIPTION
It's possible for the underlying cache to fail a `write` operation which should set cache to deleted state across all the cache indexes. When this happens, cache indexes would be in inconsistent state, i.e. primary index could return `DELETED` value, as expected while other index might still have stale values. It could also happen that all writes fail and then we have stale cache when we want to refresh it.

So far we returned hardcoded `true` value from `expire_cache` method. After tracing `cache_attribute.expire(self)` method calls, I found out that the value returned is either:
- `truthy` if underlying connection doesn't throw an exception
- or `false` in case of the exception throwed by the underlying connection (Based on ActiveSupport Cache Stores API).

This PR modifies `expire_cache` to return `true` only when all the `expire` calls underneath return a truthy value and `false` when at least one of the calls fails. This should give means for knowing whenever the `expire_cache` call has to be repeated.