### PR TITLE
Leave embedded associations preloaded when should_use_cache is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Identity Cache Changelog
 
-## unreleased
+## Unreleased
+
+### Fixes
+- Remove N+1 queries from embedded associations when using `fetch` while `should_use_cache` is false. (#531)
 
 ## 1.3.0
 

--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -70,6 +70,8 @@ module IdentityCache
         readonly: IdentityCache.fetch_read_only_records && should_use_cache?)
         return if records.empty?
 
+        return unless should_use_cache?
+
         records.each(&:readonly!) if readonly
         each_id_embedded_association do |cached_association|
           preload_id_embedded_association(records, cached_association)

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -342,6 +342,68 @@ class FetchTest < IdentityCache::TestCase
     end
   end
 
+  def test_with_should_use_cache_true_fetched_record_does_not_have_embedded_associations_preloaded_on_cache_miss
+    Item.cache_has_many(:associated_records, embed: true)
+    Item.cache_has_many(:normalized_associated_records)
+
+    @record.associated_records.build
+    @record.associated_records.build
+    @record.normalized_associated_records.build
+    @record.save
+
+    assert_memcache_operations(1) do
+      assert_queries(3) do
+        item = Item.fetch_by_id(@record.id)
+
+        refute(item.association(:associated_records).loaded?)
+        refute(item.association(:normalized_associated_records).loaded?)
+      end
+    end
+  end
+
+  def test_with_should_use_cache_true_fetched_record_does_not_have_embedded_associations_preloaded_on_cache_hit
+    Item.cache_has_many(:associated_records, embed: true)
+    Item.cache_has_many(:normalized_associated_records)
+
+    @record.associated_records.build
+    @record.associated_records.build
+    @record.normalized_associated_records.build
+    @record.save
+
+    # warm the cache
+    Item.fetch_by_id(@record.id)
+
+    assert_memcache_operations(1) do
+      assert_queries(0) do
+        item = Item.fetch_by_id(@record.id)
+
+        refute(item.association(:associated_records).loaded?)
+        refute(item.association(:normalized_associated_records).loaded?)
+      end
+    end
+  end
+
+  def test_with_should_use_cache_false_fetched_record_has_embedded_associations_preloaded
+    Item.cache_has_many(:associated_records, embed: true)
+    Item.cache_has_many(:normalized_associated_records)
+
+    @record.associated_records.build
+    @record.associated_records.build
+    @record.normalized_associated_records.build
+    @record.save
+
+    Item.stubs(:should_use_cache?).returns(false)
+
+    assert_memcache_operations(0) do
+      assert_queries(2) do
+        item = Item.fetch_by_id(@record.id)
+
+        assert(item.association(:associated_records).loaded?)
+        refute(item.association(:normalized_associated_records).loaded?)
+      end
+    end
+  end
+
   def test_fetch_supports_lock_wait_options
     @record.save
 

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -351,11 +351,11 @@ class FetchTest < IdentityCache::TestCase
     @record.normalized_associated_records.build
     @record.save
 
-    item = Item.transaction do
-      assert_memcache_operations(0) do
-        assert_queries(3) do
-          Item.fetch_by_id(@record.id)
-        end
+    Item.stubs(:should_use_cache?).returns(false)
+
+    item = assert_memcache_operations(0) do
+      assert_queries(2) do
+        Item.fetch_by_id(@record.id)
       end
     end
 


### PR DESCRIPTION
Our background jobs run against a read-replica database, and so IDC is disabled in order to avoid inconsistency stemming from the cache being "ahead" of the database. But today this results in N+1 queries when resources when `fetch` is used on resources with embedded associations.

This is how that comes to pass:
1. Set `should_use_cache` to false
2. Fetch a resource with embedded associations
3. IDC is forced to load from the database. It uses the preloads that it normally uses on a cache miss. 
    https://github.com/Shopify/identity_cache/blob/328b52fa9746105b71f079caa8fdbc3dd30804ba/lib/identity_cache/cached/primary_index.rb#L87-L89
4.  IDC sets up its embedded associations with the same behavior as if `should_use_cache` were true
    1. It populates the cached association
    2. and resets the bare AR association, per the reasoning in https://github.com/Shopify/identity_cache/pull/378
         https://github.com/Shopify/identity_cache/blob/328b52fa9746105b71f079caa8fdbc3dd30804ba/lib/identity_cache/query_api.rb#L88
    3. It then reads the cached association in order to set up the children's embedded associations
         https://github.com/Shopify/identity_cache/blob/328b52fa9746105b71f079caa8fdbc3dd30804ba/lib/identity_cache/query_api.rb#L101-L102
    4. But because `should_use_cache` is false, this bypasses the cached association and instead hits the DB N times
         https://github.com/Shopify/identity_cache/blob/328b52fa9746105b71f079caa8fdbc3dd30804ba/lib/identity_cache/cached/recursive/association.rb#L28

Even if IDC did not trigger the N queries internally, application code that uses the cached associations of a model will trigger the queries. Application code that uses embedded associations should be able to assume that they are eager loaded.

This PR proposes that when `should_use_cache` is false, the resources should not have their embedded associations hydrated using the normal logic. Instead, the instances should behave as if they were loaded with `find` and not `fetch`, with the `includes` that are necessary to meet application code's expectations for embedded associations.

cc @hovo @MatWrz