### PR TITLE
Add composite index support for `fetch_multi_by`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.4.0
+
+### Features
+- Add composite index support for `fetch_multi_by`. (#530)
+
 ## 1.3.1
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -101,7 +101,15 @@ product = Product.fetch_by_handle(handle)
 # Fetch multiple products by providing an array of index values.
 products = Product.fetch_multi_by_handle(handles)
 
+# Fetch a single product by providing composite attributes.
 products = Product.fetch_by_vendor_and_product_type(vendor, product_type)
+
+# Fetch multiple product by providing an array of composite attributes.
+products = Product.fetch_multi_by_vendor_and_product_type([
+  [vendor_1, product_type_1],
+  [vendor_2, product_type_2],
+  # ...
+])
 ```
 
 This gives you a lot of freedom to use your objects the way you want to, and doesn't get in your way. This does keep an independent cache copy in Memcached so you might want to watch the number of different caches that are being added.

--- a/lib/identity_cache/cached/attribute_by_multi.rb
+++ b/lib/identity_cache/cached/attribute_by_multi.rb
@@ -10,11 +10,75 @@ module IdentityCache
           raise_if_scoped
           cached_attribute.fetch(key_values)
         end
+
+        model.define_singleton_method(:"fetch_multi_#{fetch_method_suffix}") do |key_values|
+          raise_if_scoped
+          cached_attribute.fetch_multi(*key_values)
+        end
       end
+
+      def fetch_multi(*key_values)
+        key_values = key_values.map do |key_value|
+          cast_db_key(key_value)
+        end
+
+        unless model.should_use_cache?
+          return load_multi_from_db(key_values)
+        end
+
+        unordered_hash = CacheKeyLoader.load_multi(self, key_values)
+
+        # Calling `values` on the result is expected to return the values in the same order as their
+        # corresponding keys. The fetch_multi_by_#{field_list} generated methods depend on this.
+        ordered_hash = {}
+        key_values.each { |key_value| ordered_hash[key_value] = unordered_hash.fetch(key_value) }
+        ordered_hash
+      end
+
+      def load_multi_from_db(key_values)
+        rows = unsorted_model_with_where_conditions(key_values).pluck(attribute, *key_fields)
+        result = {}
+        default = unique ? nil : []
+        key_values.each do |index_value|
+          result[index_value] = default.try!(:dup)
+        end
+        if unique
+          rows.each do |attribute_value, *index_values|
+            result[index_values] = attribute_value
+          end
+        else
+          rows.each do |attribute_value, *index_values|
+            result[index_values] << attribute_value
+          end
+        end
+        result
+      end
+
+      def cache_encode(db_value)
+        db_value
+      end
+      alias_method :cache_decode, :cache_encode
 
       private
 
       # Attribute method overrides
+
+      def unsorted_model_with_where_conditions(key_values)
+        unsorted_model = model.reorder(nil)
+        conditions = key_values.map do |keys|
+          key_fields.each_with_object({}).with_index do |(field, conds), i|
+            conds[field] = keys[i]
+          end
+        end
+
+        conditions.reduce(nil) do |query, condition|
+          if query.nil?
+            unsorted_model.where(condition)
+          else
+            query.or(unsorted_model.where(condition))
+          end
+        end
+      end
 
       def cast_db_key(key_values)
         field_types.each_with_index do |type, i|

--- a/lib/identity_cache/cached/attribute_by_multi.rb
+++ b/lib/identity_cache/cached/attribute_by_multi.rb
@@ -54,8 +54,17 @@ module IdentityCache
           end
         end
 
-        query.pluck(attribute, *key_fields).map do |attribute, *key_values|
-          [key_values, attribute]
+        fields = key_fields.dup
+        fields.delete(attribute)
+        attribute_index = key_fields.index(attribute)
+
+        query.pluck(attribute, *fields).map do |attribute, *key_values|
+          index = if attribute_index.nil?
+            key_values
+          else
+            key_values.insert(attribute_index, attribute)
+          end
+          [index, attribute]
         end
       end
 

--- a/lib/identity_cache/cached/attribute_by_multi.rb
+++ b/lib/identity_cache/cached/attribute_by_multi.rb
@@ -6,93 +6,57 @@ module IdentityCache
       def build
         cached_attribute = self
 
-        model.define_singleton_method(:"fetch_#{fetch_method_suffix}") do |*key_values|
+        model.define_singleton_method(:"fetch_#{fetch_method_suffix}") do |*keys|
           raise_if_scoped
-          cached_attribute.fetch(key_values)
+          cached_attribute.fetch(keys)
         end
 
-        model.define_singleton_method(:"fetch_multi_#{fetch_method_suffix}") do |key_values|
+        model.define_singleton_method(:"fetch_multi_#{fetch_method_suffix}") do |keys|
           raise_if_scoped
-          cached_attribute.fetch_multi(*key_values)
+          cached_attribute.fetch_multi(keys)
         end
       end
-
-      def fetch_multi(*key_values)
-        key_values = key_values.map do |key_value|
-          cast_db_key(key_value)
-        end
-
-        unless model.should_use_cache?
-          return load_multi_from_db(key_values)
-        end
-
-        unordered_hash = CacheKeyLoader.load_multi(self, key_values)
-
-        # Calling `values` on the result is expected to return the values in the same order as their
-        # corresponding keys. The fetch_multi_by_#{field_list} generated methods depend on this.
-        ordered_hash = {}
-        key_values.each { |key_value| ordered_hash[key_value] = unordered_hash.fetch(key_value) }
-        ordered_hash
-      end
-
-      def load_multi_from_db(key_values)
-        rows = unsorted_model_with_where_conditions(key_values).pluck(attribute, *key_fields)
-        result = {}
-        default = unique ? nil : []
-        key_values.each do |index_value|
-          result[index_value] = default.try!(:dup)
-        end
-        if unique
-          rows.each do |attribute_value, *index_values|
-            result[index_values] = attribute_value
-          end
-        else
-          rows.each do |attribute_value, *index_values|
-            result[index_values] << attribute_value
-          end
-        end
-        result
-      end
-
-      def cache_encode(db_value)
-        db_value
-      end
-      alias_method :cache_decode, :cache_encode
 
       private
 
       # Attribute method overrides
 
-      def unsorted_model_with_where_conditions(key_values)
-        unsorted_model = model.reorder(nil)
-        conditions = key_values.map do |keys|
-          key_fields.each_with_object({}).with_index do |(field, conds), i|
-            conds[field] = keys[i]
-          end
-        end
-
-        conditions.reduce(nil) do |query, condition|
-          if query.nil?
-            unsorted_model.where(condition)
-          else
-            query.or(unsorted_model.where(condition))
-          end
-        end
-      end
-
-      def cast_db_key(key_values)
+      def cast_db_key(keys)
         field_types.each_with_index do |type, i|
-          key_values[i] = type.cast(key_values[i])
+          keys[i] = type.cast(keys[i])
         end
-        key_values
+        keys
       end
 
-      def unhashed_values_cache_key_string(key_values)
-        key_values.map { |v| v.try!(:to_s).inspect }.join("/")
+      def unhashed_values_cache_key_string(keys)
+        keys.map { |v| v.try!(:to_s).inspect }.join("/")
       end
 
-      def load_from_db_where_conditions(key_values)
-        Hash[key_fields.zip(key_values)]
+      def load_from_db_where_conditions(keys)
+        Hash[key_fields.zip(keys)]
+      end
+
+      def load_multi_rows(keys)
+        query = begin
+          conditions = keys.map do |keys|
+            key_fields.each_with_object({}).with_index do |(field, conds), i|
+              conds[field] = keys[i]
+            end
+          end
+
+          unsorted_model = model.reorder(nil)
+          conditions.reduce(nil) do |query, condition|
+            if query.nil?
+              unsorted_model.where(condition)
+            else
+              query.or(unsorted_model.where(condition))
+            end
+          end
+        end
+
+        query.pluck(attribute, *key_fields).map do |attribute, *key_values|
+          [key_values, attribute]
+        end
       end
 
       alias_method :cache_key_from_key_values, :cache_key

--- a/lib/identity_cache/cached/attribute_by_multi.rb
+++ b/lib/identity_cache/cached/attribute_by_multi.rb
@@ -37,23 +37,7 @@ module IdentityCache
       end
 
       def load_multi_rows(keys)
-        query = begin
-          conditions = keys.map do |keys|
-            key_fields.each_with_object({}).with_index do |(field, conds), i|
-              conds[field] = keys[i]
-            end
-          end
-
-          unsorted_model = model.reorder(nil)
-          conditions.reduce(nil) do |query, condition|
-            if query.nil?
-              unsorted_model.where(condition)
-            else
-              query.or(unsorted_model.where(condition))
-            end
-          end
-        end
-
+        query = generate_query(keys)
         fields = key_fields.dup
         fields.delete(attribute)
         attribute_index = key_fields.index(attribute)
@@ -69,6 +53,80 @@ module IdentityCache
       end
 
       alias_method :cache_key_from_key_values, :cache_key
+
+      # Helper methods
+
+      def generate_query(keys)
+        common_fields, unique_fields = extract_common_and_unique_fields(keys)
+
+        common_query = nil
+        common_fields.each do |field, value|
+          # Optimization for the case of fields in which the key being searched is
+          # always the same.
+          # This results in a single "WHERE field = value" statement being produced
+          # from a single query.
+          common_query ||= unsorted_model
+          common_query = common_query.where(field => value)
+        end
+
+        conditions = if unique_fields.one?
+          # Micro-optimization for the case of a single unique field.
+          # This results in a single "WHERE field IN (values)" statement being
+          # produced from a single query.
+          [unique_fields]
+        else
+          # More than one unique field, so we need to generate a query for each
+          # set of values for each unique field.
+          #
+          # This results in multiple
+          #   "WHERE field = value AND field_2 = value_2 OR ..."
+          # statements being produced from an object like
+          #   [{ field: value, field_2: value_2 }, ...]
+          unique_field_rows = unique_fields.keys
+          unique_fields.values.transpose.map do |keys|
+            keys.each_with_object({}).with_index do |(key, conds), i|
+              conds[unique_field_rows[i]] = key
+            end
+          end
+        end
+
+        unique_query = conditions.reduce(nil) do |query, condition|
+          if query.nil?
+            unsorted_model.where(condition)
+          else
+            query.or(unsorted_model.where(condition))
+          end
+        end
+
+        if common_query
+          common_query.merge(unique_query)
+        else
+          unique_query
+        end
+      end
+
+      def unsorted_model
+        model.reorder(nil)
+      end
+
+      def extract_common_and_unique_fields(keys)
+        common_fields = {}
+        unique_fields = {}
+
+        key_fields.length.times do |i|
+          field = key_fields[i]
+          field_values = keys.map { |key_values| key_values[i] }
+          uniq_field_values = field_values.uniq
+
+          if uniq_field_values.one?
+            common_fields[field] = uniq_field_values.first
+          else
+            unique_fields[field] = field_values
+          end
+        end
+
+        [common_fields, unique_fields]
+      end
     end
   end
 end

--- a/lib/identity_cache/version.rb
+++ b/lib/identity_cache/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module IdentityCache
-  VERSION = "1.3.1"
+  VERSION = "1.4.0"
   CACHE_VERSION = 8
 end

--- a/lib/identity_cache/with_primary_index.rb
+++ b/lib/identity_cache/with_primary_index.rb
@@ -82,15 +82,13 @@ module IdentityCache
           CODE
         end
 
-        if fields.length == 1
-          instance_eval(<<-CODE, __FILE__, __LINE__ + 1)
-            def fetch_multi_by_#{field_list}(index_values, includes: nil)
-              ids = fetch_multi_id_by_#{field_list}(index_values).values.flatten(1)
-              return ids if ids.empty?
-              fetch_multi(ids, includes: includes)
-            end
-          CODE
-        end
+        instance_eval(<<-CODE, __FILE__, __LINE__ + 1)
+          def fetch_multi_by_#{field_list}(index_values, includes: nil)
+            ids = fetch_multi_id_by_#{field_list}(index_values).values.flatten(1)
+            return ids if ids.empty?
+            fetch_multi(ids, includes: includes)
+          end
+        CODE
       end
 
       # Similar to ActiveRecord::Base#exists? will return true if the id can be

--- a/test/fetch_multi_by_test.rb
+++ b/test/fetch_multi_by_test.rb
@@ -86,4 +86,31 @@ class FetchMultiByTest < IdentityCache::TestCase
 
     assert_equal({ 1 => "bob", 999 => nil }, Item.fetch_multi_title_by_id([1, 999]))
   end
+
+  def test_fetch_multi_attribute_by_with_multiple_indexes
+    Item.cache_index(:id, :title, unique: false)
+
+    @bob.save!
+    @bertha.save!
+
+    assert_equal([@bob, @bertha], Item.fetch_multi_by_id_and_title([[1, "bob"], [2, "bertha"]]))
+  end
+
+  def test_fetch_multi_attribute_by_with_multiple_indexes_and_unknown_keys
+    Item.cache_index(:id, :title, unique: false)
+
+    @bob.save!
+    @bertha.save!
+
+    assert_equal([@bob], Item.fetch_multi_by_id_and_title([[1, "bob"], [999, "bertha"]]))
+  end
+
+  def test_fetch_multi_attribute_by_with_multiple_indexes_and_unique_cache_key
+    Item.cache_index(:id, :title, unique: true)
+
+    @bob.save!
+    @bertha.save!
+
+    assert_equal([@bob, @bertha], Item.fetch_multi_by_id_and_title([[1, "bob"], [2, "bertha"]]))
+  end
 end

--- a/test/fetch_multi_by_test.rb
+++ b/test/fetch_multi_by_test.rb
@@ -9,10 +9,12 @@ class FetchMultiByTest < IdentityCache::TestCase
     super
     @bob = Item.new
     @bob.id = 1
+    @bob.item_id = 100
     @bob.title = "bob"
 
     @bertha = Item.new
     @bertha.id = 2
+    @bertha.item_id = 100
     @bertha.title = "bertha"
   end
 
@@ -112,5 +114,14 @@ class FetchMultiByTest < IdentityCache::TestCase
     @bertha.save!
 
     assert_equal([@bob, @bertha], Item.fetch_multi_by_id_and_title([[1, "bob"], [2, "bertha"]]))
+  end
+
+  def test_fetch_multi_attribute_by_with_mix_of_unique_and_common_attributes
+    Item.cache_index(:id, :item_id, :title, unique: true)
+
+    @bob.save!
+    @bertha.save!
+
+    assert_equal([@bob, @bertha], Item.fetch_multi_by_id_and_item_id_and_title([[1, 100, "bob"], [2, 100, "bertha"]]))
   end
 end


### PR DESCRIPTION
Enables fetching multiple entities from the cache when a composite index is used.

This looks like:

```rb
class Product < ActiveRecord::Base
  include IdentityCache
  cache_index :handle, unique: true
  cache_index :vendor, :product_type
end

products = Product.fetch_multi_by_vendor_and_product_type([
  [vendor_1, product_type_1],
  [vendor_2, product_type_2],
  # ...
])
```

This changeset ships with a couple of [micro-optimizations](https://github.com/Shopify/identity_cache/commit/2cf45a869791e86ae68c92fedd9753d5d75d2386). Consider the following case:

```rb
Item.cache_index(:id, :title, unique: true)
Item.cache_index(:id, :item_id, :title, unique: true)
```

This results in queries generated like:

```rb
Item.fetch_multi_by_id_and_title([[1, "bob"], [1, "bertha"]])
```

```mysql
SELECT `items`.* FROM `items`
WHERE `items`.`id` = 1
AND `items`.`title` IN ('bob', 'bertha')
```

and

```rb
Item.fetch_multi_by_id_and_item_id_and_title([[1, 100, "bob"], [2, 100, "bertha"]])
```

```mysql
SELECT `items`.* FROM `items`
WHERE `items`.`item_id` = 100
AND (`items`.`id` = 1 AND `items`.`title` = 'bob' OR `items`.`id` = 2 AND `items`.`title` = 'bertha')
```

This allows us to keep the method signature consistent with the existing `fetch_multi` interface with query optimizations for some of the more common cases of value redundancy.