### PR TITLE
fix: `fetch_multi_by` bug for WHERE IN optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,35 +5,42 @@
 ## 1.4.0
 
 ### Features
+
 - Add `fetch_multi_by` support for composite-key indexes. (#534)
 
 ## 1.3.1
 
 ### Fixes
+
 - Remove N+1 queries from embedded associations when using `fetch` while `should_use_cache` is false. (#531)
 
 ## 1.3.0
 
 ### Features
+
 - Return meaningful value from `expire_cache` indicating whenever it succeeded or failed in the process. (#523)
 
 ### Fixes
+
 - Expire parents cache when when calling `expire_cache`. (#523)
 - Avoid creating too many shapes on Ruby 3.2+. (#526)
 
 ## 1.2.0
 
 ### Fixes
+
 - Fix mem_cache_store adapter with pool_size (#489)
 - Fix dalli deprecation warning about requiring 'dalli/cas/client' (#511)
 - Make transitionary method IdentityCache.with_fetch_read_only_records thread-safe (#503)
 
 ### Features
+
 - Add support for fill lock with lock wait to avoid thundering herd problem (#373)
 
 ## 1.1.0
 
 ### Fixes
+
 - Fix double debug logging of cache hits and misses (#474)
 - Fix a Rails 6.1 deprecation warning for Rails 7.0 compatibility (#482)
 - Recursively install parent expiry hooks when expiring parent caches (#476)
@@ -45,10 +52,12 @@
 - Fix fetch `has_many` embedded association on record after adding to it (#449)
 
 ### Features
+
 - Support multiple databases and transactional tests in `IdentityCache.should_use_cache?` (#293)
 - Add support for the default `MemCacheStore` from `ActiveSupport` (#465)
 
 ### Breaking Changes
+
 - Drop ruby 2.4 support, since it is no longer supported upstream (#468)
 
 ## 1.0.1
@@ -120,7 +129,7 @@
 - Remove support for 3.2
 - Fix N+1 from fetching embedded ids on a cache miss
 - Raise when trying to cache a through association. Previously it wouldn't be invalidated properly.
-- Raise if a class method is called on a scope.  Previously the scope was ignored.
+- Raise if a class method is called on a scope. Previously the scope was ignored.
 - Raise if a class method is called on a subclass of one that included IdentityCache. This never worked properly.
 - Fix cache_belongs_to on polymorphic assocations.
 - Fetching a cache_belongs_to association no longer loads the belongs_to association
@@ -180,7 +189,6 @@
 - Perf: Rails 4 Only create `CollectionProxy` when using it
 
 ## 0.0.5
-
 
 ## 0.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 1.4.1
+
+### Fixes
+
+- Fix `fetch_multi_by` bug for queries having a single field with distinct values. (#536)
+
 ## 1.4.0
 
 ### Features

--- a/lib/identity_cache/cached/attribute_by_multi.rb
+++ b/lib/identity_cache/cached/attribute_by_multi.rb
@@ -84,7 +84,7 @@ module IdentityCache
           # This results in a single "WHERE field IN (values)" statement being
           # produced from a single query.
           field_idx = other_field_indexes.first
-          field_name = key_fields[i]
+          field_name = key_fields[field_idx]
           field_values = keys.map { |key| key[field_idx] }
           (common_query || unsorted_model).where(field_name => field_values)
         else

--- a/lib/identity_cache/version.rb
+++ b/lib/identity_cache/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module IdentityCache
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
   CACHE_VERSION = 8
 end

--- a/test/fetch_multi_by_test.rb
+++ b/test/fetch_multi_by_test.rb
@@ -125,6 +125,15 @@ class FetchMultiByTest < IdentityCache::TestCase
     assert_equal([@bob, @bertha], Item.fetch_multi_by_id_and_item_id_and_title([[1, 100, "bob"], [2, 100, "bertha"]]))
   end
 
+  def test_fetch_multi_attribute_by_with_implicit_in_query
+    Item.cache_index(:item_id, :title, unique: true)
+
+    @bob.save!
+    @bertha.save!
+
+    assert_equal([@bob, @bertha], Item.fetch_multi_by_item_id_and_title([[100, "bob"], [100, "bertha"]]))
+  end
+
   def test_fetch_multi_attribute_by_with_empty_keys_without_using_cache
     Item.cache_index(:id, :title, unique: false)
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/Shopify/identity_cache/pull/534 for `#fetch_multi_by` invocations having a single field with distinct values.

The diff itself should make the bug pretty straightforward. This PR also adds a regression test against the case, which ensures we're now testing against each clause in the `case` statement.

I believe bumping to `1.4.1` should be germane in this case because the bug was associated with new behavior introduced in a major update, i.e., no client of this library should have been affected by the changes in #534 via a version bump alone.

Please note that CI will surely fail on the Rails edge step for unrelated reasons in the fetch test suite. This is a problem on `main`, too; you can verify it yourself by installing the Rails edge bundle and running `dev test test/fetch_test.rb`.