### PR TITLE
Do not embed too many records

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -54,6 +54,9 @@ module IdentityCache
   DELETED = :idc_cached_deleted
   DELETED_TTL = 1000
 
+  MAX_EMBEDDED_SIZE = 25
+  CACHED_EMBEDDED_TOO_MANY = :idc_too_many
+
   class AlreadyIncludedError < StandardError; end
 
   class AssociationError < StandardError; end

--- a/lib/identity_cache/cached/recursive/association.rb
+++ b/lib/identity_cache/cached/recursive/association.rb
@@ -30,6 +30,9 @@ module IdentityCache
               record.instance_variable_get(records_variable_name)
             elsif record.instance_variable_defined?(dehydrated_variable_name)
               dehydrated_target = record.instance_variable_get(dehydrated_variable_name)
+              if dehydrated_target == IdentityCache::CACHED_EMBEDDED_TOO_MANY
+                return assoc.load_target
+              end
               association_target = hydrate_association_target(assoc.klass, dehydrated_target)
               record.remove_instance_variable(dehydrated_variable_name)
               set_with_inverse(record, association_target)

--- a/lib/identity_cache/encoder.rb
+++ b/lib/identity_cache/encoder.rb
@@ -59,8 +59,12 @@ module IdentityCache
         embedded_record_or_records = record.public_send(cached_association.cached_accessor_name)
 
         if embedded_record_or_records.respond_to?(:to_ary)
-          embedded_record_or_records.map do |embedded_record|
-            coder_from_record(embedded_record, embedded_record.class)
+          if embedded_record_or_records.size > IdentityCache::MAX_EMBEDDED_SIZE
+            IdentityCache::CACHED_EMBEDDED_TOO_MANY
+          else
+            embedded_record_or_records.map do |embedded_record|
+              coder_from_record(embedded_record, embedded_record.class)
+            end
           end
         else
           coder_from_record(embedded_record_or_records, embedded_record_or_records.class)


### PR DESCRIPTION
This is half-based and probably not covering edge cases, but I'd like to show it as one possible solution to the problem.

With `cache_has_many :some_association, embed: true` combined with many (100s or 1000s) records in that association, it's very easy to hit the [large blob problem](https://github.com/Shopify/identity_cache/blob/main/CAVEATS.md#large-blobs). That leads to over-fetching, increase on network traffic and large penalty on CPU to decode and unserialize those 1000s of records.

A solution to that could be to limit how many records can be embedded, and if there's more than N of them, mark that with a special object that would indicate IDC to load records from DB even if `fetch_some_association` was called.

@martelogan @Larochelle @ptolts 