### PR TITLE
Fix Active Record's connection_pool_list deprecation warning for Rails 7.1.x

### DIFF
--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -116,7 +116,7 @@ module IdentityCache
     end
 
     def should_use_cache? # :nodoc:
-      ActiveRecord::Base.connection_handler.connection_pool_list.none? do |pool|
+      ActiveRecord::Base.connection_handler.connection_pool_list(ActiveRecord::Base.current_role).none? do |pool|
         pool.active_connection? &&
           # Rails wraps each of your tests in a transaction, so that any changes
           # made to the database during the test can be rolled back afterwards.

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -282,11 +282,11 @@ class FetchTest < IdentityCache::TestCase
     @record.save!
     record = Item.fetch(@record.id)
 
-    ActiveRecord::Base.clear_active_connections!
+    ActiveRecord::Base.clear_active_connections!(ActiveRecord::Base.current_role)
 
     assert_equal(record, Item.fetch(@record.id))
 
-    assert_equal(false, ActiveRecord::Base.connection_handler.active_connections?)
+    assert_equal(false, ActiveRecord::Base.connection_handler.active_connections?(ActiveRecord::Base.current_role))
   end
 
   def test_fetch_raises_when_called_on_a_scope


### PR DESCRIPTION
Fixes deprecation warning for Rails 7.1.x

> DEPRECATION WARNING: `connection_pool_list` currently only applies to connection pools in the current role (`writing`). In Rails 7.2, this method will apply to all known pools, regardless of role. To affect only those connections belonging to a specific role, pass the role name as an argument. To switch to the new behavior, pass `:all` as the role name.

The deprecation is coming from [here](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb#L107) and was introduced [here](https://github.com/rails/rails/commit/69396b75c91cdbbf141331356ef7c41bbfea1950)

Passing `ActiveRecord::Base.current_role` to `connection_pool_list` just preserves current behaviour while silencing the deprecation warning