### PR TITLE
Fix another Active Record deprecation

### DIFF
--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -282,7 +282,7 @@ class FetchTest < IdentityCache::TestCase
     @record.save!
     record = Item.fetch(@record.id)
 
-    ActiveRecord::Base.clear_active_connections!(ActiveRecord::Base.current_role)
+    ActiveRecord::Base.connection_handler.clear_active_connections!(ActiveRecord::Base.current_role)
 
     assert_equal(record, Item.fetch(@record.id))
 


### PR DESCRIPTION
```
DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_active_connections!`. (called from test_fetch_cache_hit_does_not_checkout_database_connection at /home/runner/work/identity_cache/identity_cache/test/fetch_test.rb:285)
```