### PR TITLE
Do not call should_use_cache? on prefetched/embedded assocs

### DIFF
--- a/lib/identity_cache/cached/belongs_to.rb
+++ b/lib/identity_cache/cached/belongs_to.rb
@@ -9,7 +9,7 @@ module IdentityCache
         reflection.active_record.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
           def #{cached_accessor_name}
             association_klass = association(:#{name}).klass
-            if association_klass.should_use_cache? && #{reflection.foreign_key}.present? && !association(:#{name}).loaded?
+            if (loaded_by_idc? || association_klass.should_use_cache?) && #{reflection.foreign_key}.present? && !association(:#{name}).loaded?
               if defined?(#{records_variable_name})
                 #{records_variable_name}
               else

--- a/lib/identity_cache/cached/primary_index.rb
+++ b/lib/identity_cache/cached/primary_index.rb
@@ -54,7 +54,10 @@ module IdentityCache
 
       def load_one_from_db(id)
         record = build_query(id).take
-        model.send(:setup_embedded_associations_on_miss, [record]) if record
+        if record
+          model.send(:setup_embedded_associations_on_miss, [record])
+          record.send(:mark_as_loaded_by_idc)
+        end
         record
       end
 

--- a/lib/identity_cache/cached/primary_index.rb
+++ b/lib/identity_cache/cached/primary_index.rb
@@ -66,6 +66,7 @@ module IdentityCache
 
         records = build_query(ids).to_a
         model.send(:setup_embedded_associations_on_miss, records)
+        records.each { |record| record.send(:mark_as_loaded_by_idc) }
         records.index_by(&:id)
       end
 

--- a/lib/identity_cache/cached/recursive/association.rb
+++ b/lib/identity_cache/cached/recursive/association.rb
@@ -25,7 +25,7 @@ module IdentityCache
         def read(record)
           assoc = record.association(name)
 
-          if assoc.klass.should_use_cache? && !assoc.loaded? && assoc.target.blank?
+          if (record.send(:loaded_by_idc?) || assoc.klass.should_use_cache?) && !assoc.loaded? && assoc.target.blank?
             if record.instance_variable_defined?(records_variable_name)
               record.instance_variable_get(records_variable_name)
             elsif record.instance_variable_defined?(dehydrated_variable_name)

--- a/lib/identity_cache/cached/reference/has_many.rb
+++ b/lib/identity_cache/cached/reference/has_many.rb
@@ -22,7 +22,7 @@ module IdentityCache
 
             def #{cached_accessor_name}
               assoc = association(:#{name})
-              if assoc.klass.should_use_cache? && !assoc.loaded? && assoc.target.blank?
+              if (loaded_by_idc? || assoc.klass.should_use_cache?) && !assoc.loaded? && assoc.target.blank?
                 #{records_variable_name} ||= #{reflection.class_name}.fetch_multi(#{cached_ids_name})
               else
                 #{name}.to_a

--- a/lib/identity_cache/encoder.rb
+++ b/lib/identity_cache/encoder.rb
@@ -69,6 +69,7 @@ module IdentityCache
 
       def record_from_coder(coder, klass) # :nodoc:
         record = klass.instantiate(coder[:attributes].dup)
+        record.send(:mark_as_loaded_by_idc)
 
         if coder.key?(:associations)
           coder[:associations].each do |name, value|

--- a/lib/identity_cache/should_use_cache.rb
+++ b/lib/identity_cache/should_use_cache.rb
@@ -9,5 +9,15 @@ module IdentityCache
         IdentityCache.should_use_cache?
       end
     end
+
+    private
+
+    def mark_as_loaded_by_idc
+      @loaded_by_idc = true
+    end
+
+    def loaded_by_idc?
+      defined?(@loaded_by_idc)
+    end
   end
 end

--- a/test/denormalized_has_many_test.rb
+++ b/test/denormalized_has_many_test.rb
@@ -171,17 +171,6 @@ class DenormalizedHasManyTest < IdentityCache::TestCase
     end
   end
 
-  def test_respect_should_use_cache_from_embedded_records
-    Item.fetch(@record.id)
-    AssociatedRecord.stubs(:should_use_cache?).returns(false)
-
-    assert_memcache_operations(1) do
-      assert_queries(1) do
-        Item.fetch(@record.id).fetch_associated_records
-      end
-    end
-  end
-
   def test_fetch_association_after_adding_to_it
     item = Item.fetch(@record.id)
     item.associated_records.create!(name: "foo")

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -342,6 +342,43 @@ class FetchTest < IdentityCache::TestCase
     end
   end
 
+  def test_should_use_cache_not_called_on_prefetched
+    Item.send(:cache_belongs_to, :item)
+
+    bob = Item.create!(title: "bob")
+    john = Item.create!(title: "john")
+    bob.update_column(:item_id, john.id)
+
+    item = Item.fetch(bob.id, includes: [:item])
+    IdentityCache.expects(:should_use_cache?).never
+    item.fetch_item
+  end
+
+  def test_should_use_cache_not_called_on_embedded_has_many
+    Item.send(:cache_has_many, :associated_records, embed: true)
+
+    bob = Item.create!(title: "bob")
+
+    bob.associated_records.create!(name: "foo")
+    bob.associated_records.create!(name: "bar")
+
+    item = Item.fetch(bob.id)
+    IdentityCache.expects(:should_use_cache?).never
+    records = item.fetch_associated_records
+    assert_equal 2, records.size
+  end
+
+  def test_should_use_cache_not_called_on_embedded_has_one
+    Item.send(:cache_has_one, :related_item, embed: true)
+
+    bob = Item.create!(title: "bob")
+    bob.build_related_item.save!
+
+    item = Item.fetch(bob.id)
+    IdentityCache.expects(:should_use_cache?).never
+    assert_predicate item.fetch_related_item, :present?
+  end
+
   def test_respects_should_use_cache_on_record
     @record.save
     Item.stubs(:should_use_cache?).returns(false)

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -354,6 +354,18 @@ class FetchTest < IdentityCache::TestCase
     item.fetch_item
   end
 
+  def test_should_use_cache_not_called_on_prefetched_multi
+    Item.send(:cache_belongs_to, :item)
+
+    bob = Item.create!(title: "bob")
+    john = Item.create!(title: "john")
+    bob.update_column(:item_id, john.id)
+
+    items = Item.fetch_multi([bob.id], includes: [:item])
+    IdentityCache.expects(:should_use_cache?).never
+    items.first.fetch_item
+  end
+
   def test_should_use_cache_not_called_on_embedded_has_many
     Item.send(:cache_has_many, :associated_records, embed: true)
 
@@ -365,7 +377,7 @@ class FetchTest < IdentityCache::TestCase
     item = Item.fetch(bob.id)
     IdentityCache.expects(:should_use_cache?).never
     records = item.fetch_associated_records
-    assert_equal 2, records.size
+    assert_equal(2, records.size)
   end
 
   def test_should_use_cache_not_called_on_embedded_has_one
@@ -376,7 +388,31 @@ class FetchTest < IdentityCache::TestCase
 
     item = Item.fetch(bob.id)
     IdentityCache.expects(:should_use_cache?).never
-    assert_predicate item.fetch_related_item, :present?
+    assert_predicate(item.fetch_related_item, :present?)
+  end
+
+  def test_should_use_cache_called_on_has_many_embed_ids
+    Item.send(:cache_has_many, :associated_records, embed: :ids)
+
+    bob = Item.create!(title: "bob")
+    bob.associated_records.create!(name: "foo")
+    bob.associated_records.create!(name: "bar")
+
+    item = Item.fetch(bob.id)
+    IdentityCache.expects(:should_use_cache?).at_least_once.returns(true)
+    records = item.fetch_associated_records
+    assert_equal(2, records.size)
+  end
+
+  def test_should_use_cache_called_on_has_one_embed_id
+    Item.send(:cache_has_one, :related_item, embed: :id)
+
+    bob = Item.create!(title: "bob")
+    bob.build_related_item.save!
+
+    item = Item.fetch(bob.id)
+    IdentityCache.expects(:should_use_cache?).at_least_once.returns(true)
+    assert_predicate(item.fetch_related_item, :present?)
   end
 
   def test_respects_should_use_cache_on_record


### PR DESCRIPTION
`IdentityCache.should_use_cache?` can be rather expensive as it checks for open transactions. Consider this example:

```ruby
# ProductVariant belongs to Product
variants = ProductVariant.fetch_multi(1000_of_ids, includes: [:product])
variants.each |v|
  product = v.fetch_product
  # do something with the product
end
```

The following would essentially call `IdentityCache.should_use_cache?` at least 1001 times. That's 1001 times of checking for transaction to be open.

For real, we only need to check `should_use_cache?` in the top level `fetch`/`fetch_multi`. For all of those variants the product has already been prefetched, and there's little point calling `should_use_cache?` on each of those `fetch_product`.


This is accomplished by marking the record as "loaded by IDC". That's a marker signaling that `should_use_cache?` has already been checked.

`ProductVariant.find(1).fetch_product` would not have that market set, and it would still run `should_use_cache?` as expected.