### PR TITLE
Bump to 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.5.3
+
+- No longer call `should_use_cache?` on embedded/prefetched associations when reading values
+
 ## 1.5.2
 
 - Add missing `should_use_cache?` to `fetch_multi` methods.

--- a/lib/identity_cache/version.rb
+++ b/lib/identity_cache/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module IdentityCache
-  VERSION = "1.5.2"
+  VERSION = "1.5.3"
   CACHE_VERSION = 8
 end


### PR DESCRIPTION
This will include https://github.com/Shopify/identity_cache/pull/553.