### PR TITLE
Fix class name in AssociationError message

### DIFF
--- a/lib/identity_cache/belongs_to_caching.rb
+++ b/lib/identity_cache/belongs_to_caching.rb
@@ -14,7 +14,7 @@ module IdentityCache
         ensure_base_model
 
         unless (reflection = reflect_on_association(association))
-          raise AssociationError, "Association named '#{association}' was not found on #{self.class}"
+          raise AssociationError, "Association named '#{association}' was not found on #{self}"
         end
 
         if reflection.scope

--- a/lib/identity_cache/configuration_dsl.rb
+++ b/lib/identity_cache/configuration_dsl.rb
@@ -143,7 +143,7 @@ module IdentityCache
 
       def check_association_for_caching(association)
         unless (association_reflection = reflect_on_association(association))
-          raise AssociationError, "Association named '#{association}' was not found on #{self.class}"
+          raise AssociationError, "Association named '#{association}' was not found on #{self}"
         end
         if association_reflection.options[:through]
           raise UnsupportedAssociationError, "caching through associations isn't supported"

--- a/test/association_error_test.rb
+++ b/test/association_error_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AssociationErrorTest < IdentityCache::TestCase
+  def test_cache_belongs_to
+    error = assert_raises(IdentityCache::AssociationError) do
+      Item.send(:cache_belongs_to, :foo)
+    end
+    assert_equal("Association named 'foo' was not found on Item", error.message)
+  end
+
+  def test_cache_has_one
+    error = assert_raises(IdentityCache::AssociationError) do
+      Item.send(:cache_has_one, :foo, embed: true)
+    end
+    assert_equal("Association named 'foo' was not found on Item", error.message)
+  end
+
+  def test_cache_has_many
+    error = assert_raises(IdentityCache::AssociationError) do
+      Item.send(:cache_has_many, :foo)
+    end
+    assert_equal("Association named 'foo' was not found on Item", error.message)
+  end
+end


### PR DESCRIPTION
`self` is the model here, so `self.class` is always "Class".