### PR TITLE
Allow prefetch_associations on association that was prefetched before

### DIFF
--- a/lib/identity_cache/cached/belongs_to.rb
+++ b/lib/identity_cache/cached/belongs_to.rb
@@ -77,16 +77,20 @@ module IdentityCache
             end
           end
 
-          load_strategy.load_multi(
-            reflection.klass.cached_primary_index,
-            ids_to_owner_record.keys
-          ) do |associated_records_by_id|
-            associated_records_by_id.each do |id, associated_record|
-              owner_record = ids_to_owner_record.fetch(id)
-              write(owner_record, associated_record)
-            end
+          if ids_to_owner_record.any?
+            load_strategy.load_multi(
+              reflection.klass.cached_primary_index,
+              ids_to_owner_record.keys
+            ) do |associated_records_by_id|
+              associated_records_by_id.each do |id, associated_record|
+                owner_record = ids_to_owner_record.fetch(id)
+                write(owner_record, associated_record)
+              end
 
-            yield associated_records_by_id.values.compact
+              yield associated_records_by_id.values.compact
+            end
+          else
+            yield records.filter_map { |record| record.instance_variable_get(records_variable_name) }
           end
         end
       end


### PR DESCRIPTION
Consider the following code:

```
def work(product_variant_ids)
  product_variants = ProductVariant.fetch_multi(product_variant_ids, includes: { product: [] })
  safe = perform_safety_checks(product_variants)
  return if !safe
  
  # Now that it's safe, we want to access product variants
  # with their products and images and some other items.
  # For that, we'd want them to be prefetched to avoid N+1
  ProductVariant.prefetch_associations({ product: [:images], some_other_items: [] }, product_variants)
end
```

The following uses `prefetch_associations` API from IDC. It works great, apart from when the same association (in our case, `:product`) has already been part of prefetching.

In the snippet above, `some_other_items` would be loaded but `product: [:images]` would not be, because `product` is already considered being loaded.

This PR fixes that bug.
