### PR TITLE
Fix test helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,14 +88,11 @@ module IdentityCache
     def assert_queries(num = 1, **subscribe_opts, &block)
       log = []
       ret = subscribe_to_sql_queries(->(sql) { log << sql }, **subscribe_opts, &block)
-      assert_equal(
-        num,
-        log.size,
-        <<~MSG.squish
-          #{log.size} instead of #{num} queries were executed.
-          #{log.empty? ? "" : "\nQueries:\n#{log.join("\n")}"}
-        MSG
-      )
+
+      msg = "#{log.size} instead of #{num} queries were executed."
+      msg << "\nQueries:\n#{log.join("\n")}" unless log.empty?
+
+      assert_equal(num, log.size, msg)
       ret
     end
 


### PR DESCRIPTION
That `sqiush` on assertion message has been removing `\n`, making it less readable:

```
  1) Failure:
IdentityCache::PrefetchAssociationsTest#test_fetch_multi_batch_fetches_non_embedded_second_level_belongs_to_associations_in_repeating_prefetch [test/prefetch_associations_test.rb:293]:
2 instead of 1 queries were executed. Queries: SELECT `associated_records`.* FROM `associated_records` WHERE `associated_records`.`id` IN (1, 3) ORDER BY id DESC SELECT `items`.* FROM `items` WHERE `items`.`id` = 4.
Expected: 1
  Actual: 2
```

After this PR:

```
  1) Failure:
IdentityCache::PrefetchAssociationsTest#test_fetch_multi_batch_fetches_non_embedded_second_level_belongs_to_associations_in_repeating_prefetch [test/prefetch_associations_test.rb:293]:
2 instead of 1 queries were executed. Queries: 
SELECT `associated_records`.* FROM `associated_records` WHERE `associated_records`.`id` IN (1, 3) ORDER BY id DESC
SELECT `items`.* FROM `items` WHERE `items`.`id` = 4.
Expected: 1
  Actual: 2
```