### PR TITLE
Change order in if clause for should_use_cache?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 1.5.6
+
+- Minor performance improvements on association read
+
+## 1.5.5
+
+- Minor performance improvements on association read
+
+
 ## 1.5.4
 
 - Make `prefetch_associations` work as expected on associations that have been partially prefetched

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    identity_cache (1.5.5)
+    identity_cache (1.5.6)
       activerecord (>= 7.0)
       ar_transaction_changes (~> 1.1)
 

--- a/lib/identity_cache/cached/belongs_to.rb
+++ b/lib/identity_cache/cached/belongs_to.rb
@@ -9,7 +9,7 @@ module IdentityCache
         reflection.active_record.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
           def #{cached_accessor_name}
             association_klass = association(:#{name}).klass
-            if (loaded_by_idc? || association_klass.should_use_cache?) && #{reflection.foreign_key}.present? && !association(:#{name}).loaded?
+            if #{reflection.foreign_key}.present? && !association(:#{name}).loaded? && (loaded_by_idc? || association_klass.should_use_cache?)
               if defined?(#{records_variable_name})
                 #{records_variable_name}
               else

--- a/lib/identity_cache/cached/recursive/association.rb
+++ b/lib/identity_cache/cached/recursive/association.rb
@@ -25,7 +25,7 @@ module IdentityCache
         def read(record)
           assoc = record.association(name)
 
-          if (record.send(:loaded_by_idc?) || assoc.klass.should_use_cache?) && !assoc.loaded? && assoc.target.blank?
+          if !assoc.loaded? && assoc.target.blank? && (record.send(:loaded_by_idc?) || assoc.klass.should_use_cache?)
             if record.instance_variable_defined?(records_variable_name)
               record.instance_variable_get(records_variable_name)
             elsif record.instance_variable_defined?(dehydrated_variable_name)

--- a/lib/identity_cache/version.rb
+++ b/lib/identity_cache/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module IdentityCache
-  VERSION = "1.5.5"
+  VERSION = "1.5.6"
   CACHE_VERSION = 8
 end

--- a/test/fetch_test.rb
+++ b/test/fetch_test.rb
@@ -388,7 +388,6 @@ class FetchTest < IdentityCache::TestCase
 
     from_db = Item.includes(:associated_records).find(bob.id)
 
-    # item = Item.fetch(bob.id)
     IdentityCache.expects(:should_use_cache?).never
     records = from_db.fetch_associated_records
     assert_equal(2, records.size)


### PR DESCRIPTION
When records are preloaded from database using `Post.includes(:author).find(id)`, `fetch_author` will fallback to returning the object that was preloaded from the database.

However, it still goes through `association_klass.should_use_cache?` which started appearing on our profiles.

`association_klass.should_use_cache?` is the more expensive check so it's gotta be in the end of `if` clause.