### PR TITLE
Support deferred expiration of records and attributes for one-to-many associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.6.2
+
+- Support deferred expiry of associations and attributes. Add a rake task to create test database.
+
 ## 1.6.1
 
 - Fix deprecation warnings on Active Record 7.2. (#575)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    identity_cache (1.6.1)
+    identity_cache (1.6.2)
       activerecord (>= 7.0)
       ar_transaction_changes (~> 1.1)
 

--- a/Rakefile
+++ b/Rakefile
@@ -47,3 +47,27 @@ namespace :profile do
     ruby "./performance/profile.rb"
   end
 end
+
+namespace :db do
+  desc "Create the identity_cache_test database"
+  task :create do
+    require "mysql2"
+
+    config = {
+      host: ENV.fetch("MYSQL_HOST") || "localhost",
+      port: ENV.fetch("MYSQL_PORT") || 1037,
+      username: ENV.fetch("MYSQL_USER") || "root",
+      password: ENV.fetch("MYSQL_PASSWORD") || "",
+    }
+
+    begin
+      client = Mysql2::Client.new(config)
+      client.query("CREATE DATABASE IF NOT EXISTS identity_cache_test")
+      puts "Database 'identity_cache_test' created successfully. host: #{config[:host]}, port: #{config[:port]}"
+    rescue Mysql2::Error => e
+      puts "Error creating database: #{e.message}"
+    ensure
+      client&.close
+    end
+  end
+end

--- a/dev.yml
+++ b/dev.yml
@@ -5,6 +5,10 @@ up:
   - bundler
   - memcached
   - mysql
+  - custom:
+      name: create database identity_cache_test
+      met?: mysql -u root -h 127.0.0.1 -P 1037 -e "SHOW DATABASES;" | grep identity_cache_test
+      meet: bundle exec rake db:create
 
 commands:
   test:
@@ -12,7 +16,7 @@ commands:
       optional:
         argument: file
         optional: args...
-    desc: 'Run tests'
+    desc: "Run tests"
     run: |
       if [[ $# -eq 0 ]]; then
         bundle exec rake test
@@ -21,21 +25,21 @@ commands:
       fi
 
   style:
-    desc: 'Run rubocop checks'
+    desc: "Run rubocop checks"
     run: bundle exec rubocop "$@"
 
   check:
-    desc: 'Run tests and style checks'
+    desc: "Run tests and style checks"
     run: bundle exec rake test && bundle exec rubocop
 
   benchmark-cpu:
-    desc: 'Run the identity cache CPU benchmark'
+    desc: "Run the identity cache CPU benchmark"
     run: bundle exec rake benchmark:cpu
 
   profile:
-    desc: 'Profile IDC code'
+    desc: "Profile IDC code"
     run: bundle exec rake profile:run
 
   update-serialization-format:
-    desc: 'Update serialization format test fixture'
+    desc: "Update serialization format test fixture"
     run: bundle exec rake update_serialization_format

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -233,9 +233,23 @@ module IdentityCache
       result = yield
 
       Thread.current[:idc_deferred_expiration] = nil
-      IdentityCache.cache.delete_multi(Thread.current[:idc_parent_records_to_expire]) if Thread.current[:idc_parent_records_to_expire].any?
-      IdentityCache.cache.delete_multi(Thread.current[:idc_child_records_to_expire]) if Thread.current[:idc_child_records_to_expire].any?
-      IdentityCache.cache.delete_multi(Thread.current[:idc_attributes_to_expire]) if Thread.current[:idc_attributes_to_expire].any?
+      if Thread.current[:idc_parent_records_to_expire].any?
+        IdentityCache.cache.delete_multi(
+          Thread.current[:idc_parent_records_to_expire]
+        )
+      end
+
+      if Thread.current[:idc_child_records_to_expire].any?
+        IdentityCache.cache.delete_multi(
+          Thread.current[:idc_child_records_to_expire]
+        )
+      end
+
+      if Thread.current[:idc_attributes_to_expire].any?
+        IdentityCache.cache.delete_multi(
+          Thread.current[:idc_attributes_to_expire]
+        )
+      end
       result
     ensure
       Thread.current[:idc_deferred_expiration] = nil

--- a/lib/identity_cache/cache_fetcher.rb
+++ b/lib/identity_cache/cache_fetcher.rb
@@ -87,10 +87,6 @@ module IdentityCache
       end
     end
 
-    def exist?(key)
-      @cache_backend.exist?(key)
-    end
-
     private
 
     def fetch_without_fill_lock(key)

--- a/lib/identity_cache/cache_fetcher.rb
+++ b/lib/identity_cache/cache_fetcher.rb
@@ -60,6 +60,11 @@ module IdentityCache
       @cache_backend.write(key, IdentityCache::DELETED, expires_in: IdentityCache::DELETED_TTL.seconds)
     end
 
+    def delete_multi(keys)
+      key_values = keys.map { |key| [key, IdentityCache::DELETED] }.to_h
+      @cache_backend.write_multi(key_values, expires_in: IdentityCache::DELETED_TTL.seconds)
+    end
+
     def clear
       @cache_backend.clear
     end
@@ -80,6 +85,10 @@ module IdentityCache
       else
         fetch_without_fill_lock(key, &block)
       end
+    end
+
+    def exist?(key)
+      @cache_backend.exist?(key)
     end
 
     private

--- a/lib/identity_cache/cached/attribute.rb
+++ b/lib/identity_cache/cached/attribute.rb
@@ -40,7 +40,7 @@ module IdentityCache
         unless record.send(:was_new_record?)
           old_key = old_cache_key(record)
 
-          if Thread.current[:idc_deferred_attribute_expiration]
+          if Thread.current[:idc_deferred_expiration]
             Thread.current[:idc_attributes_to_expire] << old_key
             # defer the deletion, and don't block the following deletion
             all_deleted = true
@@ -51,7 +51,7 @@ module IdentityCache
         unless record.destroyed?
           new_key = new_cache_key(record)
           if new_key != old_key
-            if Thread.current[:idc_deferred_attribute_expiration]
+            if Thread.current[:idc_deferred_expiration]
               Thread.current[:idc_attributes_to_expire] << new_key
               all_deleted = true
             else

--- a/lib/identity_cache/cached/primary_index.rb
+++ b/lib/identity_cache/cached/primary_index.rb
@@ -46,7 +46,7 @@ module IdentityCache
       def expire(id)
         id = cast_id(id)
         if Thread.current[:idc_deferred_expiration]
-          Thread.current[:idc_child_records_to_expire] << cache_key(id)
+          Thread.current[:idc_records_to_expire] << cache_key(id)
         else
           IdentityCache.cache.delete(cache_key(id))
         end

--- a/lib/identity_cache/cached/primary_index.rb
+++ b/lib/identity_cache/cached/primary_index.rb
@@ -45,7 +45,11 @@ module IdentityCache
 
       def expire(id)
         id = cast_id(id)
-        IdentityCache.cache.delete(cache_key(id))
+        if Thread.current[:idc_deferred_attribute_expiration]
+          Thread.current[:idc_records_to_expire] << cache_key(id)
+        else
+          IdentityCache.cache.delete(cache_key(id))
+        end
       end
 
       def cache_key(id)

--- a/lib/identity_cache/cached/primary_index.rb
+++ b/lib/identity_cache/cached/primary_index.rb
@@ -45,8 +45,8 @@ module IdentityCache
 
       def expire(id)
         id = cast_id(id)
-        if Thread.current[:idc_deferred_attribute_expiration]
-          Thread.current[:idc_records_to_expire] << cache_key(id)
+        if Thread.current[:idc_deferred_expiration]
+          Thread.current[:idc_child_records_to_expire] << cache_key(id)
         else
           IdentityCache.cache.delete(cache_key(id))
         end

--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -147,10 +147,6 @@ module IdentityCache
       end
     end
 
-    def exist?(key)
-      @cache_fetcher.exist?(key)
-    end
-
     private
 
     EMPTY_ARRAY = [].freeze

--- a/lib/identity_cache/memoized_cache_proxy.rb
+++ b/lib/identity_cache/memoized_cache_proxy.rb
@@ -70,6 +70,16 @@ module IdentityCache
       end
     end
 
+    def delete_multi(keys)
+      memoizing = memoizing?
+      ActiveSupport::Notifications.instrument("cache_delete_multi.identity_cache", memoizing: memoizing) do
+        if memoizing
+          keys.each { |key| memoized_key_values.delete(key) }
+        end
+        @cache_fetcher.delete_multi(keys)
+      end
+    end
+
     def fetch(key, cache_fetcher_options = {}, &block)
       memo_misses = 0
       cache_misses = 0
@@ -135,6 +145,10 @@ module IdentityCache
         clear_memoization
         @cache_fetcher.clear
       end
+    end
+
+    def exist?(key)
+      @cache_fetcher.exist?(key)
     end
 
     private

--- a/lib/identity_cache/parent_model_expiration.rb
+++ b/lib/identity_cache/parent_model_expiration.rb
@@ -47,10 +47,6 @@ module IdentityCache
       add_parents_to_cache_expiry_set(parents_to_expire)
       parents_to_expire.select! { |parent| parent.class.primary_cache_index_enabled }
       parents_to_expire.reduce(true) do |all_expired, parent|
-        if Thread.current[:idc_deferred_expiration]
-          Thread.current[:idc_parent_records_to_expire] << parent.cache_key
-          next parent
-        end
         parent.expire_primary_index && all_expired
       end
     end

--- a/lib/identity_cache/parent_model_expiration.rb
+++ b/lib/identity_cache/parent_model_expiration.rb
@@ -47,8 +47,8 @@ module IdentityCache
       add_parents_to_cache_expiry_set(parents_to_expire)
       parents_to_expire.select! { |parent| parent.class.primary_cache_index_enabled }
       parents_to_expire.reduce(true) do |all_expired, parent|
-        if Thread.current[:idc_deferred_parent_expiration]
-          Thread.current[:idc_parent_records_for_cache_expiry] << parent
+        if Thread.current[:idc_deferred_expiration]
+          Thread.current[:idc_parent_records_to_expire] << parent.cache_key
           next parent
         end
         parent.expire_primary_index && all_expired

--- a/lib/identity_cache/version.rb
+++ b/lib/identity_cache/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module IdentityCache
-  VERSION = "1.6.1"
+  VERSION = "1.6.2"
   CACHE_VERSION = 8
 end

--- a/test/index_cache_test.rb
+++ b/test/index_cache_test.rb
@@ -166,38 +166,36 @@ class IndexCacheTest < IdentityCache::TestCase
     assert_equal(123, KeyedRecord.fetch_by_value("a").id)
   end
 
-  def test_with_deferred_parent_expiration_expires_parent_index_once
+  def test_with_deferred_expiration_for_parent_records_expires_parent_index_once
     Item.send(:cache_has_many, :associated_records, embed: true)
 
     @parent = Item.create!(title: "bob")
     @records = @parent.associated_records.create!([{ name: "foo" }, { name: "bar" }, { name: "baz" }])
 
-    @memcached_spy = Spy.on(backend, :write).and_call_through
-
+    @memcached_spy_write_multi = Spy.on(backend, :write_multi).and_call_through
     expected_item_expiration_count = Array(@parent).count
     expected_associated_record_expiration_count = @records.count
 
     expected_return_value = "Some text that we expect to see returned from the block"
 
-    result = IdentityCache.with_deferred_parent_expiration do
+    result = IdentityCache.with_deferred_expiration do
       @parent.transaction do
         @parent.associated_records.destroy_all
       end
-      assert_equal(expected_associated_record_expiration_count, @memcached_spy.calls.count)
       expected_return_value
     end
 
-    expired_cache_keys = @memcached_spy.calls.map(&:args).map(&:first)
-    item_expiration_count = expired_cache_keys.count { _1.include?("Item") }
-    associated_record_expiration_count = expired_cache_keys.count { _1.include?("AssociatedRecord") }
+    all_keys = @memcached_spy_write_multi.calls.flat_map { |call| call.args.first.keys }
+    item_expiration_count = all_keys.count { _1.start_with?("items/") }
+    associated_record_expiration_count = all_keys.count { _1.include?(":AssociatedRecord:") }
 
-    assert_operator(@memcached_spy.calls.count, :>, 0)
+    assert_operator(@memcached_spy_write_multi.calls.count, :>, 0)
     assert_equal(expected_item_expiration_count, item_expiration_count)
     assert_equal(expected_associated_record_expiration_count, associated_record_expiration_count)
     assert_equal(expected_return_value, result)
   end
 
-  def test_double_nested_deferred_parent_expiration_will_raise_error
+  def test_double_nested_deferred_expiration_for_parent_records_will_raise_error
     Item.send(:cache_has_many, :associated_records, embed: true)
 
     @parent = Item.create!(title: "bob")
@@ -205,9 +203,9 @@ class IndexCacheTest < IdentityCache::TestCase
 
     @memcached_spy = Spy.on(backend, :write).and_call_through
 
-    assert_raises(IdentityCache::NestedDeferredParentBlockError) do
-      IdentityCache.with_deferred_parent_expiration do
-        IdentityCache.with_deferred_parent_expiration do
+    assert_raises(IdentityCache::NestedDeferredCacheExpirationBlockError) do
+      IdentityCache.with_deferred_expiration do
+        IdentityCache.with_deferred_expiration do
           @parent.transaction do
             @parent.associated_records.destroy_all
           end
@@ -218,7 +216,7 @@ class IndexCacheTest < IdentityCache::TestCase
     assert_equal(0, @memcached_spy.calls.count)
   end
 
-  def test_deep_association_with_deferred_parent_expiration_expires_parent_once
+  def test_deep_association_with_deferred_expiration_expires_parent_once
     AssociatedRecord.send(:has_many, :deeply_associated_records, dependent: :destroy)
     Item.send(:cache_has_many, :associated_records, embed: true)
 
@@ -232,27 +230,27 @@ class IndexCacheTest < IdentityCache::TestCase
       ])
     end
 
-    @memcached_spy = Spy.on(backend, :write).and_call_through
+    @memcached_spy_write_multi = Spy.on(backend, :write_multi).and_call_through
 
     expected_item_expiration_count = Array(@parent).count
     expected_associated_record_expiration_count = @records.count
     expected_deeply_associated_record_expiration_count = @records.flat_map(&:deeply_associated_records).count
 
-    IdentityCache.with_deferred_parent_expiration do
+    IdentityCache.with_deferred_expiration do
       @parent.transaction do
         @parent.associated_records.destroy_all
       end
     end
 
-    expired_cache_keys = @memcached_spy.calls.map(&:args).map(&:first)
-    item_expiration_count = expired_cache_keys.count { _1.include?("Item") }
-    associated_record_expiration_count = expired_cache_keys.count { _1.include?(":AssociatedRecord:") }
-    deeply_associated_record_expiration_count = expired_cache_keys.count { _1.include?("DeeplyAssociatedRecord") }
+    all_keys = @memcached_spy_write_multi.calls.flat_map { |call| call.args.first.keys }
+    item_expiration_count = all_keys.count { |key| key.start_with?("items/") }
+    associated_record_keys = all_keys.count { |key| key.include?(":AssociatedRecord:") }
+    deeply_associated_record_keys = all_keys.count { |key| key.include?(":DeeplyAssociatedRecord:") }
 
-    assert_operator(@memcached_spy.calls.count, :>, 0)
+    assert_operator(@memcached_spy_write_multi.calls.count, :>, 0)
     assert_equal(expected_item_expiration_count, item_expiration_count)
-    assert_equal(expected_associated_record_expiration_count, associated_record_expiration_count)
-    assert_equal(expected_deeply_associated_record_expiration_count, deeply_associated_record_expiration_count)
+    assert_equal(expected_associated_record_expiration_count, associated_record_keys)
+    assert_equal(expected_deeply_associated_record_expiration_count, deeply_associated_record_keys)
   end
 
   private

--- a/test/save_test.rb
+++ b/test/save_test.rb
@@ -118,5 +118,4 @@ class SaveTest < IdentityCache::TestCase
       end
     end
   end
-
 end

--- a/test/save_test.rb
+++ b/test/save_test.rb
@@ -111,7 +111,7 @@ class SaveTest < IdentityCache::TestCase
     ])
     expect_cache_deletes([@record1.primary_cache_index_key, @record2.primary_cache_index_key])
 
-    IdentityCache.with_deferred_attribute_expiration do
+    IdentityCache.with_deferred_expiration do
       ActiveRecord::Base.transaction do
         @record1.touch
         @record2.touch
@@ -119,14 +119,4 @@ class SaveTest < IdentityCache::TestCase
     end
   end
 
-  private
-
-  def expect_cache_delete(key)
-    @backend.expects(:write).with(key, IdentityCache::DELETED, anything)
-  end
-
-  def expect_cache_deletes(keys)
-    key_values = keys.map { |key| [key, IdentityCache::DELETED] }
-    @backend.expects(:write_multi).with(key_values, anything)
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require "helpers/cache_connection"
 require "helpers/active_record_objects"
 require "helpers/mocked_cache_backend"
 require "spy/integration"
+require "byebug"
 
 require File.dirname(__FILE__) + "/../lib/identity_cache"
 
@@ -126,6 +127,15 @@ module IdentityCache
         MSG
       )
       ret
+    end
+
+    def expect_cache_delete(key)
+      @backend.expects(:write).with(key, IdentityCache::DELETED, anything)
+    end
+
+    def expect_cache_deletes(keys)
+      key_values = keys.map { |key| [key, IdentityCache::DELETED] }.to_h
+      @backend.expects(:write_multi).with(key_values, anything)
     end
 
     def assert_no_queries(**subscribe_opts, &block)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,6 @@ require "helpers/cache_connection"
 require "helpers/active_record_objects"
 require "helpers/mocked_cache_backend"
 require "spy/integration"
-require "byebug"
 
 require File.dirname(__FILE__) + "/../lib/identity_cache"
 


### PR DESCRIPTION
Related issues: https://github.com/Shopify/caching-platform/issues/708
* Deferred the expiration of child records and attributes to the end of transaction
* Used batch operations (`delete_multi`/`write_multi`) instead of expire each record in a loop
* In dev.yml, create the test database `identity_cache_test` in Mysql, achieved it by adding a Rake task