### PR TITLE
Split the with_deferred_parent_expiration and with_deferred_parent_expiration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/version_tmp
 tmp
 .rubocop-http*
 .byebug_history
+gemfiles/*.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+## 1.6.3
+
+- Split the `with_deferred_parent_expiration` and `with_deferred_parent_expiration`. (#578)
+
 ## 1.6.2
 
-- Support deferred expiry of associations and attributes. Add a rake task to create test database.
+- Support deferred expiry of associations and attributes. Add a rake task to create test database. (#577)
 
 ## 1.6.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    identity_cache (1.6.2)
+    identity_cache (1.6.3)
       activerecord (>= 7.0)
       ar_transaction_changes (~> 1.1)
 

--- a/Rakefile
+++ b/Rakefile
@@ -21,8 +21,9 @@ namespace :test do
   desc "Test the identity_cache plugin with minimum supported dependencies"
   task :min_supported do
     gemfile = File.expand_path("gemfiles/Gemfile.min-supported", __dir__)
+    ENV["BUNDLE_GEMFILE"] = gemfile
 
-    puts "Installing dependencies for #{gemfile}..."
+    puts "\nInstalling dependencies for #{gemfile}..."
     Bundler.with_unbundled_env do
       system("bundle install --gemfile #{gemfile}") || abort("Bundle install failed")
     end
@@ -40,8 +41,9 @@ namespace :test do
   desc "Test the identity_cache plugin with latest released dependencies"
   task :latest_release do
     gemfile = File.expand_path("gemfiles/Gemfile.latest-release", __dir__)
+    ENV["BUNDLE_GEMFILE"] = gemfile
 
-    puts "Installing dependencies for #{gemfile}..."
+    puts "\nInstalling dependencies for #{gemfile}..."
     Bundler.with_unbundled_env do
       system("bundle install --gemfile #{gemfile}") || abort("Bundle install failed")
     end
@@ -59,6 +61,7 @@ namespace :test do
   desc "Test the identity_cache plugin with rails edge dependencies"
   task :rails_edge do
     gemfile = File.expand_path("gemfiles/Gemfile.rails-edge", __dir__)
+    ENV["BUNDLE_GEMFILE"] = gemfile
 
     puts "\nInstalling dependencies for #{gemfile}..."
     Bundler.with_unbundled_env do

--- a/dev.yml
+++ b/dev.yml
@@ -24,6 +24,10 @@ commands:
         bundle exec ruby -I test "$@"
       fi
 
+  test-all:
+    desc: "Run tests for all gemfiles (default, min_supported, latest_release, rails_edge)"
+    run: bundle exec rake test_all
+
   style:
     desc: "Run rubocop checks"
     run: bundle exec rubocop "$@"

--- a/lib/identity_cache.rb
+++ b/lib/identity_cache.rb
@@ -229,10 +229,7 @@ module IdentityCache
       raise NestedDeferredParentBlockError if Thread.current[:idc_deferred_parent_expiration]
 
       if Thread.current[:idc_deferred_expiration]
-        ActiveRecord.deprecator.warn(<<-WARNING.squish)
-        `with_deferred_parent_expiration` is deprecated and will be removed in 1.7.0.
-        Use `with_deferred_expiration` instead.
-        WARNING
+        deprecator.deprecation_warning("`with_deferred_parent_expiration`")
       end
 
       Thread.current[:idc_deferred_parent_expiration] = true
@@ -246,7 +243,7 @@ module IdentityCache
       result
     ensure
       Thread.current[:idc_deferred_parent_expiration] = nil
-      Thread.current[:idc_parent_records_for_cache_expiry].clear
+      Thread.current[:idc_parent_records_for_cache_expiry]&.clear
     end
 
     # Executes a block with deferred cache expiration, ensuring that the records' (parent,
@@ -273,10 +270,7 @@ module IdentityCache
       raise NestedDeferredCacheExpirationBlockError if Thread.current[:idc_deferred_expiration]
 
       if Thread.current[:idc_deferred_parent_expiration]
-        ActiveRecord.deprecator.warn(<<-WARNING.squish)
-        `with_deferred_parent_expiration` is deprecated and will be removed in 1.7.0.
-        Use `with_deferred_expiration` instead.
-        WARNING
+        deprecator.deprecation_warning("`with_deferred_parent_expiration`")
       end
 
       Thread.current[:idc_deferred_expiration] = true
@@ -320,6 +314,10 @@ module IdentityCache
 
     def eager_load!
       ParentModelExpiration.install_all_pending_parent_expiry_hooks
+    end
+
+    def deprecator
+      @deprecator ||= ActiveSupport::Deprecation.new("1.7.0", "IdentityCache")
     end
 
     private

--- a/lib/identity_cache/parent_model_expiration.rb
+++ b/lib/identity_cache/parent_model_expiration.rb
@@ -47,6 +47,10 @@ module IdentityCache
       add_parents_to_cache_expiry_set(parents_to_expire)
       parents_to_expire.select! { |parent| parent.class.primary_cache_index_enabled }
       parents_to_expire.reduce(true) do |all_expired, parent|
+        if Thread.current[:idc_deferred_parent_expiration]
+          Thread.current[:idc_parent_records_for_cache_expiry] << parent
+          next parent
+        end
         parent.expire_primary_index && all_expired
       end
     end

--- a/lib/identity_cache/version.rb
+++ b/lib/identity_cache/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module IdentityCache
-  VERSION = "1.6.2"
+  VERSION = "1.6.3"
   CACHE_VERSION = 8
 end


### PR DESCRIPTION
* Split the with_deferred_parent_expiration and with_deferred_parent_expiration to ensure the API is backward compatible
* Add a deprecation message for with_deferred_parent_expiration
* Restore all the original unit tests of with_deferred_parent_expiration, to ensure the behaviour of it is not changed

Deprecation message (tested with ActiveRecord 7.0 and 7.2): 
<img width="1409" alt="image" src="https://github.com/user-attachments/assets/f31c79aa-ec10-45e2-b593-ea1e7aa025a5">
