### PR TITLE
Add cache refresh rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.6.4
+
+- Add `cache_refresh_period` to allow for cache refresh after a period of time. (#579)
+
 ## 1.6.3
 
 - Split the `with_deferred_parent_expiration` and `with_deferred_parent_expiration`. (#578)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/test/cache_fetcher_test.rb
+++ b/test/cache_fetcher_test.rb
@@ -179,7 +179,9 @@ class CacheFetcherTest < IdentityCache::TestCase
 end
 
 def test_fetch_without_fill_lock_with_stale_cached_data
-  stale_time = Time.now - (IdentityCache.cache_refresh_period + 1) * 60
+  identity_cache = IdentityCache
+  identity_cache.cache_refresh_period = 60
+  stale_time = Time.now - (identity_cache.cache_refresh_period + 1) * 60
   backend.write(key, { cached_at: stale_time, data: :old_data })
   assert_memcache_operations(2) do
     assert_equal(:new_data, cache_fetcher.fetch_without_fill_lock(key) { :new_data })
@@ -187,7 +189,9 @@ def test_fetch_without_fill_lock_with_stale_cached_data
 end
 
 def test_fetch_without_fill_lock_with_fresh_cached_data
-  fresh_time = Time.now - (IdentityCache.cache_refresh_period - 1) * 60
+  identity_cache = IdentityCache
+  identity_cache.cache_refresh_period = 60
+  fresh_time = Time.now - (identity_cache.cache_refresh_period - 1) * 60
   cached_data = { cached_at: fresh_time, data: :fresh_data }
   backend.write(key, cached_data)
   assert_memcache_operations(1) do

--- a/test/cache_fetcher_test.rb
+++ b/test/cache_fetcher_test.rb
@@ -177,3 +177,27 @@ class CacheFetcherTest < IdentityCache::TestCase
     @other_cache_fetcher ||= IdentityCache::CacheFetcher.new(backend)
   end
 end
+
+def test_fetch_without_fill_lock_with_stale_cached_data
+  stale_time = Time.now - (IdentityCache.cache_refresh_period + 1) * 60
+  backend.write(key, { cached_at: stale_time, data: :old_data })
+  assert_memcache_operations(2) do
+    assert_equal(:new_data, cache_fetcher.fetch_without_fill_lock(key) { :new_data })
+  end
+end
+
+def test_fetch_without_fill_lock_with_fresh_cached_data
+  fresh_time = Time.now - (IdentityCache.cache_refresh_period - 1) * 60
+  cached_data = { cached_at: fresh_time, data: :fresh_data }
+  backend.write(key, cached_data)
+  assert_memcache_operations(1) do
+    assert_equal(cached_data, cache_fetcher.fetch_without_fill_lock(key) { :new_data })
+  end
+end
+
+def test_fetch_without_fill_lock_with_non_hash_value
+  backend.write(key, "string_value")
+  assert_memcache_operations(1) do
+    assert_equal("string_value", cache_fetcher.fetch_without_fill_lock(key) { :new_data })
+  end
+end

--- a/test/helpers/database_connection.rb
+++ b/test/helpers/database_connection.rb
@@ -79,6 +79,7 @@ module DatabaseConnection
       "host" => ENV["MYSQL_HOST"] || "127.0.0.1",
       "username" => "root",
       "port" => ENV["MYSQL_PORT"] ? Integer(ENV["MYSQL_PORT"]) : 3306,
+      "password" => ENV["MYSQL_PASSWORD"] || "my-secret-pw",
     },
     "postgresql" => {
       "adapter" => "postgresql",


### PR DESCRIPTION
# Cache refresh rate

The main idea behind the PR is to introduce cache invalidation for outdated cache by referring to `:cache_refresh_period` for the max duration in minutes.

- Each hash record is stored with a `cached_at` element, indicating the time of caching
- When fetching said record, we check whether the time between `cached_at` and that of fetching is greater than `:cache_refresh_period`
  - If it is, the cache is invalidated & refreshed from the database
  - If it isn't, the cache is returned normally

## Implementation progress

- [x] Abstract the duration to a variable `:cache_refresh_period`
- [x] Implement it in single fetch
- [ ] Implement it in multi fetch
- [ ] Support non-hash value types
- [x] Add unit tests