### PR TITLE
Patch `run_callbacks` instead of `_run_commit_callbacks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Patch `run_callbacks` instead of `_run_commit_callbacks` to expire cache prior to `after_commit` callbacks. (#602)
+
 ## 1.6.3
 
 - Split the `with_deferred_parent_expiration` and `with_deferred_parent_expiration`. (#578)


### PR DESCRIPTION
##  Summary

This PR updates `IdentityCache`'s callback override mechanism to be compatible with updates to Rails' callback handling code, as of https://github.com/rails/rails/commit/207a254cedef2c381c2898bac960b91ce14ab3a7. The change in Rails introduces a "fast path" for callbacks and no-ops the `_run_#{callback}_callbacks` methods up until the point where a callback is actually defined, at which point Rails aliases `_run_#{callback}_callbacks` to a `!` version of the method.

Rather than patching the ! version of the callbacks, we patch the `run_callbacks` method. This way, we don't need to worry about callbacks potentially being defined before we include the `IdentityCache` gem, which can lead to Rails aliasing the non-patched version of the `_run_commit_callbacks!` methods. Plus, `run_callbacks` is public API, and it makes more sense for us to invalidate the cache _any time_ callbacks are run (and not just when they're run via a call to `committed!` within Active Record transaction code.)

##  Changes

  - Patch `run_callbacks` instead of `_run_commit_callbacks`: Rails 8.1 made `_run_commit_callbacks` a no-op and now uses run_commit_callbacks! internally (https://github.com/rails/rails/pull/55736/commits/207a254cedef2c381c2898bac960b91ce14ab3a7).
  Overriding run_callbacks is more robust and avoids ordering issues when the IdentityCache module is included.
  - **[Temporary]** Add ignore_override parameter: Introduces a temporary compatibility flag to allow callers to bypass the cache expiration behavior. This provides backwards compatibility for existing code that calls run_callbacks directly,
  enabling safer rollout.

TODO: Remove `ignore_override` before shipping, after we verify the change doesn't cause any unintended side effects in Shopify's Core monolith.