### PR TITLE
Remove `ignore_override` flag

### DIFF
--- a/lib/identity_cache/query_api.rb
+++ b/lib/identity_cache/query_api.rb
@@ -166,11 +166,11 @@ module IdentityCache
     # callback enqueues a background job, then we don't want it to be possible for the
     # background job to run and load data from the cache before it is invalidated.
     if ActiveRecord.version >= Gem::Version.new("7.1")
-      def run_callbacks(kind, type = nil, ignore_override: false)
-        if kind == :commit && (destroyed? || transaction_changed_attributes.present?) && !ignore_override
+      def run_callbacks(kind, type = nil)
+        if kind == :commit && (destroyed? || transaction_changed_attributes.present?)
           expire_cache
         end
-        super(kind, type)
+        super
       end
     else
       def run_callbacks(kind)


### PR DESCRIPTION
Once we verify that we can expire the cache any time `run_callbacks` is called directly in Core without unexpected changes in behaviour, we can remove this flag.