### PR TITLE
Add gem benchmark to gemspec to support Ruby 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,15 @@ jobs:
           - name: 'Minimum supported'
             ruby: '3.0'
             gemfile: "Gemfile.min-supported"
-          - name: 'Latest released & run rubocop'
+          - name: 'Latest Ruby 3'
             ruby: '3.4'
+            gemfile: "Gemfile.latest-release"
+          - name: 'Latest released & run rubocop'
+            ruby: '4.0'
             gemfile: "Gemfile.latest-release"
             rubocop: true
           - name: 'Rails edge'
-            ruby: '3.4'
+            ruby: '4.0'
             gemfile: "Gemfile.rails-edge"
             edge: true
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
     identity_cache (1.6.4)
       activerecord (>= 7.0)
       ar_transaction_changes (~> 1.1)
+      benchmark
 
 GEM
   remote: https://rubygems.org/
@@ -99,6 +100,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,9 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     dalli (3.2.8)
+    date (3.5.1)
     drb (2.2.3)
+    erb (6.0.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     json (2.13.1)
@@ -55,7 +57,7 @@ GEM
     memcached_store (2.3.4)
       activesupport (>= 6)
       memcached (~> 1.8)
-    minitest (5.25.5)
+    minitest (5.27.0)
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
     mysql2 (0.5.6)
@@ -65,9 +67,16 @@ GEM
       racc
     pg (1.5.9)
     prism (1.4.0)
+    psych (5.3.1)
+      date
+      stringio
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.0)
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
     regexp_parser (2.10.0)
     rexml (3.4.2)
     rubocop (1.61.0)
@@ -91,16 +100,16 @@ GEM
     securerandom (0.4.1)
     spy (1.0.5)
     stackprof (0.2.27)
+    stringio (3.2.0)
     timeout (0.4.3)
+    tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
     uri (1.0.4)
 
 PLATFORMS
-  arm64-darwin-22
-  arm64-darwin-23
-  arm64-darwin-24
+  arm64-darwin
   x86_64-linux
 
 DEPENDENCIES
@@ -115,6 +124,7 @@ DEPENDENCIES
   mysql2 (~> 0.5.3)
   pg (>= 0.18, < 2.0)
   rake (~> 13.0)
+  rdoc
   rubocop (~> 1.61.0)
   rubocop-shopify (~> 2.9.0)
   spy (~> 1.0)

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -41,5 +41,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("minitest", "~> 5.14")
   gem.add_development_dependency("mocha", "~> 2.0")
   gem.add_development_dependency("rake", "~> 13.0")
+  gem.add_development_dependency("rdoc")
   gem.add_development_dependency("spy", "~> 1.0")
 end

--- a/identity_cache.gemspec
+++ b/identity_cache.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("activerecord", ">= 7.0")
   gem.add_dependency("ar_transaction_changes", "~> 1.1")
+  gem.add_dependency("benchmark")
 
   gem.add_development_dependency("minitest", "~> 5.14")
   gem.add_development_dependency("mocha", "~> 2.0")


### PR DESCRIPTION
Add `benchmark` to gemspec as it is not default gem in Ruby 4. Closes https://github.com/Shopify/identity_cache/issues/622