### PR TITLE
Replace deprecated around_filter with around_action in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Cache reads and writes can be memoized for a block of code to serve duplicate id
 
 ``` ruby
 class ApplicationController < ActionController::Base
-  around_filter :identity_cache_memoization
+  around_action :identity_cache_memoization
 
   def identity_cache_memoization(&block)
     IdentityCache.cache.with_memoization(&block)


### PR DESCRIPTION
Documentation-only change: updates the memoized cache proxy example in the README to use `around_action` instead of `around_filter`.

### Why

The `*_filter` callback names were deprecated in Rails 5.0 and removed entirely in Rails 5.1 (2017). Copying the current README example into any modern Rails app raises:

```
NoMethodError: undefined method 'around_filter' for ApplicationController
```

`around_action` is the direct replacement (it was introduced as an alias in Rails 4.0 and has been the canonical name since), so the example now works on all Rails versions this gem supports.

```ruby
class ApplicationController < ActionController::Base
  around_action :identity_cache_memoization

  def identity_cache_memoization(&block)
    IdentityCache.cache.with_memoization(&block)
  end
end
```

No behavior change — `with_memoization` itself is untouched.